### PR TITLE
Add JsonValid check with schema validation and tests

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/__init__.py
@@ -19,6 +19,10 @@ from .builtin import (
     StringMatching,
     from_fn,
 )
+
+# ✅ ADD THIS IMPORT
+from .builtin.json_valid import JsonValid
+
 from .core import (
     Check,
     CheckResult,
@@ -68,6 +72,7 @@ __all__ = [
     # Modules
     "builtin",
     "judges",
+
     # Core classes
     "Check",
     "CheckResult",
@@ -84,6 +89,7 @@ __all__ = [
     "Interact",
     "Interaction",
     "InteractionSpec",
+
     # Builtin and LLM-based checks
     "BaseLLMCheck",
     "LLMCheckResult",
@@ -101,14 +107,21 @@ __all__ = [
     "SemanticSimilarity",
     "StringMatching",
     "RegexMatching",
+
+    # ✅ ADD THIS LINE
+    "JsonValid",
+
     # Generators
     "UserSimulator",
+
     # Testing
     "WithSpy",
     "TestCaseRunner",
+
     # Scenarios
     "Suite",
     "ScenarioRunner",
+
     # Settings
     "set_default_generator",
     "get_default_generator",

--- a/libs/giskard-checks/src/giskard/checks/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/__init__.py
@@ -20,7 +20,7 @@ from .builtin import (
     from_fn,
 )
 
-# ✅ ADD THIS IMPORT
+
 from .builtin.json_valid import JsonValid
 
 from .core import (
@@ -108,7 +108,7 @@ __all__ = [
     "StringMatching",
     "RegexMatching",
 
-    # ✅ ADD THIS LINE
+   
     "JsonValid",
 
     # Generators

--- a/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
@@ -18,7 +18,7 @@ from .fn import FnCheck, from_fn
 from .semantic_similarity import SemanticSimilarity
 from .text_matching import RegexMatching, StringMatching
 
-# ✅ Import Json validation check
+
 from .json_valid import JsonValid
 
 

--- a/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
@@ -18,6 +18,10 @@ from .fn import FnCheck, from_fn
 from .semantic_similarity import SemanticSimilarity
 from .text_matching import RegexMatching, StringMatching
 
+# ✅ Import Json validation check
+from .json_valid import JsonValid
+
+
 __all__ = [
     "from_fn",
     "FnCheck",
@@ -35,4 +39,5 @@ __all__ = [
     "SemanticSimilarity",
     "BaseLLMCheck",
     "LLMCheckResult",
+    "JsonValid",
 ]

--- a/libs/giskard-checks/src/giskard/checks/builtin/json_valid.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/json_valid.py
@@ -9,35 +9,44 @@ class JsonValid(Check):
     key: Optional[str] = None
     schema: Optional[Dict[str, Any]] = None
 
-    async def run(self, trace: Trace) -> CheckResult:
-        try:
-            # ✅ Support both real Trace and DummyTrace
-            if hasattr(trace, "last"):
-                value = trace.last.outputs
-            else:
-                value = trace.outputs
+   async def run(self, trace: Trace) -> CheckResult:
+    try:
+        # Handle trace safely
+        if hasattr(trace, "last"):
+            if trace.last is None:
+                return CheckResult.failure(message="Trace is empty")
+            value = trace.last.outputs
+        else:
+            value = trace.outputs
 
-            # Parse JSON
-            parsed = json.loads(value)
+        if value is None:
+            return CheckResult.failure(message="Output is empty")
 
-            # Schema validation
-            if self.schema:
-                try:
-                    import jsonschema
-                    jsonschema.validate(instance=parsed, schema=self.schema)
-                except Exception as e:
-                    return CheckResult(
-                        status=CheckStatus.FAIL,
-                        message=f"Schema validation failed: {str(e)}",
-                    )
+        # Parse JSON only if string
+        parsed = json.loads(value) if isinstance(value, (str, bytes)) else value
 
-            return CheckResult(
-                status=CheckStatus.PASS,
-                message="Valid JSON",
-            )
+        # Schema validation
+        if self.schema:
+            try:
+                import jsonschema
+            except ImportError:
+                return CheckResult.error(
+                    message="The 'jsonschema' library is required for schema validation."
+                )
 
-        except Exception as e:
-            return CheckResult(
-                status=CheckStatus.FAIL,
-                message=f"Invalid JSON: {str(e)}",
-            )
+            try:
+                jsonschema.validate(instance=parsed, schema=self.schema)
+            except Exception as e:
+                return CheckResult.failure(
+                    message=f"Schema validation failed: {str(e)}"
+                )
+
+        return CheckResult.success(message="Valid JSON")
+
+    except json.JSONDecodeError as e:
+        return CheckResult.failure(message=f"Invalid JSON: {str(e)}")
+
+    except Exception as e:
+        return CheckResult.error(
+            message=f"Unexpected error: {str(e)}"
+        )

--- a/libs/giskard-checks/src/giskard/checks/builtin/json_valid.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/json_valid.py
@@ -1,52 +1,70 @@
+from typing import Optional, Dict, Any
 import json
-from typing import Any, Optional, Dict
 
-from giskard.checks.core import Check, CheckResult, CheckStatus, Trace
+from giskard.checks.core.check import Check
+from giskard.checks.core.result import CheckResult
+from giskard.checks.core import Trace
 
 
 @Check.register("json_valid")
 class JsonValid(Check):
+    """
+    Check if output is valid JSON, optionally validating against a JSON schema.
+    """
+
     key: Optional[str] = None
     schema: Optional[Dict[str, Any]] = None
 
-   async def run(self, trace: Trace) -> CheckResult:
-    try:
-        # Handle trace safely
-        if hasattr(trace, "last"):
-            if trace.last is None:
-                return CheckResult.failure(message="Trace is empty")
-            value = trace.last.outputs
-        else:
-            value = trace.outputs
+    def __init__(
+        self,
+        key: Optional[str] = None,
+        schema: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__(key=key, schema=schema)
 
-        if value is None:
-            return CheckResult.failure(message="Output is empty")
-
-        # Parse JSON only if string
-        parsed = json.loads(value) if isinstance(value, (str, bytes)) else value
-
-        # Schema validation
-        if self.schema:
+        if schema is not None:
             try:
                 import jsonschema
+                jsonschema.Draft7Validator.check_schema(schema)
             except ImportError:
-                return CheckResult.error(
-                    message="The 'jsonschema' library is required for schema validation."
+                raise ImportError(
+                    "The 'jsonschema' library is required for schema validation."
                 )
-
-            try:
-                jsonschema.validate(instance=parsed, schema=self.schema)
             except Exception as e:
-                return CheckResult.failure(
-                    message=f"Schema validation failed: {str(e)}"
-                )
+                raise ValueError(f"Invalid JSON schema: {str(e)}")
 
-        return CheckResult.success(message="Valid JSON")
+    async def run(self, trace: Trace) -> CheckResult:
+        try:
+            # Safe extraction (handles DummyTrace + real Trace)
+            if self.key:
+                if hasattr(trace, "last") and trace.last is not None:
+                    value = trace.last.output.get(self.key)
+                else:
+                    value = trace.outputs.get(self.key)
+            else:
+                if hasattr(trace, "last") and trace.last is not None:
+                    value = trace.last.output
+                else:
+                    value = trace.outputs
 
-    except json.JSONDecodeError as e:
-        return CheckResult.failure(message=f"Invalid JSON: {str(e)}")
+            if value is None:
+                return CheckResult.failure(message="Output is empty")
 
-    except Exception as e:
-        return CheckResult.error(
-            message=f"Unexpected error: {str(e)}"
-        )
+            parsed = json.loads(value) if isinstance(value, str) else value
+
+            if self.schema:
+                import jsonschema
+                try:
+                    jsonschema.validate(instance=parsed, schema=self.schema)
+                except Exception as e:
+                    return CheckResult.failure(
+                        message=f"Schema validation failed: {str(e)}"
+                    )
+
+            return CheckResult.success(message="Valid JSON")
+
+        except json.JSONDecodeError as e:
+            return CheckResult.failure(message=f"Invalid JSON: {str(e)}")
+
+        except Exception as e:
+            return CheckResult.error(message=f"Unexpected error: {str(e)}")

--- a/libs/giskard-checks/src/giskard/checks/builtin/json_valid.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/json_valid.py
@@ -3,59 +3,67 @@ import json
 
 from giskard.checks.core.check import Check
 from giskard.checks.core.result import CheckResult
-from giskard.checks.core import Trace
+from giskard.core.core import Trace
+from giskard.checks.core import resolve
+from giskard.checks.core.json_path import JSONPathStr
+from giskard.checks.core.exceptions import NoMatch
+
+from pydantic import field_validator
 
 
 @Check.register("json_valid")
 class JsonValid(Check):
     """
     Check if output is valid JSON, optionally validating against a JSON schema.
+
+    Parameters
+    ----------
+    key : Optional[str]
+        JSONPath key to extract value from trace. If None, uses full output.
+    expected_schema : Optional[Dict[str, Any]]
+        JSON schema to validate against.
     """
 
     key: Optional[str] = None
-    schema: Optional[Dict[str, Any]] = None
+    expected_schema: Optional[Dict[str, Any]] = None
 
-    def __init__(
-        self,
-        key: Optional[str] = None,
-        schema: Optional[Dict[str, Any]] = None,
-    ):
-        super().__init__(key=key, schema=schema)
-
-        if schema is not None:
-            try:
-                import jsonschema
-                jsonschema.Draft7Validator.check_schema(schema)
-            except ImportError:
-                raise ImportError(
-                    "The 'jsonschema' library is required for schema validation."
-                )
-            except Exception as e:
-                raise ValueError(f"Invalid JSON schema: {str(e)}")
+    #  Schema validation using Pydantic
+    @field_validator("expected_schema")
+    @classmethod
+    def validate_schema(cls, v):
+        if v is None:
+            return v
+        try:
+            import jsonschema
+            jsonschema.Draft7Validator.check_schema(v)
+        except ImportError:
+            raise ImportError(
+                "The 'jsonschema' library is required for schema validation."
+            )
+        except Exception as e:
+            raise ValueError(f"Invalid JSON schema: {str(e)}")
+        return v
 
     async def run(self, trace: Trace) -> CheckResult:
         try:
-            # Safe extraction (handles DummyTrace + real Trace)
-            if self.key:
-                if hasattr(trace, "last") and trace.last is not None:
-                    value = trace.last.output.get(self.key)
+            try:
+                #  ALWAYS use resolve (no manual trace access)
+                if self.key:
+                    value = resolve(trace, JSONPathStr(self.key))
                 else:
-                    value = trace.outputs.get(self.key)
-            else:
-                if hasattr(trace, "last") and trace.last is not None:
-                    value = trace.last.output
-                else:
-                    value = trace.outputs
+                    value = resolve(trace, JSONPathStr("$"))
+            except NoMatch:
+                return CheckResult.failure(message="Key not found in trace")
 
             if value is None:
                 return CheckResult.failure(message="Output is empty")
 
             parsed = json.loads(value) if isinstance(value, str) else value
 
-            if self.schema:
+            if self.expected_schema:
                 import jsonschema
                 try:
-                    jsonschema.validate(instance=parsed, schema=self.schema)
+                    jsonschema.validate(instance=parsed, schema=self.expected_schema)
                 except Exception as e:
                     return CheckResult.failure(
                         message=f"Schema validation failed: {str(e)}"

--- a/libs/giskard-checks/src/giskard/checks/builtin/json_valid.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/json_valid.py
@@ -1,70 +1,71 @@
-import asyncio
-import pytest
+from typing import Optional, Dict, Any
+import json
 
-from giskard.checks import JsonValid
-from giskard.core.core import Trace
+from giskard.checks.core.check import Check
+from giskard.checks.core.result import CheckResult
+from giskard.checks.core import Trace, resolve
 
-
-def test_valid_json():
-    trace = Trace(outputs={"result": '{"name": "John"}'})
-
-    check = JsonValid(key="result")
-    result = asyncio.run(check.run(trace))
-
-    assert result.passed
-    assert "Valid JSON" in result.message
+from pydantic import field_validator
 
 
-def test_invalid_json():
-    trace = Trace(outputs={"result": '{"name": John}'})  # invalid JSON
+@Check.register("json_valid")
+class JsonValid(Check):
+    key: Optional[str] = None
+    expected_schema: Optional[Dict[str, Any]] = None
+    schema: Optional[Dict[str, Any]] = None  # ✅ FAST FIX (compatibility)
 
-    check = JsonValid(key="result")
-    result = asyncio.run(check.run(trace))
+    @field_validator("expected_schema", "schema")
+    @classmethod
+    def validate_schema(cls, v):
+        if v is None:
+            return v
+        try:
+            import jsonschema
+            jsonschema.Draft7Validator.check_schema(v)
+        except ImportError:
+            raise ImportError("The 'jsonschema' library is required.")
+        except Exception as e:
+            raise ValueError(f"Invalid JSON schema: {str(e)}")
+        return v
 
-    assert not result.passed
-    assert "Invalid JSON" in result.message
+    async def run(self, trace: Trace) -> CheckResult:
+        try:
+            # Handle key-based extraction
+            if self.key:
+                try:
+                    value = resolve(trace, self.key)
+                except Exception:
+                    return CheckResult.failure(message="Key not found in trace")
+            else:
+                # Support DummyTrace + real Trace
+                if hasattr(trace, "last") and trace.last is not None:
+                    value = trace.last.output
+                elif hasattr(trace, "outputs"):
+                    value = trace.outputs
+                else:
+                    value = trace
 
+            if value is None:
+                return CheckResult.failure(message="Output is empty")
 
-def test_schema_validation_success():
-    trace = Trace(outputs={"result": '{"age": 25}'})
+            parsed = json.loads(value) if isinstance(value, str) else value
 
-    schema = {
-        "type": "object",
-        "properties": {
-            "age": {"type": "number"}
-        },
-        "required": ["age"]
-    }
+            #  FIX: support both expected_schema and schema
+            schema = self.expected_schema or self.schema
 
-    check = JsonValid(key="result", expected_schema=schema)
-    result = asyncio.run(check.run(trace))
+            if schema:
+                import jsonschema
+                try:
+                    jsonschema.validate(instance=parsed, schema=schema)
+                except Exception as e:
+                    return CheckResult.failure(
+                        message=f"Schema validation failed: {str(e)}"
+                    )
 
-    assert result.passed
+            return CheckResult.success(message="Valid JSON")
 
+        except json.JSONDecodeError as e:
+            return CheckResult.failure(message=f"Invalid JSON: {str(e)}")
 
-def test_schema_validation_failure():
-    trace = Trace(outputs={"result": '{"age": "twenty"}'})
-
-    schema = {
-        "type": "object",
-        "properties": {
-            "age": {"type": "number"}
-        },
-        "required": ["age"]
-    }
-
-    check = JsonValid(key="result", expected_schema=schema)
-    result = asyncio.run(check.run(trace))
-
-    assert not result.passed
-    assert "Schema validation failed" in result.message
-
-
-def test_key_not_found():
-    trace = Trace(outputs={"data": '{"name": "John"}'})
-
-    check = JsonValid(key="missing")
-    result = asyncio.run(check.run(trace))
-
-    assert not result.passed
-    assert "Key not found" in result.message
+        except Exception as e:
+            return CheckResult.error(message=f"Unexpected error: {str(e)}")

--- a/libs/giskard-checks/src/giskard/checks/builtin/json_valid.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/json_valid.py
@@ -1,78 +1,70 @@
-from typing import Optional, Dict, Any
-import json
+import asyncio
+import pytest
 
-from giskard.checks.core.check import Check
-from giskard.checks.core.result import CheckResult
+from giskard.checks import JsonValid
 from giskard.core.core import Trace
-from giskard.checks.core import resolve
-from giskard.checks.core.json_path import JSONPathStr
-from giskard.checks.core.exceptions import NoMatch
-
-from pydantic import field_validator
 
 
-@Check.register("json_valid")
-class JsonValid(Check):
-    """
-    Check if output is valid JSON, optionally validating against a JSON schema.
+def test_valid_json():
+    trace = Trace(outputs={"result": '{"name": "John"}'})
 
-    Parameters
-    ----------
-    key : Optional[str]
-        JSONPath key to extract value from trace. If None, uses full output.
-    expected_schema : Optional[Dict[str, Any]]
-        JSON schema to validate against.
-    """
+    check = JsonValid(key="result")
+    result = asyncio.run(check.run(trace))
 
-    key: Optional[str] = None
-    expected_schema: Optional[Dict[str, Any]] = None
+    assert result.passed
+    assert "Valid JSON" in result.message
 
-    #  Schema validation using Pydantic
-    @field_validator("expected_schema")
-    @classmethod
-    def validate_schema(cls, v):
-        if v is None:
-            return v
-        try:
-            import jsonschema
-            jsonschema.Draft7Validator.check_schema(v)
-        except ImportError:
-            raise ImportError(
-                "The 'jsonschema' library is required for schema validation."
-            )
-        except Exception as e:
-            raise ValueError(f"Invalid JSON schema: {str(e)}")
-        return v
 
-    async def run(self, trace: Trace) -> CheckResult:
-        try:
-            try:
-                #  ALWAYS use resolve (no manual trace access)
-                if self.key:
-                    value = resolve(trace, JSONPathStr(self.key))
-                else:
-                    value = resolve(trace, JSONPathStr("$"))
-            except NoMatch:
-                return CheckResult.failure(message="Key not found in trace")
+def test_invalid_json():
+    trace = Trace(outputs={"result": '{"name": John}'})  # invalid JSON
 
-            if value is None:
-                return CheckResult.failure(message="Output is empty")
+    check = JsonValid(key="result")
+    result = asyncio.run(check.run(trace))
 
-            parsed = json.loads(value) if isinstance(value, str) else value
+    assert not result.passed
+    assert "Invalid JSON" in result.message
 
-            if self.expected_schema:
-                import jsonschema
-                try:
-                    jsonschema.validate(instance=parsed, schema=self.expected_schema)
-                except Exception as e:
-                    return CheckResult.failure(
-                        message=f"Schema validation failed: {str(e)}"
-                    )
 
-            return CheckResult.success(message="Valid JSON")
+def test_schema_validation_success():
+    trace = Trace(outputs={"result": '{"age": 25}'})
 
-        except json.JSONDecodeError as e:
-            return CheckResult.failure(message=f"Invalid JSON: {str(e)}")
+    schema = {
+        "type": "object",
+        "properties": {
+            "age": {"type": "number"}
+        },
+        "required": ["age"]
+    }
 
-        except Exception as e:
-            return CheckResult.error(message=f"Unexpected error: {str(e)}")
+    check = JsonValid(key="result", expected_schema=schema)
+    result = asyncio.run(check.run(trace))
+
+    assert result.passed
+
+
+def test_schema_validation_failure():
+    trace = Trace(outputs={"result": '{"age": "twenty"}'})
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "age": {"type": "number"}
+        },
+        "required": ["age"]
+    }
+
+    check = JsonValid(key="result", expected_schema=schema)
+    result = asyncio.run(check.run(trace))
+
+    assert not result.passed
+    assert "Schema validation failed" in result.message
+
+
+def test_key_not_found():
+    trace = Trace(outputs={"data": '{"name": "John"}'})
+
+    check = JsonValid(key="missing")
+    result = asyncio.run(check.run(trace))
+
+    assert not result.passed
+    assert "Key not found" in result.message

--- a/libs/giskard-checks/src/giskard/checks/builtin/json_valid.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/json_valid.py
@@ -1,0 +1,43 @@
+import json
+from typing import Any, Optional, Dict
+
+from giskard.checks.core import Check, CheckResult, CheckStatus, Trace
+
+
+@Check.register("json_valid")
+class JsonValid(Check):
+    key: Optional[str] = None
+    schema: Optional[Dict[str, Any]] = None
+
+    async def run(self, trace: Trace) -> CheckResult:
+        try:
+            # ✅ Support both real Trace and DummyTrace
+            if hasattr(trace, "last"):
+                value = trace.last.outputs
+            else:
+                value = trace.outputs
+
+            # Parse JSON
+            parsed = json.loads(value)
+
+            # Schema validation
+            if self.schema:
+                try:
+                    import jsonschema
+                    jsonschema.validate(instance=parsed, schema=self.schema)
+                except Exception as e:
+                    return CheckResult(
+                        status=CheckStatus.FAIL,
+                        message=f"Schema validation failed: {str(e)}",
+                    )
+
+            return CheckResult(
+                status=CheckStatus.PASS,
+                message="Valid JSON",
+            )
+
+        except Exception as e:
+            return CheckResult(
+                status=CheckStatus.FAIL,
+                message=f"Invalid JSON: {str(e)}",
+            )

--- a/libs/giskard-checks/tests/builtin/test_json_valid.py
+++ b/libs/giskard-checks/tests/builtin/test_json_valid.py
@@ -1,0 +1,62 @@
+import sys
+import os
+import pytest
+
+sys.path.append(
+    os.path.abspath("libs/giskard-checks/src")
+)
+
+from giskard.checks import JsonValid
+
+
+class DummyTrace:
+    def __init__(self, output):
+        self.outputs = output
+
+
+@pytest.mark.asyncio
+async def test_valid_json():
+    check = JsonValid()
+    trace = DummyTrace('{"name": "Alice"}')
+
+    result = await check.run(trace)
+    assert result.passed
+
+
+@pytest.mark.asyncio
+async def test_invalid_json():
+    check = JsonValid()
+    trace = DummyTrace('{"name": Alice}')
+
+    result = await check.run(trace)
+    assert not result.passed
+
+
+@pytest.mark.asyncio
+async def test_schema_valid():
+    schema = {
+        "type": "object",
+        "properties": {"age": {"type": "number"}},
+        "required": ["age"]
+    }
+
+    check = JsonValid(schema=schema)
+    trace = DummyTrace('{"age": 25}')
+
+    result = await check.run(trace)
+    assert result.passed
+
+
+@pytest.mark.asyncio
+async def test_schema_invalid():
+    schema = {
+        "type": "object",
+        "properties": {"age": {"type": "number"}},
+        "required": ["age"]
+    }
+
+    check = JsonValid(schema=schema)
+    trace = DummyTrace('{"age": "twenty"}')
+
+    result = await check.run(trace)
+    assert not result.passed


### PR DESCRIPTION
## Description

This PR introduces a new built-in check `JsonValid` to validate whether LLM outputs are well-formed JSON, with optional JSON Schema validation.

### Features

* ✅ Validates JSON correctness using Python `json` module
* ✅ Optional JSON Schema validation (via `jsonschema`)
* ✅ Supports both `Trace` and `DummyTrace` inputs
* ✅ Returns clear error messages for invalid JSON or schema mismatch

### Motivation

Structured outputs from LLMs (e.g., function calling, tool outputs) require reliable validation. This check provides a simple and extensible way to ensure correctness, similar to tools like DeepEval and promptfoo.

---

## Related Issue

Closes #217

---

## Type of Change

* [x] 🚀 New feature (non-breaking change which adds functionality)

---

## Checklist

* [x] I've read the CODE_OF_CONDUCT.md document.
* [x] I've read the CONTRIBUTING.md guide.
* [x] I've written tests for all new methods and classes that I created.
* [ ] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
* [ ] I've updated the `uv.lock` running `uv lock` (not applicable)
