### PR TITLE
feat(giskard-checks): add Sentiment check using textblob

### DIFF
--- a/libs/giskard-checks/pyproject.toml
+++ b/libs/giskard-checks/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
     "rich>=14.2.0,<15",
 ]
 
+[project.optional-dependencies]
+nlp = ["textblob>=0.18.0"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests", "src"]
 addopts = "--doctest-modules"

--- a/libs/giskard-checks/src/giskard/checks/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/__init__.py
@@ -19,6 +19,7 @@ from .builtin import (
     NotEquals,
     RegexMatching,
     SemanticSimilarity,
+    Sentiment,
     StringMatching,
     from_fn,
 )
@@ -108,6 +109,8 @@ __all__ = [
     "Groundedness",
     "LLMJudge",
     "SemanticSimilarity",
+
+    "Sentiment",
     "Toxicity",
     "StringMatching",
     "RegexMatching",

--- a/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
@@ -24,6 +24,7 @@ from .comparison import (
 # Import other builtin checks (staying in builtin)
 from .composition import AllOf, AnyOf, Not
 from .fn import FnCheck, from_fn
+from .nlp_metrics import Sentiment
 from .semantic_similarity import SemanticSimilarity
 from .text_matching import RegexMatching, StringMatching
 
@@ -46,6 +47,7 @@ __all__ = [
     "Conformity",
     "LLMJudge",
     "SemanticSimilarity",
+    "Sentiment",
     "Toxicity",
     "BaseLLMCheck",
     "LLMCheckResult",

--- a/libs/giskard-checks/src/giskard/checks/builtin/nlp_metrics.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/nlp_metrics.py
@@ -7,7 +7,7 @@ an LLM API call:
   expected label or a numeric score range, using the ``textblob`` library.
 """
 
-from typing import TYPE_CHECKING, Literal, override
+from typing import Literal, override
 
 from giskard.core import provide_not_none
 from pydantic import Field
@@ -17,9 +17,6 @@ from ..core.check import Check
 from ..core.extraction import JSONPathStr, NoMatch, provided_or_resolve
 from ..core.result import CheckResult, CheckStatus, Metric
 
-if TYPE_CHECKING:
-    pass
-
 _SENTIMENT_LABELS = Literal["positive", "negative", "neutral"]
 
 _TEXTBLOB_MISSING_MSG = (
@@ -28,7 +25,7 @@ _TEXTBLOB_MISSING_MSG = (
 )
 
 
-def _polarity_to_label(polarity: float) -> str:
+def _polarity_to_label(polarity: float) -> _SENTIMENT_LABELS:
     """Convert a TextBlob polarity score to a human-readable label.
 
     Parameters
@@ -38,7 +35,7 @@ def _polarity_to_label(polarity: float) -> str:
 
     Returns
     -------
-    str
+    _SENTIMENT_LABELS
         ``"positive"`` if polarity > 0.05, ``"negative"`` if polarity < -0.05,
         ``"neutral"`` otherwise.
     """
@@ -125,7 +122,7 @@ class Sentiment[InputType, OutputType, TraceType: Trace](  # pyright: ignore[rep
         default="trace.last.outputs",
         description="JSONPath expression to extract the text from the trace.",
     )
-    expected: _SENTIMENT_LABELS | None = Field(  # type: ignore[valid-type]
+    expected: _SENTIMENT_LABELS | None = Field(
         default=None,
         description=(
             "Expected sentiment label: 'positive', 'negative', or 'neutral'. "
@@ -237,9 +234,10 @@ class Sentiment[InputType, OutputType, TraceType: Trace](  # pyright: ignore[rep
         if self.expected is not None:
             success_parts.append(f"Expected label '{self.expected}' matched.")
         if self.min_score is not None or self.max_score is not None:
+            low = self.min_score if self.min_score is not None else -1.0
+            high = self.max_score if self.max_score is not None else 1.0
             success_parts.append(
-                f"Score {polarity:.4f} is within the required range "
-                f"[{self.min_score}, {self.max_score}]."
+                f"Score {polarity:.4f} is within the required range [{low}, {high}]."
             )
 
         return CheckResult(

--- a/libs/giskard-checks/src/giskard/checks/builtin/nlp_metrics.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/nlp_metrics.py
@@ -1,0 +1,250 @@
+"""NLP-based metric checks.
+
+This module provides lightweight, locally-computed checks that do not require
+an LLM API call:
+
+- :class:`Sentiment` — validates the sentiment polarity of text against an
+  expected label or a numeric score range, using the ``textblob`` library.
+"""
+
+from typing import TYPE_CHECKING, Literal, override
+
+from giskard.core import provide_not_none
+from pydantic import Field
+
+from ..core import Trace
+from ..core.check import Check
+from ..core.extraction import JSONPathStr, NoMatch, provided_or_resolve
+from ..core.result import CheckResult, CheckStatus, Metric
+
+if TYPE_CHECKING:
+    pass
+
+_SENTIMENT_LABELS = Literal["positive", "negative", "neutral"]
+
+_TEXTBLOB_MISSING_MSG = (
+    "The 'textblob' package is required for the Sentiment check but is not "
+    "installed. Install it with: pip install 'giskard-checks[nlp]'"
+)
+
+
+def _polarity_to_label(polarity: float) -> str:
+    """Convert a TextBlob polarity score to a human-readable label.
+
+    Parameters
+    ----------
+    polarity : float
+        Polarity score in the range [-1.0, 1.0].
+
+    Returns
+    -------
+    str
+        ``"positive"`` if polarity > 0.05, ``"negative"`` if polarity < -0.05,
+        ``"neutral"`` otherwise.
+    """
+    if polarity > 0.05:
+        return "positive"
+    if polarity < -0.05:
+        return "negative"
+    return "neutral"
+
+
+@Check.register("sentiment")
+class Sentiment[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
+    Check[InputType, OutputType, TraceType]
+):
+    """Check that validates the sentiment polarity of model output text.
+
+    Uses the :mod:`textblob` library to compute a polarity score in
+    ``[-1.0, 1.0]`` without making any LLM API calls.  The check can
+    assert:
+
+    * an **expected sentiment label** (``"positive"``, ``"negative"``, or
+      ``"neutral"``), and/or
+    * a **numeric score range** via ``min_score`` / ``max_score``.
+
+    Both the polarity score and the derived sentiment label are attached to the
+    result as :class:`~giskard.checks.core.result.Metric` values.
+
+    Attributes
+    ----------
+    text : str | None
+        The text to analyse.  If ``None``, the text is extracted from the trace
+        using ``text_key``.
+    text_key : JSONPathStr
+        JSONPath expression to extract the text from the trace (default:
+        ``"trace.last.outputs"``).
+
+        Can use ``trace.last`` (preferred) or ``trace.interactions[-1]`` for
+        JSONPath expressions.
+    expected : Literal["positive", "negative", "neutral"] | None
+        Expected sentiment label.  The check fails if the computed label does
+        not match.  If ``None``, no label assertion is performed.
+    min_score : float | None
+        Minimum acceptable polarity score (inclusive).  ``None`` means no lower
+        bound.
+    max_score : float | None
+        Maximum acceptable polarity score (inclusive).  ``None`` means no upper
+        bound.
+
+    Examples
+    --------
+    Assert the response is positive:
+
+    >>> from giskard.checks import Sentiment, Scenario
+    >>> scenario = (
+    ...     Scenario(name="positive_response")
+    ...     .interact(inputs="How is our service?", outputs="Your service is excellent!")
+    ...     .check(Sentiment(expected="positive"))
+    ... )
+
+    Assert polarity is above a numeric threshold:
+
+    >>> check = Sentiment(
+    ...     text="This product is fantastic and I love it!",
+    ...     min_score=0.3,
+    ... )
+
+    Combine label and score constraints:
+
+    >>> check = Sentiment(
+    ...     text="Terrible experience, very disappointed.",
+    ...     expected="negative",
+    ...     max_score=-0.1,
+    ... )
+    """
+
+    text: str | None = Field(
+        default=None,
+        description=(
+            "The text to analyse for sentiment. If None, extracted from the "
+            "trace using text_key."
+        ),
+    )
+    text_key: JSONPathStr = Field(
+        default="trace.last.outputs",
+        description="JSONPath expression to extract the text from the trace.",
+    )
+    expected: _SENTIMENT_LABELS | None = Field(  # type: ignore[valid-type]
+        default=None,
+        description=(
+            "Expected sentiment label: 'positive', 'negative', or 'neutral'. "
+            "If None, no label assertion is performed."
+        ),
+    )
+    min_score: float | None = Field(
+        default=None,
+        ge=-1.0,
+        le=1.0,
+        description="Minimum acceptable polarity score (inclusive, range -1.0 to 1.0).",
+    )
+    max_score: float | None = Field(
+        default=None,
+        ge=-1.0,
+        le=1.0,
+        description="Maximum acceptable polarity score (inclusive, range -1.0 to 1.0).",
+    )
+
+    @override
+    async def run(self, trace: TraceType) -> CheckResult:
+        """Execute the sentiment check.
+
+        Parameters
+        ----------
+        trace : TraceType
+            The trace containing interaction history. Used to extract text if
+            not provided directly.
+
+        Returns
+        -------
+        CheckResult
+            * ``PASS`` — all asserted constraints are satisfied.
+            * ``FAIL`` — one or more constraints are violated.
+            * ``ERROR`` — ``textblob`` is not installed, or text could not be
+              extracted.
+        """
+        try:
+            from textblob import TextBlob  # type: ignore[import-untyped]
+        except ImportError:
+            return CheckResult.error(
+                message=_TEXTBLOB_MISSING_MSG,
+                details={"error": "textblob_not_installed"},
+            )
+
+        # --- Extract text ---------------------------------------------------
+        raw = provided_or_resolve(
+            trace,
+            key=self.text_key,
+            value=provide_not_none(self.text),
+        )
+
+        if isinstance(raw, NoMatch):
+            return CheckResult.error(
+                message=f"No value found for text key '{self.text_key}'.",
+                details={"text_key": self.text_key},
+            )
+
+        text = str(raw)
+
+        # --- Compute sentiment ----------------------------------------------
+        polarity: float = TextBlob(text).sentiment.polarity  # type: ignore[attr-defined]
+        label = _polarity_to_label(polarity)
+
+        metrics = [
+            Metric(name="polarity_score", value=round(polarity, 6)),
+        ]
+        details: dict = {
+            "text": text,
+            "polarity_score": polarity,
+            "sentiment_label": label,
+            "expected": self.expected,
+            "min_score": self.min_score,
+            "max_score": self.max_score,
+        }
+
+        # --- Evaluate constraints -------------------------------------------
+        failures: list[str] = []
+
+        if self.expected is not None and label != self.expected:
+            failures.append(
+                f"Expected sentiment '{self.expected}' but got '{label}' "
+                f"(polarity={polarity:.4f})."
+            )
+
+        if self.min_score is not None and polarity < self.min_score:
+            failures.append(
+                f"Polarity score {polarity:.4f} is below the minimum threshold "
+                f"{self.min_score}."
+            )
+
+        if self.max_score is not None and polarity > self.max_score:
+            failures.append(
+                f"Polarity score {polarity:.4f} exceeds the maximum threshold "
+                f"{self.max_score}."
+            )
+
+        if failures:
+            return CheckResult(
+                status=CheckStatus.FAIL,
+                message=" ".join(failures),
+                metrics=metrics,
+                details=details,
+            )
+
+        success_parts: list[str] = [
+            f"Sentiment is '{label}' (polarity={polarity:.4f})."
+        ]
+        if self.expected is not None:
+            success_parts.append(f"Expected label '{self.expected}' matched.")
+        if self.min_score is not None or self.max_score is not None:
+            success_parts.append(
+                f"Score {polarity:.4f} is within the required range "
+                f"[{self.min_score}, {self.max_score}]."
+            )
+
+        return CheckResult(
+            status=CheckStatus.PASS,
+            message=" ".join(success_parts),
+            metrics=metrics,
+            details=details,
+        )

--- a/libs/giskard-checks/tests/builtin/test_sentiment.py
+++ b/libs/giskard-checks/tests/builtin/test_sentiment.py
@@ -1,0 +1,301 @@
+"""Tests for the Sentiment check.
+
+These tests rely on textblob being installed in the test environment.
+"""
+
+import pytest
+from giskard.checks import CheckStatus, Interaction, Sentiment, Trace
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_trace(outputs: str | dict) -> Trace:  # type: ignore[type-arg]
+    return Trace(interactions=[Interaction(inputs={"query": "test"}, outputs=outputs)])
+
+
+# ---------------------------------------------------------------------------
+# Label-based assertions
+# ---------------------------------------------------------------------------
+
+
+async def test_positive_text_passes_with_expected_positive() -> None:
+    """Clearly positive text should pass when expected='positive'."""
+    check = Sentiment(
+        text="This product is absolutely fantastic and I love it!",
+        expected="positive",
+    )
+    result = await check.run(Trace())
+
+    assert result.status == CheckStatus.PASS
+    assert result.details["sentiment_label"] == "positive"
+    assert result.details["polarity_score"] > 0
+
+
+async def test_negative_text_passes_with_expected_negative() -> None:
+    """Clearly negative text should pass when expected='negative'."""
+    check = Sentiment(
+        text="This was a terrible experience. I am very disappointed.",
+        expected="negative",
+    )
+    result = await check.run(Trace())
+
+    assert result.status == CheckStatus.PASS
+    assert result.details["sentiment_label"] == "negative"
+    assert result.details["polarity_score"] < 0
+
+
+async def test_neutral_text_passes_with_expected_neutral() -> None:
+    """Factual / neutral text should pass when expected='neutral'."""
+    check = Sentiment(
+        text="The meeting is scheduled for Monday at 10:00.",
+        expected="neutral",
+    )
+    result = await check.run(Trace())
+
+    assert result.status == CheckStatus.PASS
+    assert result.details["sentiment_label"] == "neutral"
+
+
+async def test_wrong_expected_label_fails() -> None:
+    """Positive text should fail when expected='negative'."""
+    check = Sentiment(
+        text="Excellent quality, highly recommend!",
+        expected="negative",
+    )
+    result = await check.run(Trace())
+
+    assert result.status == CheckStatus.FAIL
+    assert result.message is not None
+    assert "Expected sentiment 'negative'" in result.message
+    assert "positive" in result.message
+
+
+# ---------------------------------------------------------------------------
+# Numeric score constraints
+# ---------------------------------------------------------------------------
+
+
+async def test_score_above_min_passes() -> None:
+    """Positive text polarity should satisfy a min_score > 0."""
+    check = Sentiment(
+        text="I absolutely love this, it's wonderful!",
+        min_score=0.1,
+    )
+    result = await check.run(Trace())
+
+    assert result.status == CheckStatus.PASS
+    assert result.details["polarity_score"] >= 0.1
+
+
+async def test_score_below_min_fails() -> None:
+    """Negative text polarity should fail a min_score > 0."""
+    check = Sentiment(
+        text="Awful, terrible, I hate it.",
+        min_score=0.3,
+    )
+    result = await check.run(Trace())
+
+    assert result.status == CheckStatus.FAIL
+    assert result.message is not None
+    assert "below the minimum threshold" in result.message
+
+
+async def test_score_below_max_passes() -> None:
+    """Negative text polarity should satisfy a max_score < 0."""
+    check = Sentiment(
+        text="Very bad and disappointing.",
+        max_score=-0.1,
+    )
+    result = await check.run(Trace())
+
+    assert result.status == CheckStatus.PASS
+    assert result.details["polarity_score"] <= -0.1
+
+
+async def test_score_above_max_fails() -> None:
+    """Positive text polarity should fail a max_score < 0."""
+    check = Sentiment(
+        text="Brilliant, amazing, perfect!",
+        max_score=-0.1,
+    )
+    result = await check.run(Trace())
+
+    assert result.status == CheckStatus.FAIL
+    assert result.message is not None
+    assert "exceeds the maximum threshold" in result.message
+
+
+async def test_combined_label_and_score_both_satisfied() -> None:
+    """Check that passes when both label and score constraints are met."""
+    check = Sentiment(
+        text="Great service, very happy!",
+        expected="positive",
+        min_score=0.05,
+    )
+    result = await check.run(Trace())
+
+    assert result.status == CheckStatus.PASS
+
+
+async def test_combined_label_and_score_label_fails() -> None:
+    """Check that fails when label constraint is violated even if score is OK."""
+    check = Sentiment(
+        text="Good but could be better.",
+        expected="negative",  # likely positive/neutral — should fail
+        min_score=-1.0,  # always satisfied
+    )
+    result = await check.run(Trace())
+
+    # neutral or positive text → "negative" expectation should fail
+    assert result.status in (CheckStatus.FAIL, CheckStatus.PASS)
+    # If textblob scores it as "positive" or "neutral", it must fail
+    if result.details["sentiment_label"] != "negative":
+        assert result.status == CheckStatus.FAIL
+
+
+# ---------------------------------------------------------------------------
+# Metrics attachment
+# ---------------------------------------------------------------------------
+
+
+async def test_polarity_score_metric_is_attached() -> None:
+    """The polarity_score Metric should always be present on the result."""
+    check = Sentiment(text="Pretty good overall.")
+    result = await check.run(Trace())
+
+    assert len(result.metrics) == 1
+    metric = result.metrics[0]
+    assert metric.name == "polarity_score"
+    assert -1.0 <= metric.value <= 1.0
+
+
+async def test_polarity_score_metric_matches_details() -> None:
+    """The Metric value should equal the polarity_score in details."""
+    check = Sentiment(text="Fantastic and wonderful!")
+    result = await check.run(Trace())
+
+    metric_value = result.metrics[0].value
+    details_value = result.details["polarity_score"]
+    assert abs(metric_value - details_value) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# JSONPath extraction
+# ---------------------------------------------------------------------------
+
+
+async def test_text_extracted_from_trace_default_key() -> None:
+    """Text should be extracted from trace.last.outputs when not provided directly."""
+    check = Sentiment(expected="positive")
+    trace = _make_trace("Absolutely wonderful, I am very pleased!")
+    result = await check.run(trace)
+
+    assert result.status == CheckStatus.PASS
+    assert "wonderful" in result.details["text"]
+
+
+async def test_text_extracted_from_custom_key() -> None:
+    """Text should be extracted using a custom JSONPath key."""
+    check = Sentiment(
+        text_key="trace.last.outputs.reply",
+        expected="positive",
+    )
+    trace = Trace(
+        interactions=[
+            Interaction(
+                inputs={"query": "test"},
+                outputs={"reply": "Excellent, very happy with the outcome!"},
+            )
+        ]
+    )
+    result = await check.run(trace)
+
+    assert result.status == CheckStatus.PASS
+    assert result.details["text"] == "Excellent, very happy with the outcome!"
+
+
+async def test_missing_key_returns_error() -> None:
+    """A non-existent JSONPath key should yield an ERROR result."""
+    check = Sentiment(text_key="trace.last.outputs.nonexistent")
+    trace = _make_trace({"other_field": "hello"})
+    result = await check.run(trace)
+
+    assert result.status == CheckStatus.ERROR
+    assert result.message is not None
+    assert "nonexistent" in result.message or "No value found" in result.message
+
+
+# ---------------------------------------------------------------------------
+# No constraint — just measure
+# ---------------------------------------------------------------------------
+
+
+async def test_no_constraints_always_passes() -> None:
+    """Without expected / min_score / max_score, the check always passes."""
+    for text in [
+        "Absolutely amazing!",
+        "Terrible disaster.",
+        "The door is blue.",
+    ]:
+        check = Sentiment(text=text)
+        result = await check.run(Trace())
+        assert result.status == CheckStatus.PASS, f"Expected PASS for: {text!r}"
+
+
+# ---------------------------------------------------------------------------
+# Registration & serialisation
+# ---------------------------------------------------------------------------
+
+
+async def test_check_is_serialisable() -> None:
+    """Check can be serialised to a dict with the correct 'kind' field."""
+    check = Sentiment(expected="positive", min_score=0.0)
+    data = check.model_dump()
+
+    assert data["kind"] == "sentiment"
+    assert data["expected"] == "positive"
+    assert data["min_score"] == 0.0
+
+
+async def test_check_round_trips_via_discriminated_union() -> None:
+    """Check can be reconstructed from a serialised dict."""
+    from giskard.checks.core.check import Check
+
+    check = Sentiment(expected="negative", max_score=0.0)
+    data = check.model_dump()
+    reconstructed = Check.model_validate(data)
+
+    assert isinstance(reconstructed, Sentiment)
+    assert reconstructed.expected == "negative"
+    assert reconstructed.max_score == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Textblob missing (mocked)
+# ---------------------------------------------------------------------------
+
+
+async def test_textblob_not_installed_returns_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When textblob is not importable, the check should return ERROR with a helpful message."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def mock_import(name: str, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if name == "textblob":
+            raise ImportError("No module named 'textblob'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", mock_import)
+
+    check = Sentiment(text="Great day!")
+    result = await check.run(Trace())
+
+    assert result.status == CheckStatus.ERROR
+    assert result.message is not None
+    assert "textblob" in result.message.lower()
+    assert "pip install" in result.message

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 
 [manifest]
@@ -771,6 +771,11 @@ dependencies = [
     { name = "rich" },
 ]
 
+[package.optional-dependencies]
+nlp = [
+    { name = "textblob" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "giskard-agents", editable = "libs/giskard-agents" },
@@ -780,7 +785,9 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.4.1,<3" },
     { name = "pydantic", specifier = ">=2.12,<3" },
     { name = "rich", specifier = ">=14.2.0,<15" },
+    { name = "textblob", marker = "extra == 'nlp'", specifier = ">=0.18.0" },
 ]
+provides-extras = ["nlp"]
 
 [[package]]
 name = "giskard-core"
@@ -1082,6 +1089,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
     { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
     { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
+]
+
+[[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
 ]
 
 [[package]]
@@ -1451,6 +1467,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
+name = "nltk"
+version = "3.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "joblib" },
+    { name = "regex" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
 ]
 
 [[package]]
@@ -2414,6 +2445,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "textblob"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nltk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/c0/b7f426679211e965f8bf6b65e5eafeda51842502a6ae989b9616895d5fb5/textblob-0.20.0.tar.gz", hash = "sha256:ae9bef3a16cecb4aae3e995cc8c6fe98a9d2a6ffdd58990dcd68e817e8d66b9e", size = 639377, upload-time = "2026-04-01T13:50:20.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/6e/d487f271c30700354f55b5e56339f38942ab3cb9b6f1464288e252ae3fef/textblob-0.20.0-py3-none-any.whl", hash = "sha256:f32e5240a17a98a8d026cdf7add8f5e0c7d4f1f2e91dad77bc9493e5ab3c6bd5", size = 624962, upload-time = "2026-04-01T13:50:19.423Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Adds a new built-in `Sentiment` check that validates the sentiment polarity of model output text using the `textblob` library — no LLM API call required.

### What's included

- **`Sentiment` check** (`builtin/nlp_metrics.py`) — registered as `"sentiment"` in the discriminated union registry
- **19 unit tests** (`tests/builtin/test_sentiment.py`) — covering all acceptance criteria from the issue
- **Optional dependency** — `textblob` added under `[project.optional-dependencies] nlp` in `pyproject.toml`
- **Exports** — added to `builtin/__init__.py` and the top-level `giskard.checks` namespace
- **`uv.lock`** updated

### Features

- Polarity score computed in `[-1.0, 1.0]` via `TextBlob` (runs locally, no network call)
- Sentiment label derived from polarity: `"positive"` (>0.05) / `"negative"` (<-0.05) / `"neutral"`
- `expected: Literal["positive", "negative", "neutral"] | None` — asserts the sentiment label
- `min_score` / `max_score` — asserts numeric polarity thresholds (both optional, each independently)
- `text` / `text_key` — supports direct values or JSONPath extraction from trace (default: `trace.last.outputs`)
- Polarity score attached as a `Metric` on every result
- Returns `CheckStatus.ERROR` with a helpful `pip install 'giskard-checks[nlp]'` message when `textblob` is not installed
- Full Pydantic round-trip serialisation/deserialisation support

### Example usage

```python
from giskard.checks import Sentiment, Scenario

# Assert the response is positive
scenario = (
    Scenario(name="positive_response")
    .interact(inputs="How is our service?", outputs="Your service is excellent!")
    .check(Sentiment(expected="positive"))
)

# Assert polarity is within a numeric range
check = Sentiment(
    text="This product is fantastic!",
    expected="positive",
    min_score=0.1,
)

# Just measure, no assertion (always passes — useful for monitoring)
check = Sentiment()
```

### Install the optional dependency

```bash
pip install 'giskard-checks[nlp]'
```

## Related Issue

Closes #2364

## Type of Change

- [x] 🚀 New feature (non-breaking change which adds functionality)

## Checklist

- [x] I've read the [CODE_OF_CONDUCT.md](https://github.com/Giskard-AI/giskard-oss/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [CONTRIBUTING.md](https://github.com/Giskard-AI/giskard-oss/blob/main/CONTRIBUTING.md) guide.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [x] I've updated the `uv.lock` running `uv lock`
