### PR TITLE
feat(checks): add JsonValid built-in check with optional JSON Schema validation

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/__init__.py
@@ -21,6 +21,7 @@ from .builtin import (
     SemanticSimilarity,
     StringMatching,
     from_fn,
+    JsonValid,   
 )
 from .core import (
     Check,
@@ -120,4 +121,5 @@ __all__ = [
     # Settings
     "set_default_generator",
     "get_default_generator",
+    "JsonValid",
 ]

--- a/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
@@ -26,6 +26,10 @@ from .fn import FnCheck, from_fn
 from .semantic_similarity import SemanticSimilarity
 from .text_matching import RegexMatching, StringMatching
 
+
+from .json_valid import JsonValid
+
+
 __all__ = [
     "AllOf",
     "AnyOf",
@@ -47,4 +51,5 @@ __all__ = [
     "SemanticSimilarity",
     "BaseLLMCheck",
     "LLMCheckResult",
+    "JsonValid", 
 ]

--- a/libs/giskard-checks/src/giskard/checks/builtin/json_valid.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/json_valid.py
@@ -1,0 +1,75 @@
+"""JSON validation check implementation."""
+
+from __future__ import annotations
+
+import json
+import jsonschema
+from typing import override
+
+
+from giskard.core import provide_not_none
+from pydantic import Field
+
+from ..core import Trace
+from ..core.check import Check
+from ..core.extraction import NoMatch, provided_or_resolve
+from ..core.result import CheckResult
+
+
+@Check.register("json_valid")
+class JsonValid[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
+    Check[InputType, OutputType, TraceType]
+):
+    """Check that passes if the output is valid JSON, with optional schema validation."""
+
+    text: str | None = Field(
+        default=None,
+        description="The text string to check. If None, extracted from trace using text_key."
+    )
+    text_key: str = Field(
+        default="trace.last.outputs",
+        description="JSONPath expression to extract text from the trace."
+    )
+    json_schema: dict | None = Field(
+        default=None,
+        description="Optional JSON schema to validate the parsed JSON against."
+    )
+
+    @override
+    async def run(self, trace: TraceType) -> CheckResult:
+        text = provided_or_resolve(
+            trace, key=self.text_key, value=provide_not_none(self.text)
+        )
+
+        details = {"text": text}
+
+        # handle NoMatch — same as ContainsAny
+        if isinstance(text, NoMatch):
+            return CheckResult.failure(message=f"No text found at key {self.text_key}",  details=details)
+
+        # handle wrong type
+        if not isinstance(text, str):
+            return CheckResult.failure(message=f"Value for text key '{self.text_key}' is not a string, got {type(text)}.",  details=details)
+
+        # try to parse JSON
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError as e:
+            return CheckResult.failure(
+                message= f"Output is not valid JSON: {e}",   # hint: show the parse error e
+                details={**details, "error": str(e)},
+            )
+
+        if self.json_schema is not None:
+            try:
+                jsonschema.validate(instance=parsed, schema=self.json_schema)
+            except jsonschema.exceptions.ValidationError as e:
+                return CheckResult.failure(
+                    message=f"JSON does not match schema: {e.message}",
+                    details={**details, "error": e.message, "parsed": parsed},
+                )
+        
+        return CheckResult.success(
+            message="Output is valid JSON",
+            details={**details, "parsed": parsed},
+        )

--- a/libs/giskard-checks/tests/builtin/test_json_valid.py
+++ b/libs/giskard-checks/tests/builtin/test_json_valid.py
@@ -1,0 +1,51 @@
+from giskard.checks import CheckStatus, JsonValid, Trace
+
+
+async def test_json_valid_passes_for_valid_json() -> None:
+    check = JsonValid(text='{"name": "Alice", "age": 30}')
+    result = await check.run(Trace())
+    assert result.status == CheckStatus.PASS
+    
+async def test_json_valid_fails_for_invalid_json() -> None:
+    check = JsonValid(text='{name: Alice}')
+    result = await check.run(Trace())
+    assert result.status == CheckStatus.FAIL
+
+async def test_json_valid_passes_for_matching_schema()-> None:
+    check = JsonValid(text='{"name": "Alice", "age": 30}', json_schema={
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"}
+        },
+        "required": ["name", "age"]
+    })
+    result = await check.run(Trace())
+    assert result.status == CheckStatus.PASS
+
+async def test_json_valid_fails_for_non_matching_schema()-> None:
+    check = JsonValid(text='{"name": "Alice", "age": "30"}', json_schema={
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"}
+        },
+        "required": ["name", "age"]
+    })
+    result = await check.run(Trace())
+    assert result.status == CheckStatus.FAIL
+
+async def test_json_valid_extracts_text_from_trace() -> None:
+    from giskard.checks import Interaction
+    interaction = Interaction(
+        inputs={"query": "Return JSON"},
+        outputs='{"name": "Alice", "age": 30}',   # ← valid JSON as output
+    )
+    check = JsonValid(text_key="trace.last.outputs")
+    result = await check.run(Trace(interactions=[interaction]))
+    assert result.status == CheckStatus.PASS
+
+async def test_json_valid_fails_when_key_not_in_trace() -> None:
+    check = JsonValid(text_key="trace.last.outputs.nonexistent")
+    result = await check.run(Trace())
+    assert result.status == CheckStatus.FAIL


### PR DESCRIPTION
## Description

Resolves #2362

### Summary
Adds a new built-in check `JsonValid` that validates whether LLM output is
well-formed JSON, with optional JSON Schema validation. This is critical for
testing structured output use cases such as tool calling, data extraction
pipelines, and function calling responses.

### Implementation Details
- Created `libs/giskard-checks/src/giskard/checks/builtin/json_valid.py`
  following the established built-in check pattern.
- Uses a **two-layer validation approach**:
  - **Layer 1** — `json.loads()` (stdlib, zero extra dependencies): validates
    syntax correctness. Fails fast with a descriptive parse error message.
  - **Layer 2** — `jsonschema.validate()` (optional): validates the parsed
    object against a user-provided JSON Schema. Only runs when `json_schema`
    is provided.
- Supports JSONPath extraction from traces via `text_key` (same pattern as
  `StringMatching`), so it integrates naturally into existing Giskard
  evaluation pipelines.
- Renamed the schema field to `json_schema` to avoid shadowing Pydantic's
  reserved `schema` attribute on the base `Check` class.
- Exported at both the `builtin` and top-level `giskard.checks` namespace.

### Example Usage
```python
from giskard.checks import JsonValid, Scenario

# Basic JSON validation — no extra dependencies needed
scenario = (
    Scenario(name="structured_output")
    .interact(inputs="Return a JSON object", outputs='{"name": "Alice", "age": 30}')
    .check(JsonValid())
)

# With JSON Schema validation
schema = {
    "type": "object",
    "properties": {
        "name": {"type": "string"},
        "age": {"type": "integer"}
    },
    "required": ["name", "age"]
}
scenario = (
    Scenario(name="schema_validation")
    .interact(inputs="Return user data", outputs='{"name": "Alice", "age": 30}')
    .check(JsonValid(json_schema=schema))
)

```

Testing

Added 6 tests in tests/builtin/test_json_valid.py:

✅ Valid JSON passes
✅ Invalid JSON fails (with descriptive parse error in details)
✅ JSON matching a schema passes
✅ JSON not matching a schema fails
✅ Text extracted from trace via JSONPath works correctly
✅ Missing key in trace returns a failure

All 6 tests pass locally.

Related Issue
Resolves #2362

Type of Change

 📚 Examples / docs / tutorials / dependencies update
 🔧 Bug fix (non-breaking change which fixes an issue)
 🥂 Improvement (non-breaking change which improves an existing feature)
 🚀 New feature (non-breaking change which adds functionality)
 💥 Breaking change (fix or feature that would cause existing functionality to change)
 🔐 Security fix

Checklist
 I've read the [CODE_OF_CONDUCT.md](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
 I've read the [CONTRIBUTING.md](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
 I've written tests for all new methods and classes that I created.
 I've written the docstring in NumPy format for all the methods and classes that I created or modified.
