### PR TITLE
feat(checks): add operator composition and utility functions

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/__init__.py
@@ -20,6 +20,9 @@ from .builtin import (
     RegexMatching,
     SemanticSimilarity,
     StringMatching,
+    all_of,
+    any_of,
+    expect_fails,
     from_fn,
 )
 from .core import (
@@ -107,6 +110,10 @@ __all__ = [
     "SemanticSimilarity",
     "StringMatching",
     "RegexMatching",
+    # Composition utilities
+    "all_of",
+    "any_of",
+    "expect_fails",
     # Generators
     "UserSimulator",
     # Testing

--- a/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
@@ -14,7 +14,7 @@ from .comparison import (
 )
 
 # Import other builtin checks (staying in builtin)
-from .composition import AllOf, AnyOf, Not
+from .composition import AllOf, AnyOf, Not, all_of, any_of, expect_fails
 from .fn import FnCheck, from_fn
 from .semantic_similarity import SemanticSimilarity
 from .text_matching import RegexMatching, StringMatching
@@ -23,6 +23,9 @@ __all__ = [
     "AllOf",
     "AnyOf",
     "Not",
+    "all_of",
+    "any_of",
+    "expect_fails",
     "from_fn",
     "FnCheck",
     "StringMatching",

--- a/libs/giskard-checks/src/giskard/checks/builtin/composition.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/composition.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import override
 
 from pydantic import Field
@@ -5,6 +7,45 @@ from pydantic import Field
 from ..core import Trace
 from ..core.check import Check
 from ..core.result import CheckResult, CheckStatus
+
+
+def all_of(*checks: Check) -> AllOf:
+    """Create an AllOf check from positional arguments.
+
+    Example
+    -------
+    >>> from giskard.checks import all_of, Equals, LesserThan
+    >>> check = all_of(
+    ...     LesserThan(expected_value=10, key="trace.last.outputs"),
+    ...     Equals(expected_value=5, key="trace.last.outputs"),
+    ... )
+    """
+    return AllOf(checks=list(checks))
+
+
+def any_of(*checks: Check) -> AnyOf:
+    """Create an AnyOf check from positional arguments.
+
+    Example
+    -------
+    >>> from giskard.checks import any_of, StringMatching
+    >>> check = any_of(
+    ...     StringMatching(keyword="yes", key="trace.last.outputs"),
+    ...     StringMatching(keyword="approved", key="trace.last.outputs"),
+    ... )
+    """
+    return AnyOf(checks=list(checks))
+
+
+def expect_fails(check: Check) -> Not:
+    """Invert a check so that failure is the expected outcome.
+
+    Example
+    -------
+    >>> from giskard.checks import expect_fails, Equals
+    >>> check = expect_fails(Equals(expected_value="bad", key="trace.last.outputs"))
+    """
+    return Not(check=check)
 
 
 @Check.register("all_of")

--- a/libs/giskard-checks/src/giskard/checks/core/check.py
+++ b/libs/giskard-checks/src/giskard/checks/core/check.py
@@ -47,12 +47,8 @@ class Check[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportM
         """
         from ..builtin.composition import AllOf
 
-        my_checks: list[Check] = (
-            list(self.checks) if hasattr(self, "checks") and self.__class__.__name__ == "AllOf" else [self]
-        )
-        other_checks: list[Check] = (
-            list(other.checks) if hasattr(other, "checks") and other.__class__.__name__ == "AllOf" else [other]
-        )
+        my_checks: list[Check] = list(self.checks) if isinstance(self, AllOf) else [self]
+        other_checks: list[Check] = list(other.checks) if isinstance(other, AllOf) else [other]
         return AllOf(checks=my_checks + other_checks)
 
     def __or__(self, other: "Check") -> "Check":
@@ -64,12 +60,8 @@ class Check[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportM
         """
         from ..builtin.composition import AnyOf
 
-        my_checks: list[Check] = (
-            list(self.checks) if hasattr(self, "checks") and self.__class__.__name__ == "AnyOf" else [self]
-        )
-        other_checks: list[Check] = (
-            list(other.checks) if hasattr(other, "checks") and other.__class__.__name__ == "AnyOf" else [other]
-        )
+        my_checks: list[Check] = list(self.checks) if isinstance(self, AnyOf) else [self]
+        other_checks: list[Check] = list(other.checks) if isinstance(other, AnyOf) else [other]
         return AnyOf(checks=my_checks + other_checks)
 
     def __invert__(self) -> "Check":

--- a/libs/giskard-checks/src/giskard/checks/core/check.py
+++ b/libs/giskard-checks/src/giskard/checks/core/check.py
@@ -37,3 +37,48 @@ class Check[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportM
             The result of the check evaluation.
         """
         raise NotImplementedError
+
+    def __and__(self, other: "Check") -> "Check":
+        """Combine two checks with AND semantics (all must pass).
+
+        Example
+        -------
+        >>> combined = check_a & check_b
+        """
+        from ..builtin.composition import AllOf
+
+        my_checks: list[Check] = (
+            list(self.checks) if hasattr(self, "checks") and self.__class__.__name__ == "AllOf" else [self]
+        )
+        other_checks: list[Check] = (
+            list(other.checks) if hasattr(other, "checks") and other.__class__.__name__ == "AllOf" else [other]
+        )
+        return AllOf(checks=my_checks + other_checks)
+
+    def __or__(self, other: "Check") -> "Check":
+        """Combine two checks with OR semantics (at least one must pass).
+
+        Example
+        -------
+        >>> combined = check_a | check_b
+        """
+        from ..builtin.composition import AnyOf
+
+        my_checks: list[Check] = (
+            list(self.checks) if hasattr(self, "checks") and self.__class__.__name__ == "AnyOf" else [self]
+        )
+        other_checks: list[Check] = (
+            list(other.checks) if hasattr(other, "checks") and other.__class__.__name__ == "AnyOf" else [other]
+        )
+        return AnyOf(checks=my_checks + other_checks)
+
+    def __invert__(self) -> "Check":
+        """Invert the check result (pass becomes fail, fail becomes pass).
+
+        Example
+        -------
+        >>> inverted = ~check_a
+        """
+        from ..builtin.composition import Not
+
+        return Not(check=self)


### PR DESCRIPTION
## Summary

Adds ergonomic composition for checks via Python operators and utility functions, as requested in #2395.

## Changes

### Operator overloads on `Check` base class (`core/check.py`)
- `check_a & check_b` creates `AllOf(checks=[check_a, check_b])` (flattens nested AllOf)
- `check_a | check_b` creates `AnyOf(checks=[check_a, check_b])` (flattens nested AnyOf)
- `~check_a` creates `Not(check=check_a)`

### Utility functions (`builtin/composition.py`)
- `all_of(*checks)` - variadic AllOf constructor
- `any_of(*checks)` - variadic AnyOf constructor
- `expect_fails(check)` - readable alias for Not

### Exports
- All three utilities exported from `giskard.checks`

## Before/After

```python
# Before
AllOf(checks=[Equals(expected_value="x", key="k"), Not(check=Equals(expected_value="y", key="k"))])

# After (utilities)
all_of(Equals(expected_value="x", key="k"), expect_fails(Equals(expected_value="y", key="k")))

# After (operators)
Equals(expected_value="x", key="k") & ~Equals(expected_value="y", key="k")
```

The existing `AllOf`, `AnyOf`, `Not` classes and their serialization are unchanged. Operators and utilities produce the same model instances.

Closes #2395

This contribution was developed with AI assistance (Claude Code).