### PR TITLE
feat(agents): add streaming support for completions (GAP-004)

### DIFF
--- a/libs/giskard-agents/src/giskard/agents/__init__.py
+++ b/libs/giskard-agents/src/giskard/agents/__init__.py
@@ -2,7 +2,7 @@ from .chat import Chat, Message
 from .context import RunContext
 from .embeddings import EmbeddingModel
 from .errors import Error, WorkflowError
-from .generators import Generator
+from .generators import Generator, StreamChunk
 from .rate_limiter import (
     RateLimiter,
     RateLimiterStrategy,
@@ -44,4 +44,5 @@ __all__ = [
     "WorkflowError",
     "Error",
     "EmbeddingModel",
+    "StreamChunk",
 ]

--- a/libs/giskard-agents/src/giskard/agents/generators/__init__.py
+++ b/libs/giskard-agents/src/giskard/agents/generators/__init__.py
@@ -1,4 +1,4 @@
-from .base import BaseGenerator, GenerationParams, Response
+from .base import BaseGenerator, GenerationParams, Response, StreamChunk
 from .litellm_generator import LiteLLMGenerator
 from .mixins import WithRateLimiter
 
@@ -12,4 +12,5 @@ __all__ = [
     "BaseGenerator",
     "LiteLLMGenerator",
     "WithRateLimiter",
+    "StreamChunk",
 ]

--- a/libs/giskard-agents/src/giskard/agents/generators/base.py
+++ b/libs/giskard-agents/src/giskard/agents/generators/base.py
@@ -1,12 +1,13 @@
 import asyncio
 from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any, Literal, Type
 
 from giskard.core import Discriminated, discriminated_base
 from pydantic import BaseModel, Field
 
 from ..chat import Message, Role
-from ..tools import Tool
+from ..tools import Tool, ToolCall
 
 if TYPE_CHECKING:
     from ..workflow import ChatWorkflow
@@ -32,6 +33,18 @@ class GenerationParams(BaseModel):
     max_tokens: int | None = Field(default=None)
     response_format: Type[BaseModel] | None = Field(default=None)
     tools: list[Tool] = Field(default_factory=list)
+
+
+class StreamChunk(BaseModel):
+    """A single chunk from a streaming completion."""
+
+    delta: str = Field(default="", description="Incremental text token from the model.")
+    finish_reason: str | None = Field(
+        default=None, description="Non-null when the stream is complete (e.g. 'stop', 'tool_calls')."
+    )
+    tool_calls: list[ToolCall] | None = Field(
+        default=None, description="Tool calls emitted with this chunk, if any."
+    )
 
 
 @discriminated_base
@@ -86,6 +99,36 @@ class BaseGenerator(Discriminated, ABC):
         completion_requests = [self._complete(m, params) for m in messages]
         responses = await asyncio.gather(*completion_requests)
         return responses
+
+    async def stream(
+        self,
+        messages: list[Message],
+        params: GenerationParams | None = None,
+    ) -> AsyncIterator[StreamChunk]:
+        """Stream a completion as incremental chunks.
+
+        The default implementation falls back to ``complete()`` and yields
+        a single chunk containing the full response. Subclasses should
+        override this with real streaming when the provider supports it.
+
+        Parameters
+        ----------
+        messages : list[Message]
+            Messages to send to the model.
+        params : GenerationParams | None
+            Generation parameters.
+
+        Yields
+        ------
+        StreamChunk
+            Incremental chunks of the response.
+        """
+        response = await self.complete(messages, params)
+        yield StreamChunk(
+            delta=response.message.content or "",
+            finish_reason=response.finish_reason,
+            tool_calls=response.message.tool_calls,
+        )
 
     def chat(self, message: str, role: Role = "user") -> "ChatWorkflow[Any]":
         """Create a new chat pipeline with the given message.

--- a/libs/giskard-agents/src/giskard/agents/generators/litellm_generator.py
+++ b/libs/giskard-agents/src/giskard/agents/generators/litellm_generator.py
@@ -1,4 +1,5 @@
-from typing import cast
+from collections.abc import AsyncIterator
+from typing import Any, cast
 
 from litellm import Choices, ModelResponse, acompletion
 from litellm import Message as LiteLLMMessage
@@ -6,7 +7,8 @@ from litellm import _should_retry as litellm_should_retry
 from pydantic import Field
 
 from ..chat import Message
-from .base import BaseGenerator, GenerationParams, Response
+from ..tools.tool import Function, ToolCall
+from .base import BaseGenerator, GenerationParams, Response, StreamChunk
 from .mixins import WithRateLimiter, WithRetryPolicy
 
 
@@ -21,18 +23,35 @@ class LiteLLMGenerator(WithRateLimiter, WithRetryPolicy, BaseGenerator):
     def _should_retry(self, err: Exception) -> bool:
         return litellm_should_retry(getattr(err, "status_code", 0))
 
-    async def _complete_once(
-        self, messages: list[Message], params: GenerationParams | None = None
-    ) -> Response:
-        params_ = self.params.model_dump(exclude={"tools"})
+    def _build_params(
+        self, params: GenerationParams | None = None
+    ) -> dict[str, Any]:
+        """Merge default and override generation params into a kwargs dict.
 
+        Parameters
+        ----------
+        params : GenerationParams | None
+            Optional overrides for this specific call.
+
+        Returns
+        -------
+        dict[str, Any]
+            Keyword arguments ready to pass to litellm.
+        """
+        params_ = self.params.model_dump(exclude={"tools"})
         if params is not None:
             params_.update(params.model_dump(exclude={"tools"}, exclude_unset=True))
 
-        # Now special handling of the tools
         tools = self.params.tools + (params.tools if params is not None else [])
         if tools:
             params_["tools"] = [t.to_litellm_function() for t in tools]
+
+        return params_
+
+    async def _complete_once(
+        self, messages: list[Message], params: GenerationParams | None = None
+    ) -> Response:
+        params_ = self._build_params(params)
 
         async with self._rate_limiter_context():
             response = cast(
@@ -49,3 +68,85 @@ class LiteLLMGenerator(WithRateLimiter, WithRetryPolicy, BaseGenerator):
             message=Message.from_litellm(cast(LiteLLMMessage, choice.message)),
             finish_reason=choice.finish_reason,  # pyright: ignore[reportArgumentType]
         )
+
+    async def stream(
+        self,
+        messages: list[Message],
+        params: GenerationParams | None = None,
+    ) -> AsyncIterator[StreamChunk]:
+        """Stream a completion as incremental chunks using litellm.
+
+        Yields ``StreamChunk`` objects as tokens arrive. Tool calls are
+        accumulated across deltas and emitted as complete ``ToolCall``
+        objects when the stream finishes.
+
+        Parameters
+        ----------
+        messages : list[Message]
+            Messages to send to the model.
+        params : GenerationParams | None
+            Generation parameters.
+
+        Yields
+        ------
+        StreamChunk
+            Incremental chunks of the response.
+        """
+        params_ = self._build_params(params)
+
+        async with self._rate_limiter_context():
+            response = await acompletion(
+                messages=[m.to_litellm() for m in messages],
+                model=self.model,
+                stream=True,
+                **params_,
+            )
+
+        # Accumulate tool calls by index since they arrive as deltas
+        tool_calls_by_index: dict[int, dict[str, Any]] = {}
+
+        async for chunk in response:
+            choice = chunk.choices[0]
+            delta = choice.delta
+
+            # Merge incremental tool_call deltas
+            if delta_tcs := getattr(delta, "tool_calls", None):
+                for dtc in delta_tcs:
+                    idx = dtc.index if hasattr(dtc, "index") else 0
+                    if idx not in tool_calls_by_index:
+                        tool_calls_by_index[idx] = {
+                            "id": getattr(dtc, "id", None) or "",
+                            "name": "",
+                            "arguments": "",
+                        }
+                    entry = tool_calls_by_index[idx]
+                    if dtc_id := getattr(dtc, "id", None):
+                        entry["id"] = dtc_id
+                    if fn := getattr(dtc, "function", None):
+                        if fn_name := getattr(fn, "name", None):
+                            entry["name"] += fn_name
+                        if fn_args := getattr(fn, "arguments", None):
+                            entry["arguments"] += fn_args
+
+            finish_reason = getattr(choice, "finish_reason", None)
+            text_delta = getattr(delta, "content", None) or ""
+
+            # On the final chunk, emit accumulated tool calls
+            resolved_tool_calls: list[ToolCall] | None = None
+            if finish_reason and tool_calls_by_index:
+                resolved_tool_calls = [
+                    ToolCall(
+                        id=entry["id"],
+                        function=Function(
+                            name=entry["name"],
+                            arguments=entry["arguments"],
+                        ),
+                    )
+                    for _, entry in sorted(tool_calls_by_index.items())
+                ]
+
+            yield StreamChunk(
+                delta=text_delta,
+                finish_reason=finish_reason,
+                tool_calls=resolved_tool_calls,
+            )

--- a/libs/giskard-agents/src/giskard/agents/workflow.py
+++ b/libs/giskard-agents/src/giskard/agents/workflow.py
@@ -23,7 +23,7 @@ from .chat import Chat, Message, Role
 from .context import RunContext
 from .errors.serializable import Error
 from .errors.workflow_errors import WorkflowError
-from .generators import BaseGenerator, GenerationParams
+from .generators import BaseGenerator, GenerationParams, StreamChunk
 from .templates import MessageTemplate, PromptsManager, get_prompts_manager
 from .tools.tool import Tool
 
@@ -82,6 +82,27 @@ class _StepRunner:
         self._params = params
         self._init_chat = init_chat
 
+    def _build_step(
+        self,
+        chat: Chat[Any],
+        message: Message,
+        previous: WorkflowStep | None,
+        index: int,
+    ) -> WorkflowStep:
+        step = WorkflowStep(
+            workflow=self._workflow,
+            chat=chat,
+            message=message,
+            previous=previous,
+            index=index,
+        )
+        logfire.info(
+            "step.completed",
+            step_index=step.index,
+            message=step.message,
+        )
+        return step
+
     async def execute(
         self, max_steps: int | None
     ) -> AsyncGenerator[WorkflowStep, None]:
@@ -100,53 +121,95 @@ class _StepRunner:
         if max_steps is not None and max_steps <= 0:
             return
 
-        chat = self._init_chat  # will be cloned for each step
-
+        chat = self._init_chat
         step = None
         step_index = 0
+
         while max_steps is None or step_index < max_steps:
-            # First, consume any pending tool calls on the current chat
             async for tool_message in self._run_tools(chat):
                 chat = chat.clone().add(tool_message)
-                step = WorkflowStep(
-                    workflow=self._workflow,
-                    chat=chat,
-                    message=tool_message,
-                    previous=step,
-                    index=step_index,
-                )
-                logfire.info(
-                    "step.completed",
-                    step_index=step.index,
-                    message=step.message,
-                )
+                step = self._build_step(chat, tool_message, step, step_index)
                 yield step
 
                 step_index += 1
                 if max_steps is not None and step_index >= max_steps:
                     return
 
-            # Now we run the generator to create a completion
             message = await self._run_completion(chat)
             chat = chat.clone().add(message)
-            step = WorkflowStep(
-                workflow=self._workflow,
-                chat=chat,
-                message=message,
-                previous=step,
-                index=step_index,
-            )
-            logfire.info(
-                "step.completed",
-                step_index=step.index,
-                message=step.message,
-            )
+            step = self._build_step(chat, message, step, step_index)
             yield step
             step_index += 1
+
             if max_steps is not None and step_index >= max_steps:
                 break
+            if not message.tool_calls:
+                break
 
-            # If the last message has no tool calls, we're done.
+    async def execute_streaming(
+        self, max_steps: int | None
+    ) -> AsyncGenerator[StreamChunk | WorkflowStep, None]:
+        """Drive the workflow, streaming completion tokens as they arrive.
+
+        Tool-result steps are yielded as ``WorkflowStep`` (same as
+        ``execute``). Completion steps first yield incremental
+        ``StreamChunk`` objects, then a final ``WorkflowStep`` once the
+        full message is assembled.
+
+        Parameters
+        ----------
+        max_steps : int or None
+            Maximum number of steps to run.
+
+        Yields
+        ------
+        StreamChunk or WorkflowStep
+            Chunks for in-progress completions, steps for completed messages.
+        """
+        if max_steps is not None and max_steps <= 0:
+            return
+
+        chat = self._init_chat
+        step = None
+        step_index = 0
+
+        while max_steps is None or step_index < max_steps:
+            async for tool_message in self._run_tools(chat):
+                chat = chat.clone().add(tool_message)
+                step = self._build_step(chat, tool_message, step, step_index)
+                yield step
+
+                step_index += 1
+                if max_steps is not None and step_index >= max_steps:
+                    return
+
+            # Stream the completion token by token
+            accumulated_content = ""
+            tool_calls: list | None = None
+            finish_reason: str | None = None
+
+            async for chunk in self._workflow.generator.stream(
+                chat.messages, self._params
+            ):
+                yield chunk
+                accumulated_content += chunk.delta
+                if chunk.finish_reason:
+                    finish_reason = chunk.finish_reason
+                if chunk.tool_calls:
+                    tool_calls = chunk.tool_calls
+
+            message = Message(
+                role="assistant",
+                content=accumulated_content or None,
+                tool_calls=tool_calls,
+            )
+            chat = chat.clone().add(message)
+            step = self._build_step(chat, message, step, step_index)
+            yield step
+            step_index += 1
+
+            if max_steps is not None and step_index >= max_steps:
+                break
             if not message.tool_calls:
                 break
 
@@ -363,6 +426,39 @@ class ChatWorkflow(BaseModel, Generic[OutputType]):
 
         runner = _StepRunner(self, params, init_chat)
         agen = runner.execute(max_steps)
+        try:
+            yield agen
+        finally:
+            await agen.aclose()
+
+    @asynccontextmanager
+    async def stream_steps(
+        self, max_steps: int | None = None
+    ) -> AsyncIterator[AsyncGenerator[StreamChunk | WorkflowStep, None]]:
+        """Stream tokens and steps from the workflow.
+
+        Works like ``steps()`` but yields ``StreamChunk`` objects for
+        in-progress completions in addition to ``WorkflowStep`` objects.
+
+        Parameters
+        ----------
+        max_steps : int or None
+            Maximum number of steps to run. If None, runs until completion.
+
+        Yields
+        ------
+        AsyncGenerator[StreamChunk | WorkflowStep, None]
+            An async generator producing both ``StreamChunk`` and
+            ``WorkflowStep`` instances.
+        """
+        params = GenerationParams(
+            tools=list(self.tools.values()),
+            response_format=self.output_model,
+        )
+        init_chat = await self._init_chat()
+
+        runner = _StepRunner(self, params, init_chat)
+        agen = runner.execute_streaming(max_steps)
         try:
             yield agen
         finally:

--- a/libs/giskard-agents/tests/test_streaming.py
+++ b/libs/giskard-agents/tests/test_streaming.py
@@ -1,0 +1,143 @@
+"""Tests for streaming support (GAP-004)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from giskard.agents.chat import Message
+from giskard.agents.generators import BaseGenerator
+from giskard.agents.generators.base import GenerationParams, Response, StreamChunk
+from giskard.agents.tools import Function, ToolCall, tool
+from giskard.agents.workflow import ChatWorkflow, WorkflowStep
+
+
+async def test_stream_fallback_yields_single_chunk():
+    """The default stream() on BaseGenerator yields one chunk matching complete()."""
+    gen = MagicMock(spec=BaseGenerator)
+    gen.complete = AsyncMock(
+        return_value=Response(
+            message=Message(role="assistant", content="Hello world!"),
+            finish_reason="stop",
+        )
+    )
+    # Use the real BaseGenerator.stream implementation via the fallback
+    gen.stream = BaseGenerator.stream.__get__(gen)
+
+    chunks = []
+    async for chunk in gen.stream(
+        [Message(role="user", content="Hi")], GenerationParams()
+    ):
+        chunks.append(chunk)
+
+    assert len(chunks) == 1
+    assert chunks[0].delta == "Hello world!"
+    assert chunks[0].finish_reason == "stop"
+    assert chunks[0].tool_calls is None
+
+
+async def test_stream_chunks_have_delta():
+    """A mock streaming generator yields chunks with delta text."""
+
+    async def _fake_stream(messages, params=None):
+        yield StreamChunk(delta="Hel")
+        yield StreamChunk(delta="lo ")
+        yield StreamChunk(delta="world!", finish_reason="stop")
+
+    gen = MagicMock(spec=BaseGenerator)
+    gen.stream = _fake_stream
+
+    chunks = []
+    async for chunk in gen.stream([Message(role="user", content="Hi")]):
+        chunks.append(chunk)
+
+    assert len(chunks) == 3
+    assert all(isinstance(c, StreamChunk) for c in chunks)
+    assert chunks[0].delta == "Hel"
+    assert chunks[1].delta == "lo "
+    assert chunks[2].delta == "world!"
+
+
+async def test_stream_accumulates_to_full_message():
+    """Concatenated deltas equal the full message content."""
+
+    async def _fake_stream(messages, params=None):
+        for part in ["The ", "quick ", "brown ", "fox."]:
+            yield StreamChunk(delta=part)
+        yield StreamChunk(delta="", finish_reason="stop")
+
+    gen = MagicMock(spec=BaseGenerator)
+    gen.stream = _fake_stream
+
+    deltas = []
+    async for chunk in gen.stream([Message(role="user", content="Go")]):
+        deltas.append(chunk.delta)
+
+    assert "".join(deltas) == "The quick brown fox."
+
+
+async def test_stream_with_tool_calls():
+    """Streaming response ending with tool_calls captures them correctly."""
+
+    async def _fake_stream(messages, params=None):
+        yield StreamChunk(delta="I'll use a tool.")
+        yield StreamChunk(
+            delta="",
+            finish_reason="tool_calls",
+            tool_calls=[
+                ToolCall(
+                    id="tc_1",
+                    function=Function(name="my_tool", arguments='{"x": 1}'),
+                )
+            ],
+        )
+
+    gen = MagicMock(spec=BaseGenerator)
+    gen.stream = _fake_stream
+
+    chunks = []
+    async for chunk in gen.stream([Message(role="user", content="Do it")]):
+        chunks.append(chunk)
+
+    assert chunks[-1].tool_calls is not None
+    assert len(chunks[-1].tool_calls) == 1
+    assert chunks[-1].tool_calls[0].function.name == "my_tool"
+
+
+@tool
+def echo(text: str) -> str:
+    """Echo text.
+
+    Parameters
+    ----------
+    text : str
+        Text to echo.
+    """
+    return text
+
+
+async def test_stream_steps_yields_chunks_and_steps():
+    """stream_steps() yields StreamChunk during completions and WorkflowStep at boundaries."""
+
+    async def _fake_stream(messages, params=None):
+        yield StreamChunk(delta="Hello ")
+        yield StreamChunk(delta="there!", finish_reason="stop")
+
+    gen = MagicMock(spec=BaseGenerator)
+    gen.stream = _fake_stream
+
+    collected_chunks = []
+    collected_steps = []
+
+    async with (
+        ChatWorkflow(generator=gen).chat("Hi").stream_steps(max_steps=5) as events
+    ):
+        async for event in events:
+            if isinstance(event, StreamChunk):
+                collected_chunks.append(event)
+            elif isinstance(event, WorkflowStep):
+                collected_steps.append(event)
+
+    assert len(collected_chunks) == 2
+    assert collected_chunks[0].delta == "Hello "
+    assert collected_chunks[1].delta == "there!"
+
+    assert len(collected_steps) == 1
+    assert collected_steps[0].message.content == "Hello there!"


### PR DESCRIPTION
- StreamChunk model with field descriptions
- BaseGenerator.stream() with fallback to complete()
- LiteLLMGenerator.stream() with real litellm streaming and proper delta-merging for incremental tool_calls
- ChatWorkflow.stream_steps() async context manager
- _StepRunner.execute_streaming() sharing _build_step() with execute() to reduce duplication
- Refactored LiteLLMGenerator with _build_params() for DRY

Made-with: Cursor

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
- [ ] I've updated the `pdm.lock` running `pdm update-lock` (only applicable when `pyproject.toml` has been
  modified)
