### PR TITLE
Observability exporters

### DIFF
--- a/libs/giskard-checks/README.md
+++ b/libs/giskard-checks/README.md
@@ -134,6 +134,106 @@ results = await suite.run()
 print(f"Aggregated pass rate: {results.pass_rate * 100}%")
 ```
 
+Observability export
+--------------------
+
+`SuiteResult` can be exported to observability backends after a suite run.
+Install the exporter dependencies you need:
+
+```bash
+pip install "giskard-checks[otel]"
+pip install "giskard-checks[langfuse]"
+```
+
+### OpenTelemetry
+
+Use `OTelExporter` when you already run an OpenTelemetry Collector or another
+OTLP-compatible backend.
+
+```python
+from giskard.checks.export import OTelExporter
+
+result = await suite.run(target=my_model)
+
+exporter = OTelExporter(endpoint="http://localhost:4317")
+exporter.export(result)
+exporter.force_flush()
+```
+
+The exporter creates a root `giskard.suite` span, one `giskard.scenario` span per
+scenario, `giskard.check` events for check results, and
+`giskard.trace.interaction` events for recorded interactions. It also records
+metrics for suite duration, suite pass rate, scenario duration, check counts, and
+numeric check metrics.
+
+By default, trace interaction events include `inputs` and `outputs`. Disable
+payload export for sensitive production traffic:
+
+```python
+exporter = OTelExporter(
+    endpoint="http://localhost:4317",
+    include_trace_payloads=False,
+)
+```
+
+### Langfuse
+
+Use `LangfuseExporter` to send Giskard runs to Langfuse as traces,
+observations, generations, and scores.
+
+```python
+from giskard.checks.export import LangfuseExporter
+
+result = await suite.run(target=my_model)
+
+exporter = LangfuseExporter(
+    public_key="pk-lf-...",
+    secret_key="sk-lf-...",
+    host="https://cloud.langfuse.com",
+)
+exporter.export(result)
+exporter.flush()
+```
+
+Mapping:
+
+- `SuiteResult` becomes a `giskard.suite` evaluator observation with a
+  `giskard.suite.pass_rate` score.
+- Each scenario becomes an evaluator observation.
+- Each recorded interaction becomes a generation observation.
+- Each check becomes an evaluator observation with a score. If a check has
+  numeric metrics, the first metric is used as the primary check score and all
+  metrics are exported as additional scores.
+
+Langfuse also accepts raw OpenTelemetry traces through its OTLP HTTP endpoint.
+Use that route through your collector when you need collector-level routing or
+filtering. Langfuse does not support OTLP/gRPC ingestion directly, so point
+collector exports at Langfuse's HTTP endpoint rather than passing a Langfuse URL
+to the generic gRPC `OTelExporter`.
+
+### Production samples and alerts
+
+`evaluate_production_sample` runs a suite for sampled production traffic,
+exports the result, and returns an alert object when pass rate falls below a
+threshold.
+
+```python
+from giskard.checks.export import OTelExporter, evaluate_production_sample
+
+exporter = OTelExporter(endpoint="http://localhost:4317")
+
+evaluation = await evaluate_production_sample(
+    suite,
+    target=my_model,
+    exporters=[exporter],
+    sample_rate=0.05,
+    min_pass_rate=0.95,
+)
+
+if evaluation.alert:
+    logger.warning(evaluation.alert.message)
+```
+
 Why this library?
 -----------------
 

--- a/libs/giskard-checks/pyproject.toml
+++ b/libs/giskard-checks/pyproject.toml
@@ -15,6 +15,22 @@ dependencies = [
     "rich>=14.2.0,<15",
 ]
 
+[project.scripts]
+giskard = "giskard.checks.cli:main"
+
+[project.optional-dependencies]
+langfuse = [
+    "langfuse>=3,<4",
+]
+otel = [
+    "opentelemetry-api>=1.38.0,<2",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.38.0,<2",
+    "opentelemetry-sdk>=1.38.0,<2",
+]
+yaml = [
+    "pyyaml>=6.0.2,<7",
+]
+
 [tool.pytest.ini_options]
 testpaths = ["tests", "src"]
 addopts = "--doctest-modules"

--- a/libs/giskard-checks/src/giskard/checks/export/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/export/__init__.py
@@ -1,3 +1,17 @@
 from .junit import to_junit_xml
+from .langfuse import LangfuseExporter
+from .monitoring import (
+    ProductionEvaluationAlert,
+    ProductionEvaluationResult,
+    evaluate_production_sample,
+)
+from .otel import OTelExporter
 
-__all__ = ["to_junit_xml"]
+__all__ = [
+    "LangfuseExporter",
+    "OTelExporter",
+    "ProductionEvaluationAlert",
+    "ProductionEvaluationResult",
+    "evaluate_production_sample",
+    "to_junit_xml",
+]

--- a/libs/giskard-checks/src/giskard/checks/export/langfuse.py
+++ b/libs/giskard-checks/src/giskard/checks/export/langfuse.py
@@ -1,0 +1,271 @@
+import json
+from typing import Any
+
+from ..core.result import CheckResult, ScenarioResult, SuiteResult
+
+_LANGFUSE_INSTALL_HINT = (
+    "Langfuse export requires optional dependencies. "
+    "Install them with `pip install giskard-checks[langfuse]`."
+)
+
+
+def _require_langfuse() -> type[Any]:
+    try:
+        from langfuse import Langfuse
+    except ImportError as exc:
+        raise ImportError(_LANGFUSE_INSTALL_HINT) from exc
+    return Langfuse
+
+
+def _status_value(status: Any) -> str:
+    value = getattr(status, "value", status)
+    return str(value)
+
+
+def _json(value: Any) -> str:
+    if hasattr(value, "model_dump"):
+        value = value.model_dump(mode="json")
+    return json.dumps(value, ensure_ascii=False, default=str)
+
+
+def _attribute_value(value: Any) -> str | bool | int | float:
+    if isinstance(value, str | bool | int | float):
+        return value
+    if value is None:
+        return ""
+    return _json(value)
+
+
+def _check_label(result: CheckResult, fallback: str) -> str:
+    return str(
+        result.details.get("check_name")
+        or result.details.get("check_kind")
+        or result.details.get("name")
+        or fallback
+    )
+
+
+def _score_value(result: CheckResult) -> float | str:
+    if result.metrics:
+        return result.metrics[0].value
+    if result.passed:
+        return 1.0
+    if result.skipped:
+        return "skipped"
+    return 0.0
+
+
+def _score_data_type(result: CheckResult) -> str:
+    if result.metrics:
+        return "NUMERIC"
+    if result.skipped:
+        return "CATEGORICAL"
+    return "NUMERIC"
+
+
+def _score_comment(result: CheckResult) -> str | None:
+    if result.message:
+        return result.message
+    if result.metrics:
+        metric = result.metrics[0]
+        return f"{metric.name}={metric.value}"
+    return None
+
+
+def _metadata(value: Any) -> dict[str, Any]:
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    if isinstance(value, dict):
+        return value
+    return {"value": _attribute_value(value)}
+
+
+class LangfuseExporter:
+    """Export suite results to Langfuse traces, observations, and scores."""
+
+    def __init__(
+        self,
+        *,
+        public_key: str | None = None,
+        secret_key: str | None = None,
+        host: str | None = None,
+        environment: str | None = None,
+        release: str | None = None,
+        client: Any | None = None,
+        sample_rate: float | None = None,
+        include_trace_payloads: bool = True,
+    ) -> None:
+        if client is None:
+            Langfuse = _require_langfuse()
+            client = Langfuse(
+                public_key=public_key,
+                secret_key=secret_key,
+                host=host,
+                environment=environment,
+                release=release,
+                sample_rate=sample_rate,
+            )
+
+        self._client = client
+        self._include_trace_payloads = include_trace_payloads
+
+    def export(self, result: SuiteResult) -> None:
+        """Export a suite result to Langfuse."""
+        trace_id = self._client.create_trace_id()
+        suite_metadata = {
+            "giskard.suite.duration_ms": result.duration_ms,
+            "giskard.suite.scenario_count": len(result.results),
+            "giskard.suite.passed_count": result.passed_count,
+            "giskard.suite.failed_count": result.failed_count,
+            "giskard.suite.errored_count": result.errored_count,
+            "giskard.suite.skipped_count": result.skipped_count,
+            "giskard.suite.pass_rate": result.pass_rate,
+        }
+
+        with self._client.start_as_current_observation(
+            trace_context={"trace_id": trace_id},
+            name="giskard.suite",
+            as_type="evaluator",
+            metadata=suite_metadata,
+            level="ERROR" if result.errored_count else "DEFAULT",
+            status_message=f"pass_rate={result.pass_rate}",
+        ) as suite_observation:
+            self._client.create_score(
+                trace_id=suite_observation.trace_id,
+                observation_id=suite_observation.id,
+                name="giskard.suite.pass_rate",
+                value=result.pass_rate,
+                data_type="NUMERIC",
+                metadata=suite_metadata,
+            )
+
+            for scenario_index, scenario in enumerate(result.results, start=1):
+                self._export_scenario(
+                    scenario=scenario,
+                    scenario_index=scenario_index,
+                )
+
+    def flush(self) -> None:
+        """Flush pending Langfuse telemetry."""
+        flush = getattr(self._client, "flush", None)
+        if flush is not None:
+            flush()
+
+    def _export_scenario(
+        self,
+        *,
+        scenario: ScenarioResult[Any],
+        scenario_index: int,
+    ) -> None:
+        scenario_metadata = {
+            "giskard.scenario.index": scenario_index,
+            "giskard.scenario.status": _status_value(scenario.status),
+            "giskard.scenario.duration_ms": scenario.duration_ms,
+            "giskard.scenario.step_count": len(scenario.steps),
+            "giskard.scenario.check_count": sum(
+                len(step.results) for step in scenario.steps
+            ),
+            "giskard.trace.interaction_count": len(scenario.final_trace.interactions),
+        }
+
+        with self._client.start_as_current_observation(
+            name=scenario.scenario_name,
+            as_type="evaluator",
+            metadata=scenario_metadata,
+            level="ERROR" if scenario.errored else "DEFAULT",
+            status_message=_status_value(scenario.status),
+        ) as scenario_observation:
+            for interaction_index, interaction in enumerate(
+                scenario.final_trace.interactions,
+                start=1,
+            ):
+                self._export_interaction(
+                    interaction=interaction,
+                    interaction_index=interaction_index,
+                )
+
+            for step_index, step in enumerate(scenario.steps, start=1):
+                for check_index, check in enumerate(step.results, start=1):
+                    self._export_check(
+                        check=check,
+                        scenario=scenario,
+                        scenario_observation=scenario_observation,
+                        step_index=step_index,
+                        check_index=check_index,
+                    )
+
+    def _export_interaction(
+        self,
+        *,
+        interaction: Any,
+        interaction_index: int,
+    ) -> None:
+        metadata = {
+            "giskard.trace.interaction.index": interaction_index,
+            **_metadata(getattr(interaction, "metadata", {})),
+        }
+        interaction_metadata = getattr(interaction, "metadata", {})
+        model = (
+            interaction_metadata.get("model")
+            if isinstance(interaction_metadata, dict)
+            else None
+        )
+
+        with self._client.start_as_current_observation(
+            name=f"interaction_{interaction_index}",
+            as_type="generation",
+            input=getattr(interaction, "inputs", None)
+            if self._include_trace_payloads
+            else None,
+            output=getattr(interaction, "outputs", None)
+            if self._include_trace_payloads
+            else None,
+            metadata=metadata,
+            model=model,
+        ):
+            pass
+
+    def _export_check(
+        self,
+        *,
+        check: CheckResult,
+        scenario: ScenarioResult[Any],
+        scenario_observation: Any,
+        step_index: int,
+        check_index: int,
+    ) -> None:
+        name = _check_label(check, f"check_{check_index}")
+        metadata = {
+            "giskard.scenario.name": scenario.scenario_name,
+            "giskard.step.index": step_index,
+            "giskard.check.index": check_index,
+            "giskard.check.status": _status_value(check.status),
+            "giskard.check.details": _json(check.details),
+        }
+
+        with self._client.start_as_current_observation(
+            name=name,
+            as_type="evaluator",
+            metadata=metadata,
+            level="ERROR" if check.errored else "DEFAULT",
+            status_message=check.message or _status_value(check.status),
+        ) as check_observation:
+            self._client.create_score(
+                trace_id=scenario_observation.trace_id,
+                observation_id=check_observation.id,
+                name=name,
+                value=_score_value(check),
+                data_type=_score_data_type(check),
+                comment=_score_comment(check),
+                metadata=metadata,
+            )
+
+            for metric in check.metrics:
+                self._client.create_score(
+                    trace_id=scenario_observation.trace_id,
+                    observation_id=check_observation.id,
+                    name=f"{name}.{metric.name}",
+                    value=metric.value,
+                    data_type="NUMERIC",
+                    metadata=metadata,
+                )

--- a/libs/giskard-checks/src/giskard/checks/export/monitoring.py
+++ b/libs/giskard-checks/src/giskard/checks/export/monitoring.py
@@ -1,0 +1,60 @@
+import random
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from ..core.result import SuiteResult
+from ..scenarios.suite import Suite
+
+
+class ResultExporter(Protocol):
+    def export(self, result: SuiteResult) -> None: ...
+
+
+@dataclass(frozen=True)
+class ProductionEvaluationAlert:
+    pass_rate: float
+    threshold: float
+    message: str
+
+
+@dataclass(frozen=True)
+class ProductionEvaluationResult:
+    result: SuiteResult | None
+    alert: ProductionEvaluationAlert | None
+    sampled: bool
+
+
+async def evaluate_production_sample(
+    suite: Suite,
+    *,
+    target: Any | None = None,
+    exporters: Iterable[ResultExporter] = (),
+    sample_rate: float = 1.0,
+    min_pass_rate: float | None = None,
+) -> ProductionEvaluationResult:
+    """Run checks for a sampled production request and export the result."""
+    if not 0.0 <= sample_rate <= 1.0:
+        raise ValueError("sample_rate must be between 0.0 and 1.0")
+    if min_pass_rate is not None and not 0.0 <= min_pass_rate <= 1.0:
+        raise ValueError("min_pass_rate must be between 0.0 and 1.0")
+
+    if random.random() > sample_rate:
+        return ProductionEvaluationResult(result=None, alert=None, sampled=False)
+
+    result = await suite.run(target=target)
+    for exporter in exporters:
+        exporter.export(result)
+
+    alert = None
+    if min_pass_rate is not None and result.pass_rate < min_pass_rate:
+        alert = ProductionEvaluationAlert(
+            pass_rate=result.pass_rate,
+            threshold=min_pass_rate,
+            message=(
+                f"Giskard pass rate {result.pass_rate:.3f} is below "
+                f"threshold {min_pass_rate:.3f}."
+            ),
+        )
+
+    return ProductionEvaluationResult(result=result, alert=alert, sampled=True)

--- a/libs/giskard-checks/src/giskard/checks/export/otel.py
+++ b/libs/giskard-checks/src/giskard/checks/export/otel.py
@@ -1,0 +1,370 @@
+import json
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from ..core.result import CheckResult, ScenarioResult, SuiteResult
+
+_OTEL_INSTALL_HINT = (
+    "OpenTelemetry export requires optional dependencies. "
+    "Install them with `pip install giskard-checks[otel]`."
+)
+
+
+def _status_value(status: Any) -> str:
+    value = getattr(status, "value", status)
+    return str(value)
+
+
+def _json(value: Any) -> str:
+    if hasattr(value, "model_dump"):
+        value = value.model_dump(mode="json")
+    return json.dumps(value, ensure_ascii=False, default=str)
+
+
+def _attribute_value(value: Any) -> str | bool | int | float:
+    if isinstance(value, str | bool | int | float):
+        return value
+    if value is None:
+        return ""
+    return _json(value)
+
+
+def _details_attributes(details: Mapping[str, Any], prefix: str) -> dict[str, Any]:
+    attributes: dict[str, Any] = {}
+    for key, value in details.items():
+        if isinstance(key, str):
+            attributes[f"{prefix}.{key}"] = _attribute_value(value)
+    return attributes
+
+
+def _check_label(result: CheckResult, fallback: str) -> str:
+    return str(
+        result.details.get("check_name")
+        or result.details.get("check_kind")
+        or result.details.get("name")
+        or fallback
+    )
+
+
+def _iter_checks(
+    scenario: ScenarioResult[Any],
+) -> Iterable[tuple[int, int, CheckResult]]:
+    for step_index, step in enumerate(scenario.steps, start=1):
+        for check_index, check in enumerate(step.results, start=1):
+            yield step_index, check_index, check
+
+
+def _suite_status(result: SuiteResult) -> str:
+    if result.errored_count:
+        return "error"
+    if result.failed_count:
+        return "fail"
+    if result.results and result.skipped_count == len(result.results):
+        return "skip"
+    return "pass"
+
+
+def _suite_attributes(result: SuiteResult) -> dict[str, Any]:
+    return {
+        "giskard.suite.status": _suite_status(result),
+        "giskard.suite.duration_ms": result.duration_ms,
+        "giskard.suite.scenario_count": len(result.results),
+        "giskard.suite.passed_count": result.passed_count,
+        "giskard.suite.failed_count": result.failed_count,
+        "giskard.suite.errored_count": result.errored_count,
+        "giskard.suite.skipped_count": result.skipped_count,
+        "giskard.suite.pass_rate": result.pass_rate,
+    }
+
+
+def _scenario_attributes(
+    scenario: ScenarioResult[Any],
+    *,
+    index: int,
+) -> dict[str, Any]:
+    return {
+        "giskard.scenario.index": index,
+        "giskard.scenario.name": scenario.scenario_name,
+        "giskard.scenario.status": _status_value(scenario.status),
+        "giskard.scenario.duration_ms": scenario.duration_ms,
+        "giskard.scenario.step_count": len(scenario.steps),
+        "giskard.scenario.check_count": sum(
+            len(step.results) for step in scenario.steps
+        ),
+        "giskard.trace.interaction_count": len(scenario.final_trace.interactions),
+    }
+
+
+def _check_attributes(
+    result: CheckResult,
+    *,
+    scenario: ScenarioResult[Any],
+    scenario_index: int,
+    step_index: int,
+    check_index: int,
+) -> dict[str, Any]:
+    attributes = {
+        "giskard.scenario.index": scenario_index,
+        "giskard.scenario.name": scenario.scenario_name,
+        "giskard.step.index": step_index,
+        "giskard.check.index": check_index,
+        "giskard.check.name": _check_label(result, f"check_{check_index}"),
+        "giskard.check.status": _status_value(result.status),
+        "giskard.check.message": result.message or "",
+    }
+    attributes.update(_details_attributes(result.details, "giskard.check.details"))
+    return attributes
+
+
+def _interaction_attributes(
+    interaction: Any,
+    *,
+    scenario: ScenarioResult[Any],
+    scenario_index: int,
+    interaction_index: int,
+    include_payloads: bool,
+) -> dict[str, Any]:
+    attributes = {
+        "giskard.scenario.index": scenario_index,
+        "giskard.scenario.name": scenario.scenario_name,
+        "giskard.trace.interaction.index": interaction_index,
+    }
+
+    metadata = getattr(interaction, "metadata", {})
+    if isinstance(metadata, Mapping):
+        attributes.update(
+            _details_attributes(metadata, "giskard.trace.interaction.metadata")
+        )
+
+    if include_payloads:
+        attributes.update(
+            {
+                "giskard.trace.interaction.inputs": _attribute_value(
+                    getattr(interaction, "inputs", None)
+                ),
+                "giskard.trace.interaction.outputs": _attribute_value(
+                    getattr(interaction, "outputs", None)
+                ),
+            }
+        )
+
+    return attributes
+
+
+def _require_otel_sdk() -> dict[str, Any]:
+    try:
+        from opentelemetry import metrics, trace
+        from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+            OTLPMetricExporter,
+        )
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+            OTLPSpanExporter,
+        )
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    except ImportError as exc:
+        raise ImportError(_OTEL_INSTALL_HINT) from exc
+
+    return {
+        "metrics": metrics,
+        "trace": trace,
+        "OTLPMetricExporter": OTLPMetricExporter,
+        "OTLPSpanExporter": OTLPSpanExporter,
+        "MeterProvider": MeterProvider,
+        "PeriodicExportingMetricReader": PeriodicExportingMetricReader,
+        "Resource": Resource,
+        "TracerProvider": TracerProvider,
+        "BatchSpanProcessor": BatchSpanProcessor,
+    }
+
+
+def _call_provider_method(method: Any, *, timeout_millis: int) -> Any:
+    try:
+        return method(timeout_millis=timeout_millis)
+    except TypeError as exc:
+        if "timeout_millis" not in str(exc):
+            raise
+        return method()
+
+
+class OTelExporter:
+    """Export suite results as OpenTelemetry traces and metrics."""
+
+    def __init__(
+        self,
+        endpoint: str | None = None,
+        *,
+        service_name: str = "giskard-checks",
+        tracer: Any | None = None,
+        meter: Any | None = None,
+        set_global_provider: bool = False,
+        include_trace_payloads: bool = True,
+    ) -> None:
+        self._provider = None
+        self._meter_provider = None
+        self._include_trace_payloads = include_trace_payloads
+
+        if tracer is None or meter is None:
+            sdk = _require_otel_sdk()
+            resource = sdk["Resource"].create({"service.name": service_name})
+
+            if tracer is None:
+                span_exporter = sdk["OTLPSpanExporter"](endpoint=endpoint)
+                self._provider = sdk["TracerProvider"](resource=resource)
+                self._provider.add_span_processor(
+                    sdk["BatchSpanProcessor"](span_exporter)
+                )
+                if set_global_provider:
+                    sdk["trace"].set_tracer_provider(self._provider)
+                    tracer = sdk["trace"].get_tracer(__name__)
+                else:
+                    tracer = self._provider.get_tracer(__name__)
+
+            if meter is None:
+                metric_exporter = sdk["OTLPMetricExporter"](endpoint=endpoint)
+                metric_reader = sdk["PeriodicExportingMetricReader"](metric_exporter)
+                self._meter_provider = sdk["MeterProvider"](
+                    resource=resource,
+                    metric_readers=[metric_reader],
+                )
+                if set_global_provider:
+                    sdk["metrics"].set_meter_provider(self._meter_provider)
+                    meter = sdk["metrics"].get_meter(__name__)
+                else:
+                    meter = self._meter_provider.get_meter(__name__)
+
+        self._tracer = tracer
+        self._meter = meter
+        self._suite_duration = meter.create_histogram(
+            "giskard.suite.duration",
+            unit="ms",
+            description="Suite execution duration.",
+        )
+        self._suite_pass_rate = meter.create_histogram(
+            "giskard.suite.pass_rate",
+            unit="1",
+            description="Suite pass rate excluding skipped scenarios.",
+        )
+        self._scenario_duration = meter.create_histogram(
+            "giskard.scenario.duration",
+            unit="ms",
+            description="Scenario execution duration.",
+        )
+        self._check_count = meter.create_counter(
+            "giskard.check.count",
+            unit="1",
+            description="Number of executed checks by status.",
+        )
+        self._check_metric_value = meter.create_histogram(
+            "giskard.check.metric.value",
+            unit="1",
+            description="Numeric metric values emitted by checks.",
+        )
+
+    def export(self, result: SuiteResult) -> None:
+        """Export a suite result to the configured OpenTelemetry backend."""
+        suite_attributes = _suite_attributes(result)
+
+        with self._tracer.start_as_current_span(
+            "giskard.suite",
+            attributes=suite_attributes,
+        ):
+            self._record_suite_metrics(result, suite_attributes)
+
+            for scenario_index, scenario in enumerate(result.results, start=1):
+                self._export_scenario(
+                    scenario=scenario,
+                    scenario_index=scenario_index,
+                )
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        """Flush configured OpenTelemetry providers when they expose force_flush."""
+        ok = True
+        for provider in (self._provider, self._meter_provider):
+            force_flush = getattr(provider, "force_flush", None)
+            if force_flush is not None:
+                ok = bool(
+                    _call_provider_method(
+                        force_flush,
+                        timeout_millis=timeout_millis,
+                    )
+                ) and ok
+        return ok
+
+    def shutdown(self, timeout_millis: int = 30_000) -> None:
+        """Shutdown configured OpenTelemetry providers when they expose shutdown."""
+        for provider in (self._meter_provider, self._provider):
+            shutdown = getattr(provider, "shutdown", None)
+            if shutdown is not None:
+                _call_provider_method(shutdown, timeout_millis=timeout_millis)
+
+    def _export_scenario(
+        self,
+        *,
+        scenario: ScenarioResult[Any],
+        scenario_index: int,
+    ) -> None:
+        scenario_attributes = _scenario_attributes(
+            scenario,
+            index=scenario_index,
+        )
+        self._scenario_duration.record(
+            scenario.duration_ms,
+            attributes=scenario_attributes,
+        )
+
+        with self._tracer.start_as_current_span(
+            "giskard.scenario",
+            attributes=scenario_attributes,
+        ) as scenario_span:
+            for interaction_index, interaction in enumerate(
+                scenario.final_trace.interactions,
+                start=1,
+            ):
+                scenario_span.add_event(
+                    "giskard.trace.interaction",
+                    attributes=_interaction_attributes(
+                        interaction,
+                        scenario=scenario,
+                        scenario_index=scenario_index,
+                        interaction_index=interaction_index,
+                        include_payloads=self._include_trace_payloads,
+                    ),
+                )
+
+            for step_index, check_index, check in _iter_checks(scenario):
+                check_attributes = _check_attributes(
+                    check,
+                    scenario=scenario,
+                    scenario_index=scenario_index,
+                    step_index=step_index,
+                    check_index=check_index,
+                )
+                scenario_span.add_event("giskard.check", attributes=check_attributes)
+                self._record_check_metrics(check, check_attributes)
+
+    def _record_suite_metrics(
+        self,
+        result: SuiteResult,
+        attributes: dict[str, Any],
+    ) -> None:
+        self._suite_duration.record(result.duration_ms, attributes=attributes)
+        self._suite_pass_rate.record(result.pass_rate, attributes=attributes)
+
+    def _record_check_metrics(
+        self,
+        result: CheckResult,
+        attributes: dict[str, Any],
+    ) -> None:
+        self._check_count.add(1, attributes=attributes)
+        for metric in result.metrics:
+            self._check_metric_value.record(
+                metric.value,
+                attributes={
+                    **attributes,
+                    "giskard.check.metric.name": metric.name,
+                },
+            )

--- a/libs/giskard-checks/tests/export/test_langfuse.py
+++ b/libs/giskard-checks/tests/export/test_langfuse.py
@@ -1,0 +1,163 @@
+import builtins
+from types import TracebackType
+from typing import Any
+
+import pytest
+from giskard.checks import (
+    CheckResult,
+    CheckStatus,
+    Interaction,
+    Metric,
+    ScenarioResult,
+    SuiteResult,
+    Trace,
+)
+from giskard.checks import TestCaseResult as GiskardTestCaseResult
+from giskard.checks.export.langfuse import LangfuseExporter
+
+
+class FakeObservation:
+    def __init__(self, trace_id: str, observation_id: str) -> None:
+        self.trace_id = trace_id
+        self.id = observation_id
+
+    def __enter__(self) -> "FakeObservation":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        return None
+
+
+class FakeLangfuseClient:
+    def __init__(self) -> None:
+        self.observations: list[dict[str, Any]] = []
+        self.scores: list[dict[str, Any]] = []
+        self.flushed = False
+
+    def create_trace_id(self) -> str:
+        return "trace-1"
+
+    def start_as_current_observation(self, **kwargs: Any) -> FakeObservation:
+        observation_id = f"observation-{len(self.observations) + 1}"
+        self.observations.append({"id": observation_id, **kwargs})
+        return FakeObservation(trace_id="trace-1", observation_id=observation_id)
+
+    def create_score(self, **kwargs: Any) -> None:
+        self.scores.append(kwargs)
+
+    def flush(self) -> None:
+        self.flushed = True
+
+
+def _sample_suite_result() -> SuiteResult:
+    return SuiteResult(
+        results=[
+            ScenarioResult(
+                scenario_name="scenario_pass",
+                steps=[
+                    GiskardTestCaseResult(
+                        results=[
+                            CheckResult(
+                                status=CheckStatus.PASS,
+                                message="grounded",
+                                metrics=[Metric(name="score", value=0.95)],
+                                details={"check_name": "Groundedness"},
+                            )
+                        ],
+                        duration_ms=100,
+                    )
+                ],
+                duration_ms=100,
+                final_trace=Trace(
+                    interactions=[
+                        Interaction(
+                            inputs={"question": "What is Giskard?"},
+                            outputs={"answer": "An evaluation framework."},
+                            metadata={"model": "test-model"},
+                        )
+                    ]
+                ),
+            )
+        ],
+        duration_ms=100,
+    )
+
+
+def test_langfuse_export_maps_suite_scenarios_generations_and_scores() -> None:
+    client = FakeLangfuseClient()
+    exporter = LangfuseExporter(client=client)
+
+    exporter.export(_sample_suite_result())
+
+    assert [observation["name"] for observation in client.observations] == [
+        "giskard.suite",
+        "scenario_pass",
+        "interaction_1",
+        "Groundedness",
+    ]
+    assert client.observations[0]["as_type"] == "evaluator"
+    assert client.observations[2]["as_type"] == "generation"
+    assert client.observations[2]["input"] == {"question": "What is Giskard?"}
+    assert client.observations[2]["output"] == {
+        "answer": "An evaluation framework."
+    }
+    assert client.observations[2]["model"] == "test-model"
+
+    assert [score["name"] for score in client.scores] == [
+        "giskard.suite.pass_rate",
+        "Groundedness",
+        "Groundedness.score",
+    ]
+    assert client.scores[0]["value"] == 1.0
+    assert client.scores[1]["observation_id"] == "observation-4"
+    assert client.scores[1]["value"] == 0.95
+    assert client.scores[2]["value"] == 0.95
+
+
+def test_langfuse_export_can_hide_trace_payloads() -> None:
+    client = FakeLangfuseClient()
+    exporter = LangfuseExporter(client=client, include_trace_payloads=False)
+
+    exporter.export(_sample_suite_result())
+
+    generation = client.observations[2]
+    assert generation["as_type"] == "generation"
+    assert generation["input"] is None
+    assert generation["output"] is None
+    assert generation["metadata"]["model"] == "test-model"
+
+
+def test_langfuse_flush_delegates_to_client() -> None:
+    client = FakeLangfuseClient()
+    exporter = LangfuseExporter(client=client)
+
+    exporter.flush()
+
+    assert client.flushed is True
+
+
+def test_langfuse_exporter_without_dependency_raises_helpful_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_import = builtins.__import__
+
+    def fake_import(
+        name: str,
+        globals: dict[str, Any] | None = None,
+        locals: dict[str, Any] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> Any:
+        if name == "langfuse" or name.startswith("langfuse."):
+            raise ImportError(name)
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError, match=r"giskard-checks\[langfuse\]"):
+        LangfuseExporter(public_key="pk", secret_key="sk")

--- a/libs/giskard-checks/tests/export/test_monitoring.py
+++ b/libs/giskard-checks/tests/export/test_monitoring.py
@@ -1,0 +1,64 @@
+from typing import Any
+
+import pytest
+from giskard.checks import CheckResult, Scenario, Suite, from_fn
+from giskard.checks.export.monitoring import evaluate_production_sample
+
+
+class FakeExporter:
+    def __init__(self) -> None:
+        self.results: list[Any] = []
+
+    def export(self, result: Any) -> None:
+        self.results.append(result)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_production_sample_exports_and_alerts() -> None:
+    exporter = FakeExporter()
+    suite = Suite(name="production")
+    suite.append(
+        Scenario("failing").check(
+            from_fn(
+                lambda trace: CheckResult.failure(message="bad answer"),
+                name="failing_check",
+            )
+        )
+    )
+
+    result = await evaluate_production_sample(
+        suite,
+        exporters=[exporter],
+        sample_rate=1.0,
+        min_pass_rate=0.9,
+    )
+
+    assert result.sampled is True
+    assert result.result is not None
+    assert result.result.pass_rate == 0.0
+    assert result.alert is not None
+    assert result.alert.threshold == 0.9
+    assert exporter.results == [result.result]
+
+
+@pytest.mark.asyncio
+async def test_evaluate_production_sample_can_skip_unsampled_request() -> None:
+    suite = Suite(name="production")
+    suite.append(Scenario("passing").check(from_fn(lambda trace: True, name="ok")))
+
+    result = await evaluate_production_sample(suite, sample_rate=0.0)
+
+    assert result.sampled is False
+    assert result.result is None
+    assert result.alert is None
+
+
+@pytest.mark.asyncio
+async def test_evaluate_production_sample_validates_thresholds() -> None:
+    suite = Suite(name="production")
+
+    with pytest.raises(ValueError, match="sample_rate"):
+        _ = await evaluate_production_sample(suite, sample_rate=1.5)
+
+    with pytest.raises(ValueError, match="min_pass_rate"):
+        _ = await evaluate_production_sample(suite, min_pass_rate=-0.1)

--- a/libs/giskard-checks/tests/export/test_otel.py
+++ b/libs/giskard-checks/tests/export/test_otel.py
@@ -1,0 +1,340 @@
+import builtins
+from types import TracebackType
+from typing import Any
+
+import pytest
+from giskard.checks import (
+    CheckResult,
+    CheckStatus,
+    Interaction,
+    Metric,
+    ScenarioResult,
+    SuiteResult,
+    Trace,
+)
+from giskard.checks import TestCaseResult as GiskardTestCaseResult
+from giskard.checks.export.otel import OTelExporter
+
+
+class FakeSpan:
+    def __init__(self, name: str, attributes: dict[str, Any] | None) -> None:
+        self.name = name
+        self.attributes = attributes or {}
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    def __enter__(self) -> "FakeSpan":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        return None
+
+    def add_event(self, name: str, attributes: dict[str, Any]) -> None:
+        self.events.append((name, attributes))
+
+
+class FakeTracer:
+    def __init__(self) -> None:
+        self.spans: list[FakeSpan] = []
+
+    def start_as_current_span(
+        self,
+        name: str,
+        attributes: dict[str, Any] | None = None,
+    ) -> FakeSpan:
+        span = FakeSpan(name, attributes)
+        self.spans.append(span)
+        return span
+
+
+class FakeInstrument:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.records: list[tuple[str, float, dict[str, Any]]] = []
+
+    def record(self, value: float, attributes: dict[str, Any]) -> None:
+        self.records.append(("record", value, attributes))
+
+    def add(self, value: float, attributes: dict[str, Any]) -> None:
+        self.records.append(("add", value, attributes))
+
+
+class FakeMeter:
+    def __init__(self) -> None:
+        self.instruments: dict[str, FakeInstrument] = {}
+
+    def create_histogram(
+        self,
+        name: str,
+        *,
+        unit: str,
+        description: str,
+    ) -> FakeInstrument:
+        return self._instrument(name)
+
+    def create_counter(
+        self,
+        name: str,
+        *,
+        unit: str,
+        description: str,
+    ) -> FakeInstrument:
+        return self._instrument(name)
+
+    def _instrument(self, name: str) -> FakeInstrument:
+        instrument = FakeInstrument(name)
+        self.instruments[name] = instrument
+        return instrument
+
+
+class FakeProvider:
+    def __init__(self, *, supports_timeout: bool = True) -> None:
+        self.supports_timeout = supports_timeout
+        self.flushed = False
+        self.shutdown_called = False
+        self.timeout_millis: int | None = None
+
+    def force_flush(self, timeout_millis: int | None = None) -> bool:
+        if not self.supports_timeout and timeout_millis is not None:
+            raise TypeError("unexpected keyword argument 'timeout_millis'")
+        self.flushed = True
+        self.timeout_millis = timeout_millis
+        return True
+
+    def shutdown(self, timeout_millis: int | None = None) -> None:
+        if not self.supports_timeout and timeout_millis is not None:
+            raise TypeError("unexpected keyword argument 'timeout_millis'")
+        self.shutdown_called = True
+        self.timeout_millis = timeout_millis
+
+
+def _sample_suite_result() -> SuiteResult:
+    return SuiteResult(
+        results=[
+            ScenarioResult(
+                scenario_name="scenario_pass",
+                steps=[
+                    GiskardTestCaseResult(
+                        results=[
+                            CheckResult(
+                                status=CheckStatus.PASS,
+                                message="grounded",
+                                metrics=[Metric(name="score", value=0.95)],
+                                details={"check_name": "Groundedness"},
+                            ),
+                            CheckResult(
+                                status=CheckStatus.PASS,
+                                message="relevant",
+                                details={"check_name": "AnswerRelevance"},
+                            ),
+                        ],
+                        duration_ms=100,
+                    )
+                ],
+                duration_ms=100,
+                final_trace=Trace(
+                    interactions=[
+                        Interaction(
+                            inputs={"question": "What is Giskard?"},
+                            outputs={"answer": "An evaluation framework."},
+                            metadata={"model": "test-model"},
+                        )
+                    ]
+                ),
+            ),
+            ScenarioResult(
+                scenario_name="scenario_fail",
+                steps=[
+                    GiskardTestCaseResult(
+                        results=[
+                            CheckResult(
+                                status=CheckStatus.FAIL,
+                                message="answer is not grounded",
+                                metrics=[Metric(name="confidence", value=0.2)],
+                                details={"check_name": "Groundedness"},
+                            )
+                        ],
+                        duration_ms=120,
+                    )
+                ],
+                duration_ms=120,
+                final_trace=Trace(),
+            ),
+        ],
+        duration_ms=220,
+    )
+
+
+def test_export_emits_suite_scenario_check_and_trace_events() -> None:
+    tracer = FakeTracer()
+    meter = FakeMeter()
+    exporter = OTelExporter(tracer=tracer, meter=meter)
+
+    exporter.export(_sample_suite_result())
+
+    assert [span.name for span in tracer.spans] == [
+        "giskard.suite",
+        "giskard.scenario",
+        "giskard.scenario",
+    ]
+
+    suite_span = tracer.spans[0]
+    assert suite_span.attributes["giskard.suite.status"] == "fail"
+    assert suite_span.attributes["giskard.suite.duration_ms"] == 220
+    assert suite_span.attributes["giskard.suite.pass_rate"] == 0.5
+    assert suite_span.events == []
+
+    scenario_span = tracer.spans[1]
+    interaction_events = [
+        event for event in scenario_span.events if event[0] == "giskard.trace.interaction"
+    ]
+    check_events = [event for event in scenario_span.events if event[0] == "giskard.check"]
+    assert scenario_span.attributes["giskard.trace.interaction_count"] == 1
+    assert interaction_events[0][1]["giskard.trace.interaction.index"] == 1
+    assert "What is Giskard?" in interaction_events[0][1][
+        "giskard.trace.interaction.inputs"
+    ]
+    assert check_events[0][1]["giskard.check.name"] == "Groundedness"
+
+
+def test_export_can_hide_trace_payloads() -> None:
+    tracer = FakeTracer()
+    meter = FakeMeter()
+    exporter = OTelExporter(
+        tracer=tracer,
+        meter=meter,
+        include_trace_payloads=False,
+    )
+
+    exporter.export(_sample_suite_result())
+
+    interaction_event = tracer.spans[1].events[0]
+    assert interaction_event[0] == "giskard.trace.interaction"
+    assert "giskard.trace.interaction.inputs" not in interaction_event[1]
+    assert "giskard.trace.interaction.outputs" not in interaction_event[1]
+    assert (
+        interaction_event[1]["giskard.trace.interaction.metadata.model"]
+        == "test-model"
+    )
+
+
+def test_export_records_suite_scenario_check_and_score_metrics() -> None:
+    tracer = FakeTracer()
+    meter = FakeMeter()
+    exporter = OTelExporter(tracer=tracer, meter=meter)
+
+    exporter.export(_sample_suite_result())
+
+    assert meter.instruments["giskard.suite.duration"].records[0][1] == 220
+    assert meter.instruments["giskard.suite.pass_rate"].records[0][1] == 0.5
+    assert [
+        record[1]
+        for record in meter.instruments["giskard.scenario.duration"].records
+    ] == [
+        100,
+        120,
+    ]
+    assert len(meter.instruments["giskard.check.count"].records) == 3
+
+    score_records = meter.instruments["giskard.check.metric.value"].records
+    assert [record[1] for record in score_records] == [0.95, 0.2]
+    assert score_records[0][2]["giskard.check.metric.name"] == "score"
+    assert score_records[1][2]["giskard.check.metric.name"] == "confidence"
+
+
+def test_export_with_opentelemetry_sdk_in_memory_exporters() -> None:
+    pytest.importorskip("opentelemetry.sdk")
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    span_exporter = InMemorySpanExporter()
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+    metric_reader = InMemoryMetricReader()
+    meter_provider = MeterProvider(metric_readers=[metric_reader])
+    exporter = OTelExporter(
+        tracer=tracer_provider.get_tracer(__name__),
+        meter=meter_provider.get_meter(__name__),
+    )
+
+    exporter.export(_sample_suite_result())
+
+    spans = span_exporter.get_finished_spans()
+    assert [span.name for span in spans] == [
+        "giskard.scenario",
+        "giskard.scenario",
+        "giskard.suite",
+    ]
+    assert spans[-1].attributes["giskard.suite.pass_rate"] == 0.5
+    assert any(
+        event.name == "giskard.trace.interaction" for event in spans[0].events
+    )
+    assert any(event.name == "giskard.check" for event in spans[0].events)
+    assert not any(event.name == "giskard.check" for event in spans[-1].events)
+
+    metrics_data = metric_reader.get_metrics_data()
+    metric_names = {
+        metric.name
+        for resource_metric in metrics_data.resource_metrics
+        for scope_metric in resource_metric.scope_metrics
+        for metric in scope_metric.metrics
+    }
+    assert {
+        "giskard.suite.duration",
+        "giskard.suite.pass_rate",
+        "giskard.scenario.duration",
+        "giskard.check.count",
+        "giskard.check.metric.value",
+    }.issubset(metric_names)
+
+    tracer_provider.shutdown()
+    meter_provider.shutdown()
+
+
+def test_flush_and_shutdown_support_providers_without_timeout_argument() -> None:
+    exporter = OTelExporter(tracer=FakeTracer(), meter=FakeMeter())
+    provider = FakeProvider(supports_timeout=False)
+    meter_provider = FakeProvider()
+    exporter._provider = provider
+    exporter._meter_provider = meter_provider
+
+    assert exporter.force_flush(timeout_millis=10_000) is True
+    exporter.shutdown(timeout_millis=10_000)
+
+    assert provider.flushed is True
+    assert provider.shutdown_called is True
+    assert provider.timeout_millis is None
+    assert meter_provider.flushed is True
+    assert meter_provider.shutdown_called is True
+    assert meter_provider.timeout_millis == 10_000
+
+
+def test_exporter_without_injected_otel_raises_helpful_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_import = builtins.__import__
+
+    def fake_import(
+        name: str,
+        globals: dict[str, Any] | None = None,
+        locals: dict[str, Any] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> Any:
+        if name == "opentelemetry" or name.startswith("opentelemetry."):
+            raise ImportError(name)
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError, match=r"giskard-checks\[otel\]"):
+        OTelExporter(endpoint="http://localhost:4317")

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,11 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
 
 [manifest]
 members = [
@@ -771,16 +776,35 @@ dependencies = [
     { name = "rich" },
 ]
 
+[package.optional-dependencies]
+langfuse = [
+    { name = "langfuse" },
+]
+otel = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-sdk" },
+]
+yaml = [
+    { name = "pyyaml" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "giskard-agents", editable = "libs/giskard-agents" },
     { name = "giskard-core", editable = "libs/giskard-core" },
     { name = "jinja2", specifier = ">=3.1.6,<4" },
     { name = "jsonpath-ng", specifier = ">=1.7.0,<2" },
+    { name = "langfuse", marker = "extra == 'langfuse'", specifier = ">=3,<4" },
     { name = "numpy", specifier = ">=2.4.1,<3" },
+    { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.38.0,<2" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'otel'", specifier = ">=1.38.0,<2" },
+    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.38.0,<2" },
     { name = "pydantic", specifier = ">=2.12,<3" },
+    { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=6.0.2,<7" },
     { name = "rich", specifier = ">=14.2.0,<15" },
 ]
+provides-extras = ["langfuse", "otel", "yaml"]
 
 [[package]]
 name = "giskard-core"
@@ -798,6 +822,18 @@ requires-dist = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.74.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/18/a746c8344152d368a5aac738d4c857012f2c5d1fd2eac7e17b647a7861bd/googleapis_common_protos-1.74.0.tar.gz", hash = "sha256:57971e4eeeba6aad1163c1f0fc88543f965bb49129b8bb55b2b7b26ecab084f1", size = 151254, upload-time = "2026-04-02T21:23:26.679Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/b0/be5d3329badb9230b765de6eea66b73abd5944bdeb5afb3562ddcd80ae84/googleapis_common_protos-1.74.0-py3-none-any.whl", hash = "sha256:702216f78610bb510e3f12ac3cafd281b7ac45cc5d86e90ad87e4d301a3426b5", size = 300743, upload-time = "2026-04-02T21:22:49.108Z" },
+]
+
+[[package]]
 name = "griffe"
 version = "1.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -807,6 +843,47 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0d/0c/3a471b6e31951dce2360477420d0a8d1e00dea6cf33b70f3e8c3ab6e28e1/griffe-1.15.0.tar.gz", hash = "sha256:7726e3afd6f298fbc3696e67958803e7ac843c1cfe59734b6251a40cdbfb5eea", size = 424112, upload-time = "2025-11-10T15:03:15.52Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/83/3b1d03d36f224edded98e9affd0467630fc09d766c0e56fb1498cbb04a9b/griffe-1.15.0-py3-none-any.whl", hash = "sha256:6f6762661949411031f5fcda9593f586e6ce8340f0ba88921a0f2ef7a81eb9a3", size = 150705, upload-time = "2025-11-10T15:03:13.549Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e8/a2b749265eb3415abc94f2e619bbd9e9707bebdda787e61c593004ec927a/grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0", size = 6015616, upload-time = "2026-03-30T08:47:13.428Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/97/b1282161a15d699d1e90c360df18d19165a045ce1c343c7f313f5e8a0b77/grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2", size = 12014204, upload-time = "2026-03-30T08:47:15.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/d319c6e997b50c155ac5a8cb12f5173d5b42677510e886d250d50264949d/grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de", size = 6563866, upload-time = "2026-03-30T08:47:18.588Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f6/fdd975a2cb4d78eb67769a7b3b3830970bfa2e919f1decf724ae4445f42c/grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921", size = 7273060, upload-time = "2026-03-30T08:47:21.113Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f0/a3deb5feba60d9538a962913e37bd2e69a195f1c3376a3dd44fe0427e996/grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411", size = 6782121, upload-time = "2026-03-30T08:47:23.827Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/84/36c6dcfddc093e108141f757c407902a05085e0c328007cb090d56646cdf/grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd", size = 7383811, upload-time = "2026-03-30T08:47:26.517Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ef/f3a77e3dc5b471a0ec86c564c98d6adfa3510d38f8ee99010410858d591e/grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f", size = 8393860, upload-time = "2026-03-30T08:47:29.439Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8d/9d4d27ed7f33d109c50d6b5ce578a9914aa68edab75d65869a17e630a8d1/grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f", size = 7830132, upload-time = "2026-03-30T08:47:33.254Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e4/9990b41c6d7a44e1e9dee8ac11d7a9802ba1378b40d77468a7761d1ad288/grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193", size = 4140904, upload-time = "2026-03-30T08:47:35.319Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2c/296f6138caca1f4b92a31ace4ae1b87dab692fc16a7a3417af3bb3c805bf/grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff", size = 4880944, upload-time = "2026-03-30T08:47:37.831Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
+    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
+    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
+    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
+    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
+    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
 ]
 
 [[package]]
@@ -1150,6 +1227,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407", size = 29032, upload-time = "2025-10-16T19:19:16.783Z" },
+]
+
+[[package]]
+name = "langfuse"
+version = "3.14.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "httpx" },
+    { name = "openai" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/e4/5bb96bc5f95f476c8f7c4e654a6420250938cc21645b914a1309c2dc3d49/langfuse-3.14.6.tar.gz", hash = "sha256:058f7b7caa9284b964feaee81c223542d78e9fb4daabf312269b9f903471b9c4", size = 236530, upload-time = "2026-04-01T17:27:55.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/9a/f2d82cdb7fb71d89de2e693b317a8f2c3d3da44db8a1533b96cf0fbe362f/langfuse-3.14.6-py3-none-any.whl", hash = "sha256:5eb22a5ea579ac10f050513e3fedccc3c9a981eeefe44f9014273bc229a56f88", size = 421426, upload-time = "2026-04-01T17:27:53.487Z" },
 ]
 
 [[package]]
@@ -1534,6 +1631,106 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/8e/3778a7e87801d994869a9396b9fc2a289e5f9be91ff54a27d41eace494b0/opentelemetry_api-1.41.0.tar.gz", hash = "sha256:9421d911326ec12dee8bc933f7839090cad7a3f13fcfb0f9e82f8174dc003c09", size = 71416, upload-time = "2026-04-09T14:38:34.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/ee/99ab786653b3bda9c37ade7e24a7b607a1b1f696063172768417539d876d/opentelemetry_api-1.41.0-py3-none-any.whl", hash = "sha256:0e77c806e6a89c9e4f8d372034622f3e1418a11bdbe1c80a50b3d3397ad0fa4f", size = 69007, upload-time = "2026-04-09T14:38:11.833Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/28/e8eca94966fe9a1465f6094dc5ddc5398473682180279c94020bc23b4906/opentelemetry_exporter_otlp_proto_common-1.41.0.tar.gz", hash = "sha256:966bbce537e9edb166154779a7c4f8ab6b8654a03a28024aeaf1a3eacb07d6ee", size = 20411, upload-time = "2026-04-09T14:38:36.572Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/c4/78b9bf2d9c1d5e494f44932988d9d91c51a66b9a7b48adf99b62f7c65318/opentelemetry_exporter_otlp_proto_common-1.41.0-py3-none-any.whl", hash = "sha256:7a99177bf61f85f4f9ed2072f54d676364719c066f6d11f515acc6c745c7acf0", size = 18366, upload-time = "2026-04-09T14:38:15.135Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/46/d75a3f8c91915f2e58f61d0a2e4ada63891e7c7a37a20ff7949ba184a6b2/opentelemetry_exporter_otlp_proto_grpc-1.41.0.tar.gz", hash = "sha256:f704201251c6f65772b11bddea1c948000554459101bdbb0116e0a01b70592f6", size = 25754, upload-time = "2026-04-09T14:38:37.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/f6/b09e2e0c9f0b5750cebc6eaf31527b910821453cef40a5a0fe93550422b2/opentelemetry_exporter_otlp_proto_grpc-1.41.0-py3-none-any.whl", hash = "sha256:3a1a86bd24806ccf136ec9737dbfa4c09b069f9130ff66b0acb014f9c5255fd1", size = 20299, upload-time = "2026-04-09T14:38:17.01Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/63/d9f43cd75f3fabb7e01148c89cfa9491fc18f6580a6764c554ff7c953c46/opentelemetry_exporter_otlp_proto_http-1.41.0.tar.gz", hash = "sha256:dcd6e0686f56277db4eecbadd5262124e8f2cc739cadbc3fae3d08a12c976cf5", size = 24139, upload-time = "2026-04-09T14:38:38.128Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b5/a214cd907eedc17699d1c2d602288ae17cb775526df04db3a3b3585329d2/opentelemetry_exporter_otlp_proto_http-1.41.0-py3-none-any.whl", hash = "sha256:a9c4ee69cce9c3f4d7ee736ad1b44e3c9654002c0816900abbafd9f3cf289751", size = 22673, upload-time = "2026-04-09T14:38:18.349Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/d9/08e3dc6156878713e8c811682bc76151f5fe1a3cb7f3abda3966fd56e71e/opentelemetry_proto-1.41.0.tar.gz", hash = "sha256:95d2e576f9fb1800473a3e4cfcca054295d06bdb869fda4dc9f4f779dc68f7b6", size = 45669, upload-time = "2026-04-09T14:38:45.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/8c/65ef7a9383a363864772022e822b5d5c6988e6f9dabeebb9278f5b86ebc3/opentelemetry_proto-1.41.0-py3-none-any.whl", hash = "sha256:b970ab537309f9eed296be482c3e7cca05d8aca8165346e929f658dbe153b247", size = 72074, upload-time = "2026-04-09T14:38:29.38Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/0e/a586df1186f9f56b5a0879d52653effc40357b8e88fc50fe300038c3c08b/opentelemetry_sdk-1.41.0.tar.gz", hash = "sha256:7bddf3961131b318fc2d158947971a8e37e38b1cd23470cfb72b624e7cc108bd", size = 230181, upload-time = "2026-04-09T14:38:47.225Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/13/a7825118208cb32e6a4edcd0a99f925cbef81e77b3b0aedfd9125583c543/opentelemetry_sdk-1.41.0-py3-none-any.whl", hash = "sha256:a596f5687964a3e0d7f8edfdcf5b79cbca9c93c7025ebf5fb00f398a9443b0bd", size = 180214, upload-time = "2026-04-09T14:38:30.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/b0/c14f723e86c049b7bf8ff431160d982519b97a7be2857ed2247377397a24/opentelemetry_semantic_conventions-0.62b0.tar.gz", hash = "sha256:cbfb3c8fc259575cf68a6e1b94083cc35adc4a6b06e8cf431efa0d62606c0097", size = 145753, upload-time = "2026-04-09T14:38:48.274Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/6c/5e86fa1759a525ef91c2d8b79d668574760ff3f900d114297765eb8786cb/opentelemetry_semantic_conventions-0.62b0-py3-none-any.whl", hash = "sha256:0ddac1ce59eaf1a827d9987ab60d9315fb27aea23304144242d1fcad9e16b489", size = 231619, upload-time = "2026-04-09T14:38:32.394Z" },
+]
+
+[[package]]
 name = "packageurl-python"
 version = "0.17.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1544,11 +1741,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
 ]
 
 [[package]]
@@ -1765,6 +1962,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
     { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
     { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]
@@ -2654,6 +2866,55 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "1.17.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/41/cad1aba93e752f1f9268c77270da3c469883d56e2798e7df6240dcb2287b/wrapt-1.17.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab232e7fdb44cdfbf55fc3afa31bcdb0d8980b9b95c38b6405df2acb672af0e0", size = 53998, upload-time = "2025-08-12T05:51:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f8/096a7cc13097a1869fe44efe68dace40d2a16ecb853141394047f0780b96/wrapt-1.17.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9baa544e6acc91130e926e8c802a17f3b16fbea0fd441b5a60f5cf2cc5c3deba", size = 39020, upload-time = "2025-08-12T05:51:35.906Z" },
+    { url = "https://files.pythonhosted.org/packages/33/df/bdf864b8997aab4febb96a9ae5c124f700a5abd9b5e13d2a3214ec4be705/wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b538e31eca1a7ea4605e44f81a48aa24c4632a277431a6ed3f328835901f4fd", size = 39098, upload-time = "2025-08-12T05:51:57.474Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/81/5d931d78d0eb732b95dc3ddaeeb71c8bb572fb01356e9133916cd729ecdd/wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:042ec3bb8f319c147b1301f2393bc19dba6e176b7da446853406d041c36c7828", size = 88036, upload-time = "2025-08-12T05:52:34.784Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/38/2e1785df03b3d72d34fc6252d91d9d12dc27a5c89caef3335a1bbb8908ca/wrapt-1.17.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3af60380ba0b7b5aeb329bc4e402acd25bd877e98b3727b0135cb5c2efdaefe9", size = 88156, upload-time = "2025-08-12T05:52:13.599Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8b/48cdb60fe0603e34e05cffda0b2a4adab81fd43718e11111a4b0100fd7c1/wrapt-1.17.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0b02e424deef65c9f7326d8c19220a2c9040c51dc165cddb732f16198c168396", size = 87102, upload-time = "2025-08-12T05:52:14.56Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/51/d81abca783b58f40a154f1b2c56db1d2d9e0d04fa2d4224e357529f57a57/wrapt-1.17.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:74afa28374a3c3a11b3b5e5fca0ae03bef8450d6aa3ab3a1e2c30e3a75d023dc", size = 87732, upload-time = "2025-08-12T05:52:36.165Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b1/43b286ca1392a006d5336412d41663eeef1ad57485f3e52c767376ba7e5a/wrapt-1.17.3-cp312-cp312-win32.whl", hash = "sha256:4da9f45279fff3543c371d5ababc57a0384f70be244de7759c85a7f989cb4ebe", size = 36705, upload-time = "2025-08-12T05:53:07.123Z" },
+    { url = "https://files.pythonhosted.org/packages/28/de/49493f962bd3c586ab4b88066e967aa2e0703d6ef2c43aa28cb83bf7b507/wrapt-1.17.3-cp312-cp312-win_amd64.whl", hash = "sha256:e71d5c6ebac14875668a1e90baf2ea0ef5b7ac7918355850c0908ae82bcb297c", size = 38877, upload-time = "2025-08-12T05:53:05.436Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/48/0f7102fe9cb1e8a5a77f80d4f0956d62d97034bbe88d33e94699f99d181d/wrapt-1.17.3-cp312-cp312-win_arm64.whl", hash = "sha256:604d076c55e2fdd4c1c03d06dc1a31b95130010517b5019db15365ec4a405fc6", size = 36885, upload-time = "2025-08-12T05:52:54.367Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003, upload-time = "2025-08-12T05:51:48.627Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a9/49940b9dc6d47027dc850c116d79b4155f15c08547d04db0f07121499347/wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77", size = 39025, upload-time = "2025-08-12T05:51:37.156Z" },
+    { url = "https://files.pythonhosted.org/packages/45/35/6a08de0f2c96dcdd7fe464d7420ddb9a7655a6561150e5fc4da9356aeaab/wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7", size = 39108, upload-time = "2025-08-12T05:51:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277", size = 88072, upload-time = "2025-08-12T05:52:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f2/efe19ada4a38e4e15b6dff39c3e3f3f73f5decf901f66e6f72fe79623a06/wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d", size = 88214, upload-time = "2025-08-12T05:52:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/ca86701e9de1622b16e09689fc24b76f69b06bb0150990f6f4e8b0eeb576/wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa", size = 87105, upload-time = "2025-08-12T05:52:17.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e0/d10bd257c9a3e15cbf5523025252cc14d77468e8ed644aafb2d6f54cb95d/wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050", size = 87766, upload-time = "2025-08-12T05:52:39.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/cf/7d848740203c7b4b27eb55dbfede11aca974a51c3d894f6cc4b865f42f58/wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8", size = 36711, upload-time = "2025-08-12T05:53:10.074Z" },
+    { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885, upload-time = "2025-08-12T05:53:08.695Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896, upload-time = "2025-08-12T05:52:55.34Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/cd864b2a14f20d14f4c496fab97802001560f9f41554eef6df201cd7f76c/wrapt-1.17.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cf30f6e3c077c8e6a9a7809c94551203c8843e74ba0c960f4a98cd80d4665d39", size = 54132, upload-time = "2025-08-12T05:51:49.864Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/46/d011725b0c89e853dc44cceb738a307cde5d240d023d6d40a82d1b4e1182/wrapt-1.17.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e228514a06843cae89621384cfe3a80418f3c04aadf8a3b14e46a7be704e4235", size = 39091, upload-time = "2025-08-12T05:51:38.935Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/9e/3ad852d77c35aae7ddebdbc3b6d35ec8013af7d7dddad0ad911f3d891dae/wrapt-1.17.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ea5eb3c0c071862997d6f3e02af1d055f381b1d25b286b9d6644b79db77657c", size = 39172, upload-time = "2025-08-12T05:51:59.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f7/c983d2762bcce2326c317c26a6a1e7016f7eb039c27cdf5c4e30f4160f31/wrapt-1.17.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:281262213373b6d5e4bb4353bc36d1ba4084e6d6b5d242863721ef2bf2c2930b", size = 87163, upload-time = "2025-08-12T05:52:40.965Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0f/f673f75d489c7f22d17fe0193e84b41540d962f75fce579cf6873167c29b/wrapt-1.17.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4a8d2b25efb6681ecacad42fca8859f88092d8732b170de6a5dddd80a1c8fa", size = 87963, upload-time = "2025-08-12T05:52:20.326Z" },
+    { url = "https://files.pythonhosted.org/packages/df/61/515ad6caca68995da2fac7a6af97faab8f78ebe3bf4f761e1b77efbc47b5/wrapt-1.17.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:373342dd05b1d07d752cecbec0c41817231f29f3a89aa8b8843f7b95992ed0c7", size = 86945, upload-time = "2025-08-12T05:52:21.581Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/bd/4e70162ce398462a467bc09e768bee112f1412e563620adc353de9055d33/wrapt-1.17.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d40770d7c0fd5cbed9d84b2c3f2e156431a12c9a37dc6284060fb4bec0b7ffd4", size = 86857, upload-time = "2025-08-12T05:52:43.043Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/da8560695e9284810b8d3df8a19396a6e40e7518059584a1a394a2b35e0a/wrapt-1.17.3-cp314-cp314-win32.whl", hash = "sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10", size = 37178, upload-time = "2025-08-12T05:53:12.605Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c8/b71eeb192c440d67a5a0449aaee2310a1a1e8eca41676046f99ed2487e9f/wrapt-1.17.3-cp314-cp314-win_amd64.whl", hash = "sha256:e1a4120ae5705f673727d3253de3ed0e016f7cd78dc463db1b31e2463e1f3cf6", size = 39310, upload-time = "2025-08-12T05:53:11.106Z" },
+    { url = "https://files.pythonhosted.org/packages/45/20/2cda20fd4865fa40f86f6c46ed37a2a8356a7a2fde0773269311f2af56c7/wrapt-1.17.3-cp314-cp314-win_arm64.whl", hash = "sha256:507553480670cab08a800b9463bdb881b2edeed77dc677b0a5915e6106e91a58", size = 37266, upload-time = "2025-08-12T05:52:56.531Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ed/dd5cf21aec36c80443c6f900449260b80e2a65cf963668eaef3b9accce36/wrapt-1.17.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ed7c635ae45cfbc1a7371f708727bf74690daedc49b4dba310590ca0bd28aa8a", size = 56544, upload-time = "2025-08-12T05:51:51.109Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/450c651cc753877ad100c7949ab4d2e2ecc4d97157e00fa8f45df682456a/wrapt-1.17.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:249f88ed15503f6492a71f01442abddd73856a0032ae860de6d75ca62eed8067", size = 40283, upload-time = "2025-08-12T05:51:39.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/86/2fcad95994d9b572db57632acb6f900695a648c3e063f2cd344b3f5c5a37/wrapt-1.17.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a03a38adec8066d5a37bea22f2ba6bbf39fcdefbe2d91419ab864c3fb515454", size = 40366, upload-time = "2025-08-12T05:52:00.693Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0e/f4472f2fdde2d4617975144311f8800ef73677a159be7fe61fa50997d6c0/wrapt-1.17.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d4478d72eb61c36e5b446e375bbc49ed002430d17cdec3cecb36993398e1a9e", size = 108571, upload-time = "2025-08-12T05:52:44.521Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/01/9b85a99996b0a97c8a17484684f206cbb6ba73c1ce6890ac668bcf3838fb/wrapt-1.17.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223db574bb38637e8230eb14b185565023ab624474df94d2af18f1cdb625216f", size = 113094, upload-time = "2025-08-12T05:52:22.618Z" },
+    { url = "https://files.pythonhosted.org/packages/25/02/78926c1efddcc7b3aa0bc3d6b33a822f7d898059f7cd9ace8c8318e559ef/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e405adefb53a435f01efa7ccdec012c016b5a1d3f35459990afc39b6be4d5056", size = 110659, upload-time = "2025-08-12T05:52:24.057Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/ee/c414501ad518ac3e6fe184753632fe5e5ecacdcf0effc23f31c1e4f7bfcf/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88547535b787a6c9ce4086917b6e1d291aa8ed914fdd3a838b3539dc95c12804", size = 106946, upload-time = "2025-08-12T05:52:45.976Z" },
+    { url = "https://files.pythonhosted.org/packages/be/44/a1bd64b723d13bb151d6cc91b986146a1952385e0392a78567e12149c7b4/wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977", size = 38717, upload-time = "2025-08-12T05:53:15.214Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Adds observability export support for `giskard-checks`.

This PR adds:
- `OTelExporter` for exporting `SuiteResult` data as OpenTelemetry spans, events, and metrics.
- `LangfuseExporter` for exporting suite runs to Langfuse as evaluator observations, generation observations, and scores.
- `evaluate_production_sample` for sampled production evaluation with pass-rate degradation alerts.
- Optional `otel` and `langfuse` dependency extras so the core install remains unchanged.
- README documentation for OpenTelemetry, Langfuse, payload privacy, and production monitoring usage.
- Tests for the OpenTelemetry exporter, Langfuse exporter, and production sampling helper.

Validation ran locally

## Related Issue

Closes #2375

## Type of Change

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [x] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been
  modified)
