### PR TITLE
feat(checks): add Sentiment builtin check (#2364)

### DIFF
--- a/libs/giskard-checks/pyproject.toml
+++ b/libs/giskard-checks/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "giskard-core>=1.0.0a1",
     "numpy>=2.4.1,<3",
     "rich>=14.2.0,<15",
+    "textblob>=0.20.0",
 ]
 
 [tool.pytest.ini_options]

--- a/libs/giskard-checks/src/giskard/checks/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/__init__.py
@@ -21,6 +21,7 @@ from .builtin import (
     SemanticSimilarity,
     StringMatching,
     from_fn,
+    Sentiment,
 )
 from .core import (
     Check,
@@ -120,4 +121,5 @@ __all__ = [
     # Settings
     "set_default_generator",
     "get_default_generator",
+    "Sentiment",
 ]

--- a/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
@@ -25,6 +25,8 @@ from .composition import AllOf, AnyOf, Not
 from .fn import FnCheck, from_fn
 from .semantic_similarity import SemanticSimilarity
 from .text_matching import RegexMatching, StringMatching
+from .sentiment import Sentiment
+
 
 __all__ = [
     "AllOf",
@@ -47,4 +49,5 @@ __all__ = [
     "SemanticSimilarity",
     "BaseLLMCheck",
     "LLMCheckResult",
+    "Sentiment",
 ]

--- a/libs/giskard-checks/src/giskard/checks/builtin/sentiment.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/sentiment.py
@@ -1,0 +1,63 @@
+"""Sentiment analysis check implementation."""
+
+from __future__ import annotations
+
+from textblob import TextBlob
+from typing import override
+
+from giskard.core import provide_not_none
+from pydantic import Field
+
+from ..core import Trace
+from ..core.check import Check
+from ..core.extraction import NoMatch, provided_or_resolve
+from ..core.result import CheckResult
+
+
+@Check.register("sentiment")
+class Sentiment[InputType, OutputType, TraceType: Trace](
+    Check[InputType, OutputType, TraceType]
+):
+    """Check that validates the sentiment polarity of text output."""
+
+    text: str | None = Field(default=None, description="The text string to analyze. If None, it will be extracted from the trace using text_key.")
+    text_key: str = Field(default="trace.last.outputs", description="JSONPath expression to extract text from the trace.")
+    min_polarity: float | None = Field(default=None, description="The minimum acceptable polarity score, from -1.0 to 1.0.")
+    max_polarity: float | None = Field(default=None, description="The maximum acceptable polarity score, from -1.0 to 1.0.")
+
+    @override
+    async def run(self, trace: TraceType) -> CheckResult:
+        text = provided_or_resolve(
+            trace, key=self.text_key, value=provide_not_none(self.text)
+        )
+        details = {"text": text}
+
+        # handle NoMatch
+        if isinstance(text, NoMatch):
+            return CheckResult.failure(message=f"No text found at key {self.text_key}", details=details)
+
+        # handle wrong type
+        if not isinstance(text, str):
+            return CheckResult.failure(message=f"Value for text key '{self.text_key}' is not a string, got {type(text).__name__}.", details=details)
+
+        # compute polarity
+        polarity = TextBlob(text).sentiment.polarity
+        details["polarity"] = polarity
+
+        # check bounds
+        if self.min_polarity is not None and polarity < self.min_polarity:
+            return CheckResult.failure(
+                message=f"Sentiment polarity {polarity:.2f} is below the required minimum of {self.min_polarity:.2f}.",  # hint: show actual vs required
+                details=details,
+            )
+
+        if self.max_polarity is not None and polarity > self.max_polarity:
+            return CheckResult.failure(
+                message=f"Sentiment polarity {polarity:.2f} is above the required maximum of {self.max_polarity:.2f}.",
+                details=details,
+            )
+
+        return CheckResult.success(
+            message=f"Sentiment polarity {polarity:.2f} is within acceptable bounds.",
+            details=details,
+        )

--- a/libs/giskard-checks/tests/builtin/test_sentiment.py
+++ b/libs/giskard-checks/tests/builtin/test_sentiment.py
@@ -1,0 +1,51 @@
+import pytest
+from giskard.checks import Sentiment, CheckStatus, Trace, Interaction
+from giskard.checks.core.extraction import NoMatch
+
+
+async def test_min_polarity_passes() -> None:
+    """Test that check passes when Sentiment has minimum polarity as 0.0"""
+    check = Sentiment(text="I love this product, it is absolutely amazing!", min_polarity=0.0)
+    result = await check.run(Trace())
+    assert result.status == CheckStatus.PASS
+    
+
+async def test_min_polarity_fails() -> None:
+    """Test that check fails when Sentiment has minimum polarity as 0.0"""
+    check = Sentiment(text="I hate this product, it is absolutely terrible!", min_polarity=0.0)
+    result = await check.run(Trace())
+    assert result.status == CheckStatus.FAIL
+
+async def test_max_polarity_fails() -> None:
+    """Test that check fails when Sentiment has maximum polarity as 0.0"""
+    check = Sentiment(text="I love this product, it is absolutely amazing!", max_polarity=0.0)
+    result = await check.run(Trace())
+    assert result.status == CheckStatus.FAIL
+
+async def test_no_bounds_passes() -> None:
+    """Test that check passes when Sentiment has no bounds"""
+    check = Sentiment(text="I love this product, it is absolutely amazing!")
+    result = await check.run(Trace())
+    assert result.status == CheckStatus.PASS
+
+async def test_text_from_trace() -> None:
+    """Test extracting text from trace"""
+    check = Sentiment(text_key="trace.last.outputs.response")
+    interaction = Interaction(
+        inputs={"query": "What is the sentiment of this text?"},
+        outputs={"response": "I love this product, it is absolutely amazing!"},
+    )
+    result = await check.run(Trace(interactions=[interaction]))
+    assert result.status == CheckStatus.PASS
+    assert result.details["text"] == "I love this product, it is absolutely amazing!"
+
+async def test_text_not_found_in_trace() -> None:
+    """Test that check fails when text is not found in trace"""
+    check = Sentiment(text_key="trace.last.outputs.nonexistent")
+    interaction = Interaction(
+        inputs={"query": "What is the sentiment of this text?"},
+        outputs={"response": "I love this product, it is absolutely amazing!"},
+    )
+    result = await check.run(Trace(interactions=[interaction]))
+    assert result.status == CheckStatus.FAIL
+    assert isinstance(result.details["text"], NoMatch)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "giskard-agents>=1.0.0a1",
     "giskard-checks>=1.0.0a1",
     "regex>=2026.1.15",
+    "textblob>=0.20.0",
 ]
 requires-python = ">=3.12"
 

--- a/uv.lock
+++ b/uv.lock
@@ -687,6 +687,7 @@ dependencies = [
     { name = "giskard-checks" },
     { name = "giskard-core" },
     { name = "regex" },
+    { name = "textblob" },
 ]
 
 [package.dev-dependencies]
@@ -706,6 +707,7 @@ requires-dist = [
     { name = "giskard-checks", editable = "libs/giskard-checks" },
     { name = "giskard-core", editable = "libs/giskard-core" },
     { name = "regex", specifier = ">=2026.1.15" },
+    { name = "textblob", specifier = ">=0.20.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -760,6 +762,7 @@ dependencies = [
     { name = "numpy" },
     { name = "pydantic" },
     { name = "rich" },
+    { name = "textblob" },
 ]
 
 [package.metadata]
@@ -771,6 +774,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.4.1,<3" },
     { name = "pydantic", specifier = ">=2.12,<3" },
     { name = "rich", specifier = ">=14.2.0,<15" },
+    { name = "textblob", specifier = ">=0.20.0" },
 ]
 
 [[package]]
@@ -1069,6 +1073,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
     { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
     { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
+]
+
+[[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
 ]
 
 [[package]]
@@ -1438,6 +1451,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
+name = "nltk"
+version = "3.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "joblib" },
+    { name = "regex" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
 ]
 
 [[package]]
@@ -2384,6 +2412,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "textblob"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nltk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/c0/b7f426679211e965f8bf6b65e5eafeda51842502a6ae989b9616895d5fb5/textblob-0.20.0.tar.gz", hash = "sha256:ae9bef3a16cecb4aae3e995cc8c6fe98a9d2a6ffdd58990dcd68e817e8d66b9e", size = 639377, upload-time = "2026-04-01T13:50:20.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/6e/d487f271c30700354f55b5e56339f38942ab3cb9b6f1464288e252ae3fef/textblob-0.20.0-py3-none-any.whl", hash = "sha256:f32e5240a17a98a8d026cdf7add8f5e0c7d4f1f2e91dad77bc9493e5ab3c6bd5", size = 624962, upload-time = "2026-04-01T13:50:19.423Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Resolves #2364

### Summary
Adds a new built-in check `Sentiment` that validates the sentiment polarity of LLM output. This is highly useful for checking if AI outputs are sufficiently positive or not overly negative (toxicity) in customer-facing applications. 

### Implementation Details
- Created `libs/giskard-checks/src/giskard/checks/builtin/sentiment.py` following the established built-in check pattern.
- Added `textblob` as a dependency.
- Added `min_polarity` and `max_polarity` thresholds. Returns a structured `CheckResult` with descriptive bounds-checking failures.
- Supports JSONPath extraction from traces via `text_key`. 
- Added the check to `__init__.py` exports.

### Example Usage
```python
from giskard.checks import Sentiment, Scenario

scenario = (
    Scenario(name="sentiment_test")
    .interact(inputs="What do you think?", outputs="I love this product, it's absolutely amazing!")
    .check(Sentiment(min_polarity=0.0))
)
```

Testing
Added 6 tests in tests/builtin/test_sentiment.py covering:

✅ Check passes when min_polarity is satisfied.
✅ Check fails when min_polarity is violated.
✅ Check fails when max_polarity is violated.
✅ Check passes and simply records polarity when bounds are omitted.
✅ Text extracted dynamically from trace interactions JSON.
✅ Fails cleanly when metadata context misses target output keys (NoMatch object properly asserted).
All tests run smoothly on my end via uv run pytest.

Related Issue
Resolves #2364

Type of Change
 📚 Examples / docs / tutorials / dependencies update
 🔧 Bug fix (non-breaking change which fixes an issue)
 🚀 New feature (non-breaking change which adds functionality)

Checklist
 I've read the CODE_OF_CONDUCT.md document.
 I've read the CONTRIBUTING.md guide.
 I've written tests for all new methods and classes that I created.
 I've written the docstring in NumPy format for all the methods and classes that I created or modified.
 I've updated the uv.lock running uv add (since pyproject.toml has been modified)