### PR TITLE
Add CLI for running and validating checks

### DIFF
--- a/libs/giskard-checks/pyproject.toml
+++ b/libs/giskard-checks/pyproject.toml
@@ -13,11 +13,15 @@ dependencies = [
     "giskard-core>=1.0.0a1",
     "numpy>=2.4.1,<3",
     "rich>=14.2.0,<15",
-    "pyyaml>=6.0.2,<7",
 ]
 
 [project.scripts]
 giskard = "giskard.checks.cli:main"
+
+[project.optional-dependencies]
+yaml = [
+    "pyyaml>=6.0.2,<7",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "src"]

--- a/libs/giskard-checks/pyproject.toml
+++ b/libs/giskard-checks/pyproject.toml
@@ -13,7 +13,11 @@ dependencies = [
     "giskard-core>=1.0.0a1",
     "numpy>=2.4.1,<3",
     "rich>=14.2.0,<15",
+    "pyyaml>=6.0.2,<7",
 ]
+
+[project.scripts]
+giskard = "giskard.checks.cli:main"
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "src"]

--- a/libs/giskard-checks/src/giskard/checks/cli.py
+++ b/libs/giskard-checks/src/giskard/checks/cli.py
@@ -2,27 +2,21 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import importlib
 import inspect
 import json
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
-import yaml
-from pydantic import ValidationError
+from pydantic import TypeAdapter, ValidationError
 from rich.console import Console
 from rich.table import Table
 
-from giskard.core.discriminated import _REGISTRY
-from giskard.core.utils import NOT_PROVIDED, NotProvided
-
 from . import builtin, judges, testing  # noqa: F401
 from .core.check import Check
-from .core.interaction import InteractionSpec, Trace
+from .core.importing import python_reference_path
 from .core.result import ScenarioResult, SuiteResult
-from .core.scenario import Scenario, Step
+from .core.scenario import Scenario
 from .scenarios.suite import Suite
 
 console = Console()
@@ -42,241 +36,42 @@ class LoadedDefinition:
     path: Path
 
 
+def _load_yaml(raw: str, path: Path) -> Any:
+    try:
+        import yaml
+    except ImportError as exc:
+        raise CliError(
+            "YAML support requires PyYAML. Install `giskard-checks[yaml]` or use a JSON definition file."
+        ) from exc
+
+    try:
+        return yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise CliError(f"Failed to parse {path.name}: {exc}") from exc
+
+
 def _load_file(path: Path) -> Any:
     if not path.exists():
         raise CliError(f"Definition file not found: {path}")
 
-    suffix = path.suffix.lower()
     try:
         raw = path.read_text(encoding="utf-8")
     except OSError as exc:
         raise CliError(f"Unable to read definition file {path}: {exc}") from exc
 
-    try:
-        if suffix == ".json":
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        try:
             return json.loads(raw)
-        if suffix in {".yaml", ".yml"}:
-            return yaml.safe_load(raw)
-    except (json.JSONDecodeError, yaml.YAMLError) as exc:
-        raise CliError(f"Failed to parse {path.name}: {exc}") from exc
+        except json.JSONDecodeError as exc:
+            raise CliError(f"Failed to parse {path.name}: {exc}") from exc
+
+    if suffix in {".yaml", ".yml"}:
+        return _load_yaml(raw, path)
 
     raise CliError(
         f"Unsupported file type for {path.name}. Expected .json, .yaml, or .yml."
     )
-
-
-def _normalize_items(
-    singular: str,
-    plural: str,
-    payload: dict[str, Any],
-) -> list[dict[str, Any]]:
-    items: list[dict[str, Any]] = []
-    for key in (singular, plural):
-        value = payload.get(key)
-        if value is None:
-            continue
-        if isinstance(value, list):
-            candidate_items = value
-        else:
-            candidate_items = [value]
-
-        for item in candidate_items:
-            if not isinstance(item, dict):
-                raise CliError(f"Expected '{key}' entries to be objects, got {item!r}.")
-            normalized = dict(item)
-            if singular == "interact":
-                normalized.setdefault("kind", "interact")
-            items.append(normalized)
-    return items
-
-
-def _ensure_allowed_keys(
-    payload: dict[str, Any], *, allowed: set[str], context: str
-) -> None:
-    unknown = sorted(set(payload) - allowed)
-    if unknown:
-        raise CliError(
-            f"Unexpected keys in {context}: {', '.join(unknown)}. Allowed keys: {', '.join(sorted(allowed))}."
-        )
-
-
-def _module_search_paths(path: Path) -> list[str]:
-    search_paths = [str(path.parent.resolve()), str(Path.cwd().resolve())]
-    unique_paths: list[str] = []
-    for candidate in search_paths:
-        if candidate not in unique_paths:
-            unique_paths.append(candidate)
-    return unique_paths
-
-
-def _module_belongs_to_search_path(module: Any, search_path: str) -> bool:
-    module_file = getattr(module, "__file__", None)
-    if module_file is None:
-        return False
-
-    module_path = Path(module_file).resolve()
-    return module_path.is_relative_to(Path(search_path))
-
-
-def _module_belongs_to_search_paths(module: Any, search_paths: list[str]) -> bool:
-    return any(
-        _module_belongs_to_search_path(module, search_path)
-        for search_path in search_paths
-    )
-
-
-def _module_exists_in_search_path(module_name: str, search_path: str) -> bool:
-    module_parts = module_name.split(".")
-    module_root = Path(search_path).resolve().joinpath(*module_parts)
-    return module_root.with_suffix(".py").exists() or (
-        module_root / "__init__.py"
-    ).exists()
-
-
-def _resolve_python_target(value: Any, *, path: Path) -> Any:
-    if value is None:
-        return NOT_PROVIDED
-    if isinstance(value, NotProvided):
-        return value
-    if not isinstance(value, str):
-        raise CliError(
-            f"Invalid target in {path.name}: expected a string like 'python:module.symbol'."
-        )
-    if not value.startswith("python:"):
-        raise CliError(
-            f"Unsupported target '{value}' in {path.name}. Only 'python:module.symbol' is supported."
-        )
-
-    import_path = value.removeprefix("python:")
-    module_name, _, attribute_path = import_path.rpartition(".")
-    if not module_name or not attribute_path:
-        raise CliError(
-            f"Invalid python target '{value}' in {path.name}. Expected 'python:module.symbol'."
-        )
-
-    search_paths = _module_search_paths(path)
-    original_sys_path = sys.path[:]
-    try:
-        for search_path in reversed(search_paths):
-            if search_path not in sys.path:
-                sys.path.insert(0, search_path)
-
-        cached_module = sys.modules.get(module_name)
-        if cached_module is not None:
-            preferred_search_path = search_paths[0]
-            if _module_exists_in_search_path(module_name, preferred_search_path):
-                if not _module_belongs_to_search_path(
-                    cached_module, preferred_search_path
-                ):
-                    sys.modules.pop(module_name, None)
-            elif not _module_belongs_to_search_paths(cached_module, search_paths):
-                sys.modules.pop(module_name, None)
-
-        importlib.invalidate_caches()
-        module = importlib.import_module(module_name)
-    except ModuleNotFoundError as exc:
-        raise CliError(
-            f"Could not import module '{module_name}' for target '{value}' in {path.name}: {exc}"
-        ) from exc
-    finally:
-        sys.path[:] = original_sys_path
-
-    target: Any = module
-    try:
-        for attribute in attribute_path.split("."):
-            target = getattr(target, attribute)
-    except AttributeError as exc:
-        raise CliError(
-            f"Could not resolve attribute '{attribute_path}' for target '{value}' in {path.name}."
-        ) from exc
-
-    if not callable(target):
-        raise CliError(
-            f"Resolved target '{value}' in {path.name}, but it is not callable."
-        )
-
-    return target
-
-
-def _build_step(data: Any) -> Step[Any, Any, Any]:
-    if not isinstance(data, dict):
-        raise CliError(f"Each step must be an object, got {data!r}.")
-
-    _ensure_allowed_keys(
-        data,
-        allowed={"interact", "interacts", "check", "checks"},
-        context="a scenario step",
-    )
-
-    interactions = [
-        InteractionSpec[Any, Any, Any].model_validate(item)
-        for item in _normalize_items("interact", "interacts", data)
-    ]
-    checks = [
-        Check[Any, Any, Any].model_validate(item)
-        for item in _normalize_items("check", "checks", data)
-    ]
-    return Step[Any, Any, Any](interacts=interactions, checks=checks)
-
-
-def _build_scenario(data: Any, *, path: Path) -> Scenario[Any, Any, Any]:
-    if not isinstance(data, dict):
-        raise CliError(f"Scenario definition in {path.name} must be an object.")
-
-    _ensure_allowed_keys(
-        data,
-        allowed={"annotations", "name", "steps", "target", "trace_type"},
-        context=f"scenario definition in {path.name}",
-    )
-
-    steps = data.get("steps")
-    if not isinstance(steps, list):
-        raise CliError(
-            f"Scenario definition in {path.name} must contain a 'steps' list."
-        )
-
-    scenario_data = {
-        "name": data.get("name", path.stem),
-        "steps": [_build_step(step) for step in steps],
-        "annotations": data.get("annotations", {}),
-        "target": _resolve_python_target(data.get("target"), path=path),
-        "trace_type": data.get("trace_type"),
-    }
-
-    trace_type = scenario_data["trace_type"]
-    if isinstance(trace_type, str):
-        trace_type = _resolve_python_target(trace_type, path=path)
-        if not isinstance(trace_type, type) or not issubclass(trace_type, Trace):
-            raise CliError(
-                f"Resolved trace_type '{scenario_data['trace_type']}' in {path.name}, but it is not a Trace subclass."
-            )
-        scenario_data["trace_type"] = trace_type
-
-    return Scenario[Any, Any, Any].model_validate(scenario_data)
-
-
-def _build_suite(data: Any, *, path: Path) -> Suite[Any, Any]:
-    if not isinstance(data, dict):
-        raise CliError(f"Suite definition in {path.name} must be an object.")
-
-    _ensure_allowed_keys(
-        data,
-        allowed={"name", "scenarios", "target"},
-        context=f"suite definition in {path.name}",
-    )
-
-    scenarios = data.get("scenarios")
-    if not isinstance(scenarios, list):
-        raise CliError(
-            f"Suite definition in {path.name} must contain a 'scenarios' list."
-        )
-
-    suite_data = {
-        "name": data.get("name", path.stem),
-        "scenarios": [_build_scenario(scenario, path=path) for scenario in scenarios],
-        "target": _resolve_python_target(data.get("target"), path=path),
-    }
-    return Suite[Any, Any].model_validate(suite_data)
 
 
 def load_definition(path_str: str) -> LoadedDefinition:
@@ -286,17 +81,28 @@ def load_definition(path_str: str) -> LoadedDefinition:
     if not isinstance(payload, dict):
         raise CliError(f"Definition file {path.name} must contain a top-level object.")
 
+    if "scenarios" not in payload and "steps" not in payload:
+        raise CliError(
+            f"Unable to determine definition type for {path.name}. Expected top-level 'steps' or 'scenarios'."
+        )
+
+    definition_kind = "suite" if "scenarios" in payload else "scenario"
+    adapter: TypeAdapter[Suite[Any, Any] | Scenario[Any, Any, Any]]
+    if definition_kind == "suite":
+        adapter = TypeAdapter(Suite[Any, Any])
+    else:
+        adapter = TypeAdapter(Scenario[Any, Any, Any])
+
     try:
-        if "scenarios" in payload:
-            return LoadedDefinition("suite", _build_suite(payload, path=path), path)
-        if "steps" in payload:
-            return LoadedDefinition("scenario", _build_scenario(payload, path=path), path)
+        with python_reference_path(path):
+            definition = adapter.validate_python(payload, context={"path": path})
     except ValidationError as exc:
         raise CliError(f"Invalid definition in {path.name}:\n{exc}") from exc
 
-    raise CliError(
-        f"Unable to determine definition type for {path.name}. Expected top-level 'steps' or 'scenarios'."
-    )
+    if definition_kind == "scenario":
+        return LoadedDefinition("scenario", definition, path)
+
+    return LoadedDefinition("suite", definition, path)
 
 
 def _build_suite_result(
@@ -311,6 +117,8 @@ def _write_text_output(output: str, path: Path | None) -> None:
     if path is None:
         print(output)
         return
+
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(output, encoding="utf-8")
 
 
@@ -332,7 +140,9 @@ def _run_command(args: argparse.Namespace) -> int:
     output_path = Path(args.output).expanduser().resolve() if args.output else None
     if args.format == "rich":
         if output_path is not None:
-            raise CliError("The rich format does not support --output. Use json or junit.")
+            raise CliError(
+                "The rich format does not support --output. Use json or junit."
+            )
         console.print(execution)
     elif args.format == "json":
         _write_text_output(_render_json(execution), output_path)
@@ -385,10 +195,9 @@ def _validate_command(args: argparse.Namespace) -> int:
 
 
 def _iter_registered_checks() -> list[tuple[str, type[Any]]]:
-    registered = _REGISTRY._reverse_kinds.get(Check, {})
     checks = [
         (kind, cls)
-        for kind, cls in registered.items()
+        for kind, cls in Check.list_registered_types().items()
         if cls.__module__.startswith("giskard.checks.")
         and ".testing." not in cls.__module__
         and ".tests." not in cls.__module__

--- a/libs/giskard-checks/src/giskard/checks/cli.py
+++ b/libs/giskard-checks/src/giskard/checks/cli.py
@@ -1,0 +1,496 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib
+import inspect
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+from pydantic import ValidationError
+from rich.console import Console
+from rich.table import Table
+
+from giskard.core.discriminated import _REGISTRY
+from giskard.core.utils import NOT_PROVIDED, NotProvided
+
+from . import builtin, judges, testing  # noqa: F401
+from .core.check import Check
+from .core.interaction import InteractionSpec, Trace
+from .core.result import ScenarioResult, SuiteResult
+from .core.scenario import Scenario, Step
+from .scenarios.suite import Suite
+
+console = Console()
+error_console = Console(stderr=True)
+
+
+class CliError(Exception):
+    def __init__(self, message: str, exit_code: int = 2):
+        super().__init__(message)
+        self.exit_code = exit_code
+
+
+@dataclass(frozen=True)
+class LoadedDefinition:
+    kind: str
+    value: Scenario[Any, Any, Any] | Suite[Any, Any]
+    path: Path
+
+
+def _load_file(path: Path) -> Any:
+    if not path.exists():
+        raise CliError(f"Definition file not found: {path}")
+
+    suffix = path.suffix.lower()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise CliError(f"Unable to read definition file {path}: {exc}") from exc
+
+    try:
+        if suffix == ".json":
+            return json.loads(raw)
+        if suffix in {".yaml", ".yml"}:
+            return yaml.safe_load(raw)
+    except (json.JSONDecodeError, yaml.YAMLError) as exc:
+        raise CliError(f"Failed to parse {path.name}: {exc}") from exc
+
+    raise CliError(
+        f"Unsupported file type for {path.name}. Expected .json, .yaml, or .yml."
+    )
+
+
+def _normalize_items(
+    singular: str,
+    plural: str,
+    payload: dict[str, Any],
+) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for key in (singular, plural):
+        value = payload.get(key)
+        if value is None:
+            continue
+        if isinstance(value, list):
+            candidate_items = value
+        else:
+            candidate_items = [value]
+
+        for item in candidate_items:
+            if not isinstance(item, dict):
+                raise CliError(f"Expected '{key}' entries to be objects, got {item!r}.")
+            normalized = dict(item)
+            if singular == "interact":
+                normalized.setdefault("kind", "interact")
+            items.append(normalized)
+    return items
+
+
+def _ensure_allowed_keys(
+    payload: dict[str, Any], *, allowed: set[str], context: str
+) -> None:
+    unknown = sorted(set(payload) - allowed)
+    if unknown:
+        raise CliError(
+            f"Unexpected keys in {context}: {', '.join(unknown)}. Allowed keys: {', '.join(sorted(allowed))}."
+        )
+
+
+def _module_search_paths(path: Path) -> list[str]:
+    search_paths = [str(path.parent.resolve()), str(Path.cwd().resolve())]
+    unique_paths: list[str] = []
+    for candidate in search_paths:
+        if candidate not in unique_paths:
+            unique_paths.append(candidate)
+    return unique_paths
+
+
+def _module_belongs_to_search_path(module: Any, search_path: str) -> bool:
+    module_file = getattr(module, "__file__", None)
+    if module_file is None:
+        return False
+
+    module_path = Path(module_file).resolve()
+    return module_path.is_relative_to(Path(search_path))
+
+
+def _module_belongs_to_search_paths(module: Any, search_paths: list[str]) -> bool:
+    return any(
+        _module_belongs_to_search_path(module, search_path)
+        for search_path in search_paths
+    )
+
+
+def _module_exists_in_search_path(module_name: str, search_path: str) -> bool:
+    module_parts = module_name.split(".")
+    module_root = Path(search_path).resolve().joinpath(*module_parts)
+    return module_root.with_suffix(".py").exists() or (
+        module_root / "__init__.py"
+    ).exists()
+
+
+def _resolve_python_target(value: Any, *, path: Path) -> Any:
+    if value is None:
+        return NOT_PROVIDED
+    if isinstance(value, NotProvided):
+        return value
+    if not isinstance(value, str):
+        raise CliError(
+            f"Invalid target in {path.name}: expected a string like 'python:module.symbol'."
+        )
+    if not value.startswith("python:"):
+        raise CliError(
+            f"Unsupported target '{value}' in {path.name}. Only 'python:module.symbol' is supported."
+        )
+
+    import_path = value.removeprefix("python:")
+    module_name, _, attribute_path = import_path.rpartition(".")
+    if not module_name or not attribute_path:
+        raise CliError(
+            f"Invalid python target '{value}' in {path.name}. Expected 'python:module.symbol'."
+        )
+
+    search_paths = _module_search_paths(path)
+    original_sys_path = sys.path[:]
+    try:
+        for search_path in reversed(search_paths):
+            if search_path not in sys.path:
+                sys.path.insert(0, search_path)
+
+        cached_module = sys.modules.get(module_name)
+        if cached_module is not None:
+            preferred_search_path = search_paths[0]
+            if _module_exists_in_search_path(module_name, preferred_search_path):
+                if not _module_belongs_to_search_path(
+                    cached_module, preferred_search_path
+                ):
+                    sys.modules.pop(module_name, None)
+            elif not _module_belongs_to_search_paths(cached_module, search_paths):
+                sys.modules.pop(module_name, None)
+
+        importlib.invalidate_caches()
+        module = importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:
+        raise CliError(
+            f"Could not import module '{module_name}' for target '{value}' in {path.name}: {exc}"
+        ) from exc
+    finally:
+        sys.path[:] = original_sys_path
+
+    target: Any = module
+    try:
+        for attribute in attribute_path.split("."):
+            target = getattr(target, attribute)
+    except AttributeError as exc:
+        raise CliError(
+            f"Could not resolve attribute '{attribute_path}' for target '{value}' in {path.name}."
+        ) from exc
+
+    if not callable(target):
+        raise CliError(
+            f"Resolved target '{value}' in {path.name}, but it is not callable."
+        )
+
+    return target
+
+
+def _build_step(data: Any) -> Step[Any, Any, Any]:
+    if not isinstance(data, dict):
+        raise CliError(f"Each step must be an object, got {data!r}.")
+
+    _ensure_allowed_keys(
+        data,
+        allowed={"interact", "interacts", "check", "checks"},
+        context="a scenario step",
+    )
+
+    interactions = [
+        InteractionSpec[Any, Any, Any].model_validate(item)
+        for item in _normalize_items("interact", "interacts", data)
+    ]
+    checks = [
+        Check[Any, Any, Any].model_validate(item)
+        for item in _normalize_items("check", "checks", data)
+    ]
+    return Step[Any, Any, Any](interacts=interactions, checks=checks)
+
+
+def _build_scenario(data: Any, *, path: Path) -> Scenario[Any, Any, Any]:
+    if not isinstance(data, dict):
+        raise CliError(f"Scenario definition in {path.name} must be an object.")
+
+    _ensure_allowed_keys(
+        data,
+        allowed={"annotations", "name", "steps", "target", "trace_type"},
+        context=f"scenario definition in {path.name}",
+    )
+
+    steps = data.get("steps")
+    if not isinstance(steps, list):
+        raise CliError(
+            f"Scenario definition in {path.name} must contain a 'steps' list."
+        )
+
+    scenario_data = {
+        "name": data.get("name", path.stem),
+        "steps": [_build_step(step) for step in steps],
+        "annotations": data.get("annotations", {}),
+        "target": _resolve_python_target(data.get("target"), path=path),
+        "trace_type": data.get("trace_type"),
+    }
+
+    trace_type = scenario_data["trace_type"]
+    if isinstance(trace_type, str):
+        trace_type = _resolve_python_target(trace_type, path=path)
+        if not isinstance(trace_type, type) or not issubclass(trace_type, Trace):
+            raise CliError(
+                f"Resolved trace_type '{scenario_data['trace_type']}' in {path.name}, but it is not a Trace subclass."
+            )
+        scenario_data["trace_type"] = trace_type
+
+    return Scenario[Any, Any, Any].model_validate(scenario_data)
+
+
+def _build_suite(data: Any, *, path: Path) -> Suite[Any, Any]:
+    if not isinstance(data, dict):
+        raise CliError(f"Suite definition in {path.name} must be an object.")
+
+    _ensure_allowed_keys(
+        data,
+        allowed={"name", "scenarios", "target"},
+        context=f"suite definition in {path.name}",
+    )
+
+    scenarios = data.get("scenarios")
+    if not isinstance(scenarios, list):
+        raise CliError(
+            f"Suite definition in {path.name} must contain a 'scenarios' list."
+        )
+
+    suite_data = {
+        "name": data.get("name", path.stem),
+        "scenarios": [_build_scenario(scenario, path=path) for scenario in scenarios],
+        "target": _resolve_python_target(data.get("target"), path=path),
+    }
+    return Suite[Any, Any].model_validate(suite_data)
+
+
+def load_definition(path_str: str) -> LoadedDefinition:
+    path = Path(path_str).expanduser().resolve()
+    payload = _load_file(path)
+
+    if not isinstance(payload, dict):
+        raise CliError(f"Definition file {path.name} must contain a top-level object.")
+
+    try:
+        if "scenarios" in payload:
+            return LoadedDefinition("suite", _build_suite(payload, path=path), path)
+        if "steps" in payload:
+            return LoadedDefinition("scenario", _build_scenario(payload, path=path), path)
+    except ValidationError as exc:
+        raise CliError(f"Invalid definition in {path.name}:\n{exc}") from exc
+
+    raise CliError(
+        f"Unable to determine definition type for {path.name}. Expected top-level 'steps' or 'scenarios'."
+    )
+
+
+def _build_suite_result(
+    result: ScenarioResult[Any] | SuiteResult,
+) -> SuiteResult:
+    if isinstance(result, SuiteResult):
+        return result
+    return SuiteResult(results=[result], duration_ms=result.duration_ms)
+
+
+def _write_text_output(output: str, path: Path | None) -> None:
+    if path is None:
+        print(output)
+        return
+    path.write_text(output, encoding="utf-8")
+
+
+def _result_exit_code(result: ScenarioResult[Any] | SuiteResult) -> int:
+    suite_result = _build_suite_result(result)
+    return 0 if not suite_result.failures_and_errors else 1
+
+
+def _render_json(result: ScenarioResult[Any] | SuiteResult) -> str:
+    return json.dumps(result.model_dump(mode="json"), indent=2, default=str)
+
+
+def _run_command(args: argparse.Namespace) -> int:
+    loaded = load_definition(args.path)
+    execution = asyncio.run(
+        cast(Any, loaded.value).run(return_exception=True)  # pyright: ignore[reportAttributeAccessIssue]
+    )
+
+    output_path = Path(args.output).expanduser().resolve() if args.output else None
+    if args.format == "rich":
+        if output_path is not None:
+            raise CliError("The rich format does not support --output. Use json or junit.")
+        console.print(execution)
+    elif args.format == "json":
+        _write_text_output(_render_json(execution), output_path)
+    elif args.format == "junit":
+        xml = _build_suite_result(execution).to_junit_xml(path=output_path)
+        if output_path is None:
+            print(xml)
+    else:
+        raise CliError(f"Unsupported output format: {args.format}")
+
+    return _result_exit_code(execution)
+
+
+def _validate_summary(loaded: LoadedDefinition) -> dict[str, Any]:
+    if loaded.kind == "scenario":
+        scenario = cast(Scenario[Any, Any, Any], loaded.value)
+        return {
+            "valid": True,
+            "type": "scenario",
+            "name": scenario.name,
+            "steps": len(scenario.steps),
+        }
+
+    suite = cast(Suite[Any, Any], loaded.value)
+    return {
+        "valid": True,
+        "type": "suite",
+        "name": suite.name,
+        "scenarios": len(suite.scenarios),
+    }
+
+
+def _validate_command(args: argparse.Namespace) -> int:
+    loaded = load_definition(args.path)
+    summary = _validate_summary(loaded)
+
+    if args.format == "json":
+        print(json.dumps(summary, indent=2))
+    else:
+        if loaded.kind == "scenario":
+            console.print(
+                f"[green]Valid scenario[/green] '{summary['name']}' with {summary['steps']} step(s)."
+            )
+        else:
+            console.print(
+                f"[green]Valid suite[/green] '{summary['name']}' with {summary['scenarios']} scenario(s)."
+            )
+
+    return 0
+
+
+def _iter_registered_checks() -> list[tuple[str, type[Any]]]:
+    registered = _REGISTRY._reverse_kinds.get(Check, {})
+    checks = [
+        (kind, cls)
+        for kind, cls in registered.items()
+        if cls.__module__.startswith("giskard.checks.")
+        and ".testing." not in cls.__module__
+        and ".tests." not in cls.__module__
+    ]
+    return sorted(checks, key=lambda item: item[0])
+
+
+def _list_checks_command(args: argparse.Namespace) -> int:
+    registered_checks = _iter_registered_checks()
+    if args.format == "json":
+        payload = [
+            {
+                "kind": kind,
+                "class_name": cls.__name__,
+                "module": cls.__module__,
+                "summary": (inspect.getdoc(cls) or "").splitlines()[0]
+                if inspect.getdoc(cls)
+                else "",
+            }
+            for kind, cls in registered_checks
+        ]
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    table = Table(title="Available Checks")
+    table.add_column("Kind")
+    table.add_column("Class")
+    table.add_column("Summary")
+    for kind, cls in registered_checks:
+        doc = inspect.getdoc(cls) or ""
+        summary = doc.splitlines()[0] if doc else ""
+        table.add_row(kind, cls.__name__, summary)
+    console.print(table)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="giskard",
+        description="Run and validate Giskard scenarios and suites from YAML or JSON.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser(
+        "run", help="Run a scenario or suite definition from YAML or JSON."
+    )
+    run_parser.add_argument("path", help="Path to a .yaml, .yml, or .json definition.")
+    run_parser.add_argument(
+        "--format",
+        choices=("rich", "json", "junit"),
+        default="rich",
+        help="Output format for run results.",
+    )
+    run_parser.add_argument(
+        "--output",
+        help="Optional file path for json or junit output.",
+    )
+    run_parser.set_defaults(handler=_run_command)
+
+    validate_parser = subparsers.add_parser(
+        "validate", help="Validate a scenario or suite definition without running it."
+    )
+    validate_parser.add_argument(
+        "path", help="Path to a .yaml, .yml, or .json definition."
+    )
+    validate_parser.add_argument(
+        "--format",
+        choices=("rich", "json"),
+        default="rich",
+        help="Output format for validation results.",
+    )
+    validate_parser.set_defaults(handler=_validate_command)
+
+    list_parser = subparsers.add_parser(
+        "list", help="List available objects exposed by the CLI."
+    )
+    list_subparsers = list_parser.add_subparsers(dest="list_command", required=True)
+    checks_parser = list_subparsers.add_parser(
+        "checks", help="List built-in checks that can be referenced in definitions."
+    )
+    checks_parser.add_argument(
+        "--format",
+        choices=("table", "json"),
+        default="table",
+        help="Output format for the checks listing.",
+    )
+    checks_parser.set_defaults(handler=_list_checks_command)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        handler = args.handler
+        return handler(args)
+    except CliError as exc:
+        error_console.print(f"[red]{exc}[/red]")
+        return exc.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/libs/giskard-checks/src/giskard/checks/cli.py
+++ b/libs/giskard-checks/src/giskard/checks/cli.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import asyncio
 import inspect

--- a/libs/giskard-checks/src/giskard/checks/cli.py
+++ b/libs/giskard-checks/src/giskard/checks/cli.py
@@ -145,6 +145,8 @@ def _run_command(args: argparse.Namespace) -> int:
     elif args.format == "json":
         _write_text_output(_render_json(execution), output_path)
     elif args.format == "junit":
+        if output_path:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
         xml = _build_suite_result(execution).to_junit_xml(path=output_path)
         if output_path is None:
             print(xml)

--- a/libs/giskard-checks/src/giskard/checks/core/importing.py
+++ b/libs/giskard-checks/src/giskard/checks/core/importing.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from pathlib import Path
+from typing import Any
+
+from giskard.core.utils import NOT_PROVIDED, NotProvided
+
+_REFERENCE_PATH: ContextVar[Path | None] = ContextVar(
+    "giskard_checks_reference_path", default=None
+)
+
+
+@contextmanager
+def python_reference_path(path: Path | None) -> Iterator[None]:
+    token = _REFERENCE_PATH.set(path)
+    try:
+        yield
+    finally:
+        _REFERENCE_PATH.reset(token)
+
+
+def validation_reference_path(value: Any) -> Path | None:
+    if isinstance(value, Path):
+        return value
+    return _REFERENCE_PATH.get()
+
+
+def _module_search_paths(path: Path | None) -> list[str]:
+    if path is None:
+        return []
+
+    search_paths = [str(path.parent.resolve()), str(Path.cwd().resolve())]
+    unique_paths: list[str] = []
+    for candidate in search_paths:
+        if candidate not in unique_paths:
+            unique_paths.append(candidate)
+    return unique_paths
+
+
+def _module_belongs_to_search_path(module: Any, search_path: str) -> bool:
+    module_file = getattr(module, "__file__", None)
+    if module_file is None:
+        return False
+
+    return Path(module_file).resolve().is_relative_to(Path(search_path))
+
+
+def _module_belongs_to_search_paths(module: Any, search_paths: list[str]) -> bool:
+    return any(
+        _module_belongs_to_search_path(module, search_path)
+        for search_path in search_paths
+    )
+
+
+def _module_exists_in_search_path(module_name: str, search_path: str) -> bool:
+    module_parts = module_name.split(".")
+    module_root = Path(search_path).resolve().joinpath(*module_parts)
+    return (
+        module_root.with_suffix(".py").exists()
+        or (module_root / "__init__.py").exists()
+    )
+
+
+def resolve_python_reference(value: Any, *, path: Path | None = None) -> Any:
+    if value is None:
+        return NOT_PROVIDED
+    if isinstance(value, NotProvided):
+        return value
+    if value == {}:
+        return NOT_PROVIDED
+    if not isinstance(value, str):
+        return value
+    if not value.startswith("python:"):
+        raise ValueError(
+            f"Unsupported Python reference '{value}'. Expected 'python:module.symbol'."
+        )
+
+    import_path = value.removeprefix("python:")
+    module_name, _, attribute_path = import_path.rpartition(".")
+    if not module_name or not attribute_path:
+        raise ValueError(
+            f"Invalid Python reference '{value}'. Expected 'python:module.symbol'."
+        )
+
+    search_paths = _module_search_paths(path)
+    original_sys_path = sys.path[:]
+    try:
+        for search_path in reversed(search_paths):
+            if search_path not in sys.path:
+                sys.path.insert(0, search_path)
+
+        cached_module = sys.modules.get(module_name)
+        if cached_module is not None and search_paths:
+            preferred_search_path = search_paths[0]
+            if _module_exists_in_search_path(module_name, preferred_search_path):
+                if not _module_belongs_to_search_path(
+                    cached_module, preferred_search_path
+                ):
+                    sys.modules.pop(module_name, None)
+            elif not _module_belongs_to_search_paths(cached_module, search_paths):
+                sys.modules.pop(module_name, None)
+
+        importlib.invalidate_caches()
+        module = importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:
+        raise ValueError(
+            f"Could not import module '{module_name}' for Python reference '{value}': {exc}"
+        ) from exc
+    finally:
+        sys.path[:] = original_sys_path
+
+    try:
+        return getattr(module, attribute_path)
+    except AttributeError as exc:
+        raise ValueError(
+            f"Could not resolve attribute '{attribute_path}' for Python reference '{value}'."
+        ) from exc

--- a/libs/giskard-checks/src/giskard/checks/core/importing.py
+++ b/libs/giskard-checks/src/giskard/checks/core/importing.py
@@ -90,8 +90,6 @@ def resolve_python_reference(value: str, *, path: Path | None = None) -> Any:
                     cached_module, preferred_search_path
                 ):
                     sys.modules.pop(module_name, None)
-            elif not _module_belongs_to_search_paths(cached_module, search_paths):
-                sys.modules.pop(module_name, None)
 
         importlib.invalidate_caches()
         module = importlib.import_module(module_name)

--- a/libs/giskard-checks/src/giskard/checks/core/importing.py
+++ b/libs/giskard-checks/src/giskard/checks/core/importing.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import importlib
 import sys
 from collections.abc import Iterator
@@ -7,8 +5,6 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from pathlib import Path
 from typing import Any
-
-from giskard.core.utils import NOT_PROVIDED, NotProvided
 
 _REFERENCE_PATH: ContextVar[Path | None] = ContextVar(
     "giskard_checks_reference_path", default=None
@@ -66,15 +62,7 @@ def _module_exists_in_search_path(module_name: str, search_path: str) -> bool:
     )
 
 
-def resolve_python_reference(value: Any, *, path: Path | None = None) -> Any:
-    if value is None:
-        return NOT_PROVIDED
-    if isinstance(value, NotProvided):
-        return value
-    if value == {}:
-        return NOT_PROVIDED
-    if not isinstance(value, str):
-        return value
+def resolve_python_reference(value: str, *, path: Path | None = None) -> Any:
     if not value.startswith("python:"):
         raise ValueError(
             f"Unsupported Python reference '{value}'. Expected 'python:module.symbol'."

--- a/libs/giskard-checks/src/giskard/checks/core/scenario.py
+++ b/libs/giskard-checks/src/giskard/checks/core/scenario.py
@@ -103,29 +103,24 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
     @field_validator("target", mode="before")
     @classmethod
     def _load_target_reference(cls, value: Any, info: ValidationInfo) -> Any:
-        path = validation_reference_path(
-            info.context.get("path") if isinstance(info.context, dict) else None
-        )
-        target = resolve_python_reference(value, path=path)
-        if isinstance(target, NotProvided):
-            return target
-        if not callable(target):
-            raise ValueError("Scenario target must be callable.")
-        return target
-
-    @field_validator("trace_type", mode="before")
-    @classmethod
-    def _load_trace_type_reference(cls, value: Any, info: ValidationInfo) -> Any:
-        if value is None:
+        if not isinstance(value, str):
             return value
 
         path = validation_reference_path(
             info.context.get("path") if isinstance(info.context, dict) else None
         )
-        trace_type = resolve_python_reference(value, path=path)
-        if not isinstance(trace_type, type) or not issubclass(trace_type, Trace):
-            raise ValueError("Scenario trace_type must be a Trace subclass.")
-        return trace_type
+        return resolve_python_reference(value, path=path)
+
+    @field_validator("trace_type", mode="before")
+    @classmethod
+    def _load_trace_type_reference(cls, value: Any, info: ValidationInfo) -> Any:
+        if not isinstance(value, str):
+            return value
+
+        path = validation_reference_path(
+            info.context.get("path") if isinstance(info.context, dict) else None
+        )
+        return resolve_python_reference(value, path=path)
 
     def __init__(
         self,

--- a/libs/giskard-checks/src/giskard/checks/core/scenario.py
+++ b/libs/giskard-checks/src/giskard/checks/core/scenario.py
@@ -1,9 +1,10 @@
 from typing import Any, Self
 
 from giskard.core.utils import NOT_PROVIDED, NotProvided
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationInfo, field_validator
 
 from .check import Check
+from .importing import resolve_python_reference, validation_reference_path
 from .input_generator import InputGenerator
 from .interaction import Interact, InteractionSpec, Trace
 from .result import ScenarioResult
@@ -98,6 +99,33 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
         default=NOT_PROVIDED,
         description="Scenario-level target SUT that will be used to replace NOT_PROVIDED outputs.",
     )
+
+    @field_validator("target", mode="before")
+    @classmethod
+    def _load_target_reference(cls, value: Any, info: ValidationInfo) -> Any:
+        path = validation_reference_path(
+            info.context.get("path") if isinstance(info.context, dict) else None
+        )
+        target = resolve_python_reference(value, path=path)
+        if isinstance(target, NotProvided):
+            return target
+        if not callable(target):
+            raise ValueError("Scenario target must be callable.")
+        return target
+
+    @field_validator("trace_type", mode="before")
+    @classmethod
+    def _load_trace_type_reference(cls, value: Any, info: ValidationInfo) -> Any:
+        if value is None:
+            return value
+
+        path = validation_reference_path(
+            info.context.get("path") if isinstance(info.context, dict) else None
+        )
+        trace_type = resolve_python_reference(value, path=path)
+        if not isinstance(trace_type, type) or not issubclass(trace_type, Trace):
+            raise ValueError("Scenario trace_type must be a Trace subclass.")
+        return trace_type
 
     def __init__(
         self,

--- a/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
@@ -63,15 +63,13 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
     @field_validator("target", mode="before")
     @classmethod
     def _load_target_reference(cls, value: Any, info: ValidationInfo) -> Any:
+        if not isinstance(value, str):
+            return value
+
         path = validation_reference_path(
             info.context.get("path") if isinstance(info.context, dict) else None
         )
-        target = resolve_python_reference(value, path=path)
-        if isinstance(target, NotProvided):
-            return target
-        if not callable(target):
-            raise ValueError("Suite target must be callable.")
-        return target
+        return resolve_python_reference(value, path=path)
 
     def append(
         self,

--- a/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
@@ -2,8 +2,9 @@ import time
 from typing import Any, Generic, Self, TypeVar
 
 from giskard.core.utils import NOT_PROVIDED, NotProvided
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationInfo, field_validator
 
+from ..core.importing import resolve_python_reference, validation_reference_path
 from ..core.interaction import Trace
 from ..core.result import ScenarioResult, SuiteResult
 from ..core.scenario import Scenario
@@ -58,6 +59,19 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
         default=NOT_PROVIDED,
         description="Suite-level target SUT that will override any scenario-level target.",
     )
+
+    @field_validator("target", mode="before")
+    @classmethod
+    def _load_target_reference(cls, value: Any, info: ValidationInfo) -> Any:
+        path = validation_reference_path(
+            info.context.get("path") if isinstance(info.context, dict) else None
+        )
+        target = resolve_python_reference(value, path=path)
+        if isinstance(target, NotProvided):
+            return target
+        if not callable(target):
+            raise ValueError("Suite target must be callable.")
+        return target
 
     def append(
         self,

--- a/libs/giskard-checks/tests/cli/data/invalid_target.json
+++ b/libs/giskard-checks/tests/cli/data/invalid_target.json
@@ -1,0 +1,14 @@
+{
+  "name": "broken_test",
+  "target": "python:missing_targets.missing",
+  "steps": [
+    {
+      "interacts": [
+        {
+          "kind": "interact",
+          "inputs": "hello"
+        }
+      ]
+    }
+  ]
+}

--- a/libs/giskard-checks/tests/cli/data/scenario.json
+++ b/libs/giskard-checks/tests/cli/data/scenario.json
@@ -1,0 +1,20 @@
+{
+  "name": "basic_test",
+  "target": "python:targets.explain_python",
+  "steps": [
+    {
+      "interacts": [
+        {
+          "kind": "interact",
+          "inputs": "What is Python?"
+        }
+      ],
+      "checks": [
+        {
+          "kind": "string_matching",
+          "keyword": "programming language"
+        }
+      ]
+    }
+  ]
+}

--- a/libs/giskard-checks/tests/cli/data/scenario.yaml
+++ b/libs/giskard-checks/tests/cli/data/scenario.yaml
@@ -1,0 +1,9 @@
+name: basic_test
+target: python:targets.explain_python
+steps:
+  - interacts:
+      - kind: interact
+        inputs: What is Python?
+    checks:
+      - kind: string_matching
+        keyword: programming language

--- a/libs/giskard-checks/tests/cli/data/suite.json
+++ b/libs/giskard-checks/tests/cli/data/suite.json
@@ -1,0 +1,26 @@
+{
+  "name": "cli_suite",
+  "target": "python:targets.echo",
+  "scenarios": [
+    {
+      "name": "suite_case",
+      "steps": [
+        {
+          "interacts": [
+            {
+              "kind": "interact",
+              "inputs": "hello"
+            }
+          ],
+          "checks": [
+            {
+              "kind": "equals",
+              "key": "trace.last.outputs",
+              "expected_value": "hello"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/libs/giskard-checks/tests/cli/data/targets.py
+++ b/libs/giskard-checks/tests/cli/data/targets.py
@@ -1,0 +1,6 @@
+def explain_python(inputs):
+    return "Python is a programming language."
+
+
+def echo(inputs):
+    return inputs

--- a/libs/giskard-checks/tests/cli/data/trace_type.json
+++ b/libs/giskard-checks/tests/cli/data/trace_type.json
@@ -1,0 +1,5 @@
+{
+  "name": "custom_trace_test",
+  "trace_type": "python:trace_types.CustomTrace",
+  "steps": []
+}

--- a/libs/giskard-checks/tests/cli/data/trace_types.py
+++ b/libs/giskard-checks/tests/cli/data/trace_types.py
@@ -1,5 +1,5 @@
 from giskard.checks import Trace
 
 
-class CustomTrace(Trace[str, str]):
+class CustomTrace(Trace[str, str], frozen=True):
     pass

--- a/libs/giskard-checks/tests/cli/data/trace_types.py
+++ b/libs/giskard-checks/tests/cli/data/trace_types.py
@@ -1,0 +1,5 @@
+from giskard.checks import Trace
+
+
+class CustomTrace(Trace[str, str]):
+    pass

--- a/libs/giskard-checks/tests/cli/test_cli.py
+++ b/libs/giskard-checks/tests/cli/test_cli.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 from pathlib import Path
 

--- a/libs/giskard-checks/tests/cli/test_cli.py
+++ b/libs/giskard-checks/tests/cli/test_cli.py
@@ -4,23 +4,9 @@ import json
 from pathlib import Path
 
 import pytest
-
 from giskard.checks.cli import main
 
-
-def _write_target_module(path: Path) -> None:
-    path.write_text(
-        "\n".join(
-            [
-                "def explain_python(inputs):",
-                '    return "Python is a programming language."',
-                "",
-                "def echo(inputs):",
-                "    return inputs",
-            ]
-        ),
-        encoding="utf-8",
-    )
+DATA_DIR = Path(__file__).parent / "data"
 
 
 def test_help_lists_commands(capsys: pytest.CaptureFixture[str]) -> None:
@@ -44,28 +30,8 @@ def test_list_checks_includes_string_matching(
     assert "regex_matching" in captured.out
 
 
-def test_validate_scenario_yaml(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    _write_target_module(tmp_path / "targets.py")
-    scenario_path = tmp_path / "scenario.yaml"
-    scenario_path.write_text(
-        "\n".join(
-            [
-                "name: basic_test",
-                "target: python:targets.explain_python",
-                "steps:",
-                "  - interact:",
-                '      inputs: "What is Python?"',
-                "    check:",
-                "      - kind: string_matching",
-                '        keyword: "programming language"',
-            ]
-        ),
-        encoding="utf-8",
-    )
-
-    exit_code = main(["validate", str(scenario_path)])
+def test_validate_scenario_json(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main(["validate", str(DATA_DIR / "scenario.json")])
 
     captured = capsys.readouterr()
     assert exit_code == 0
@@ -73,28 +39,21 @@ def test_validate_scenario_yaml(
     assert "basic_test" in captured.out
 
 
-def test_run_scenario_yaml_json_output(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+def test_validate_scenario_yaml_when_pyyaml_is_available(
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
-    _write_target_module(tmp_path / "targets.py")
-    scenario_path = tmp_path / "scenario.yaml"
-    scenario_path.write_text(
-        "\n".join(
-            [
-                "name: basic_test",
-                "target: python:targets.explain_python",
-                "steps:",
-                "  - interact:",
-                '      inputs: "What is Python?"',
-                "    check:",
-                "      - kind: string_matching",
-                '        keyword: "programming language"',
-            ]
-        ),
-        encoding="utf-8",
-    )
+    pytest.importorskip("yaml")
 
-    exit_code = main(["run", str(scenario_path), "--format", "json"])
+    exit_code = main(["validate", str(DATA_DIR / "scenario.yaml")])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Valid scenario" in captured.out
+    assert "basic_test" in captured.out
+
+
+def test_run_scenario_json_output(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main(["run", str(DATA_DIR / "scenario.json"), "--format", "json"])
 
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
@@ -103,35 +62,15 @@ def test_run_scenario_yaml_json_output(
     assert payload["status"] == "pass"
 
 
-def test_run_suite_yaml_writes_junit_output(
+def test_run_suite_json_writes_junit_output(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    _write_target_module(tmp_path / "targets.py")
-    suite_path = tmp_path / "suite.yaml"
-    output_path = tmp_path / "results.xml"
-    suite_path.write_text(
-        "\n".join(
-            [
-                "name: cli_suite",
-                "target: python:targets.echo",
-                "scenarios:",
-                "  - name: suite_case",
-                "    steps:",
-                "      - interact:",
-                '          inputs: "hello"',
-                "        check:",
-                "          - kind: equals",
-                '            key: "trace.last.outputs"',
-                '            expected_value: "hello"',
-            ]
-        ),
-        encoding="utf-8",
-    )
+    output_path = tmp_path / "reports" / "results.xml"
 
     exit_code = main(
         [
             "run",
-            str(suite_path),
+            str(DATA_DIR / "suite.json"),
             "--format",
             "junit",
             "--output",
@@ -146,32 +85,9 @@ def test_run_suite_yaml_writes_junit_output(
 
 
 def test_validate_scenario_with_trace_type_string(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
-    (tmp_path / "trace_types.py").write_text(
-        "\n".join(
-            [
-                "from giskard.checks import Trace",
-                "",
-                "class CustomTrace(Trace[str, str]):",
-                "    pass",
-            ]
-        ),
-        encoding="utf-8",
-    )
-    scenario_path = tmp_path / "scenario.yaml"
-    scenario_path.write_text(
-        "\n".join(
-            [
-                "name: custom_trace_test",
-                "trace_type: python:trace_types.CustomTrace",
-                "steps: []",
-            ]
-        ),
-        encoding="utf-8",
-    )
-
-    exit_code = main(["validate", str(scenario_path)])
+    exit_code = main(["validate", str(DATA_DIR / "trace_type.json")])
 
     captured = capsys.readouterr()
     assert exit_code == 0
@@ -195,34 +111,49 @@ def test_run_prefers_definition_directory_targets_over_cwd_cache(
         ),
         encoding="utf-8",
     )
-    cached_scenario_path = cwd_dir / "cached.yaml"
+    cached_scenario_path = cwd_dir / "cached.json"
     cached_scenario_path.write_text(
-        "\n".join(
-            [
-                "name: cached_target",
-                "target: python:targets.explain_python",
-                "steps: []",
-            ]
+        json.dumps(
+            {
+                "name": "cached_target",
+                "target": "python:targets.explain_python",
+                "steps": [],
+            }
         ),
         encoding="utf-8",
     )
 
     scenario_dir = tmp_path / "scenario_case"
     scenario_dir.mkdir()
-    _write_target_module(scenario_dir / "targets.py")
-    scenario_path = scenario_dir / "scenario.yaml"
-    scenario_path.write_text(
+    (scenario_dir / "targets.py").write_text(
         "\n".join(
             [
-                "name: basic_test",
-                "target: python:targets.explain_python",
-                "steps:",
-                "  - interact:",
-                '      inputs: "What is Python?"',
-                "    check:",
-                "      - kind: string_matching",
-                '        keyword: "programming language"',
+                "def explain_python(inputs):",
+                '    return "Python is a programming language."',
             ]
+        ),
+        encoding="utf-8",
+    )
+    scenario_path = scenario_dir / "scenario.json"
+    scenario_path.write_text(
+        json.dumps(
+            {
+                "name": "basic_test",
+                "target": "python:targets.explain_python",
+                "steps": [
+                    {
+                        "interacts": [
+                            {"kind": "interact", "inputs": "What is Python?"}
+                        ],
+                        "checks": [
+                            {
+                                "kind": "string_matching",
+                                "keyword": "programming language",
+                            }
+                        ],
+                    }
+                ],
+            }
         ),
         encoding="utf-8",
     )
@@ -236,28 +167,14 @@ def test_run_prefers_definition_directory_targets_over_cwd_cache(
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
     assert exit_code == 0
-    assert payload["final_trace"]["last"]["outputs"] == "Python is a programming language."
-
-
-def test_validate_reports_invalid_target(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    scenario_path = tmp_path / "invalid.yaml"
-    scenario_path.write_text(
-        "\n".join(
-            [
-                "name: broken_test",
-                "target: python:targets.missing",
-                "steps:",
-                "  - interact:",
-                '      inputs: "hello"',
-            ]
-        ),
-        encoding="utf-8",
+    assert (
+        payload["final_trace"]["last"]["outputs"] == "Python is a programming language."
     )
 
-    exit_code = main(["validate", str(scenario_path)])
+
+def test_validate_reports_invalid_target(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main(["validate", str(DATA_DIR / "invalid_target.json")])
 
     captured = capsys.readouterr()
     assert exit_code == 2
-    assert "Could not import module 'targets'" in captured.err
+    assert "Could not import module 'missing_targets'" in captured.err

--- a/libs/giskard-checks/tests/cli/test_cli.py
+++ b/libs/giskard-checks/tests/cli/test_cli.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from giskard.checks.cli import main
+
+
+def _write_target_module(path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "def explain_python(inputs):",
+                '    return "Python is a programming language."',
+                "",
+                "def echo(inputs):",
+                "    return inputs",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_help_lists_commands(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit):
+        main(["--help"])
+
+    captured = capsys.readouterr()
+    assert "run" in captured.out
+    assert "validate" in captured.out
+    assert "list" in captured.out
+
+
+def test_list_checks_includes_string_matching(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(["list", "checks"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "string_matching" in captured.out
+    assert "regex_matching" in captured.out
+
+
+def test_validate_scenario_yaml(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_target_module(tmp_path / "targets.py")
+    scenario_path = tmp_path / "scenario.yaml"
+    scenario_path.write_text(
+        "\n".join(
+            [
+                "name: basic_test",
+                "target: python:targets.explain_python",
+                "steps:",
+                "  - interact:",
+                '      inputs: "What is Python?"',
+                "    check:",
+                "      - kind: string_matching",
+                '        keyword: "programming language"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = main(["validate", str(scenario_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Valid scenario" in captured.out
+    assert "basic_test" in captured.out
+
+
+def test_run_scenario_yaml_json_output(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_target_module(tmp_path / "targets.py")
+    scenario_path = tmp_path / "scenario.yaml"
+    scenario_path.write_text(
+        "\n".join(
+            [
+                "name: basic_test",
+                "target: python:targets.explain_python",
+                "steps:",
+                "  - interact:",
+                '      inputs: "What is Python?"',
+                "    check:",
+                "      - kind: string_matching",
+                '        keyword: "programming language"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = main(["run", str(scenario_path), "--format", "json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert payload["scenario_name"] == "basic_test"
+    assert payload["status"] == "pass"
+
+
+def test_run_suite_yaml_writes_junit_output(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_target_module(tmp_path / "targets.py")
+    suite_path = tmp_path / "suite.yaml"
+    output_path = tmp_path / "results.xml"
+    suite_path.write_text(
+        "\n".join(
+            [
+                "name: cli_suite",
+                "target: python:targets.echo",
+                "scenarios:",
+                "  - name: suite_case",
+                "    steps:",
+                "      - interact:",
+                '          inputs: "hello"',
+                "        check:",
+                "          - kind: equals",
+                '            key: "trace.last.outputs"',
+                '            expected_value: "hello"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = main(
+        [
+            "run",
+            str(suite_path),
+            "--format",
+            "junit",
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    capsys.readouterr()
+    assert exit_code == 0
+    assert output_path.exists()
+    assert "<testsuite" in output_path.read_text(encoding="utf-8")
+
+
+def test_validate_scenario_with_trace_type_string(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (tmp_path / "trace_types.py").write_text(
+        "\n".join(
+            [
+                "from giskard.checks import Trace",
+                "",
+                "class CustomTrace(Trace[str, str]):",
+                "    pass",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    scenario_path = tmp_path / "scenario.yaml"
+    scenario_path.write_text(
+        "\n".join(
+            [
+                "name: custom_trace_test",
+                "trace_type: python:trace_types.CustomTrace",
+                "steps: []",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = main(["validate", str(scenario_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Valid scenario" in captured.out
+    assert "custom_trace_test" in captured.out
+
+
+def test_run_prefers_definition_directory_targets_over_cwd_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    cwd_dir = tmp_path / "cwd_case"
+    cwd_dir.mkdir()
+    (cwd_dir / "targets.py").write_text(
+        "\n".join(
+            [
+                "def explain_python(inputs):",
+                '    return "Wrong answer from cwd."',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    cached_scenario_path = cwd_dir / "cached.yaml"
+    cached_scenario_path.write_text(
+        "\n".join(
+            [
+                "name: cached_target",
+                "target: python:targets.explain_python",
+                "steps: []",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    scenario_dir = tmp_path / "scenario_case"
+    scenario_dir.mkdir()
+    _write_target_module(scenario_dir / "targets.py")
+    scenario_path = scenario_dir / "scenario.yaml"
+    scenario_path.write_text(
+        "\n".join(
+            [
+                "name: basic_test",
+                "target: python:targets.explain_python",
+                "steps:",
+                "  - interact:",
+                '      inputs: "What is Python?"',
+                "    check:",
+                "      - kind: string_matching",
+                '        keyword: "programming language"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(cwd_dir)
+    assert main(["validate", str(cached_scenario_path)]) == 0
+    capsys.readouterr()
+
+    exit_code = main(["run", str(scenario_path), "--format", "json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert payload["final_trace"]["last"]["outputs"] == "Python is a programming language."
+
+
+def test_validate_reports_invalid_target(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    scenario_path = tmp_path / "invalid.yaml"
+    scenario_path.write_text(
+        "\n".join(
+            [
+                "name: broken_test",
+                "target: python:targets.missing",
+                "steps:",
+                "  - interact:",
+                '      inputs: "hello"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = main(["validate", str(scenario_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "Could not import module 'targets'" in captured.err

--- a/libs/giskard-core/src/giskard/core/discriminated.py
+++ b/libs/giskard-core/src/giskard/core/discriminated.py
@@ -89,6 +89,20 @@ class Discriminated(BaseModel):
         return decorator
 
     @classmethod
+    def list_registered_kinds(cls) -> tuple[str, ...]:
+        """Return registered discriminator kinds for this discriminated base."""
+        metadata = getattr(cls, "__pydantic_generic_metadata__", {})
+        origin = metadata.get("origin") or cls
+        return tuple(sorted(_REGISTRY._reverse_kinds.get(origin, {})))
+
+    @classmethod
+    def list_registered_types(cls) -> dict[str, type[Any]]:
+        """Return registered discriminator kinds and their concrete types."""
+        metadata = getattr(cls, "__pydantic_generic_metadata__", {})
+        origin = metadata.get("origin") or cls
+        return dict(_REGISTRY._reverse_kinds.get(origin, {}))
+
+    @classmethod
     def __get_pydantic_core_schema__(
         cls, source: Any, handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,11 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
 
 [manifest]
 members = [
@@ -757,8 +762,12 @@ dependencies = [
     { name = "jsonpath-ng" },
     { name = "numpy" },
     { name = "pydantic" },
-    { name = "pyyaml" },
     { name = "rich" },
+]
+
+[package.optional-dependencies]
+yaml = [
+    { name = "pyyaml" },
 ]
 
 [package.metadata]
@@ -769,9 +778,10 @@ requires-dist = [
     { name = "jsonpath-ng", specifier = ">=1.7.0,<2" },
     { name = "numpy", specifier = ">=2.4.1,<3" },
     { name = "pydantic", specifier = ">=2.12,<3" },
-    { name = "pyyaml", specifier = ">=6.0.2,<7" },
+    { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=6.0.2,<7" },
     { name = "rich", specifier = ">=14.2.0,<15" },
 ]
+provides-extras = ["yaml"]
 
 [[package]]
 name = "giskard-core"

--- a/uv.lock
+++ b/uv.lock
@@ -757,6 +757,7 @@ dependencies = [
     { name = "jsonpath-ng" },
     { name = "numpy" },
     { name = "pydantic" },
+    { name = "pyyaml" },
     { name = "rich" },
 ]
 
@@ -768,6 +769,7 @@ requires-dist = [
     { name = "jsonpath-ng", specifier = ">=1.7.0,<2" },
     { name = "numpy", specifier = ">=2.4.1,<3" },
     { name = "pydantic", specifier = ">=2.12,<3" },
+    { name = "pyyaml", specifier = ">=6.0.2,<7" },
     { name = "rich", specifier = ">=14.2.0,<15" },
 ]
 


### PR DESCRIPTION
## Description

Add a `giskard` CLI for running and validating serialized scenarios and suites.

This PR adds:
- `giskard run <file>` for YAML/JSON scenario and suite definitions
- `giskard validate <file>` to validate definitions without execution
- `giskard list checks` to expose built-in check kinds
- output formats for rich terminal output, JSON, and JUnit XML

It also preserves support for serialized `trace_type` values and ensures `python:...` target resolution prefers the definition file directory over the current working directory when module names collide.

## Related Issue

Closes #2376 

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [x] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [x] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been modified)
