### PR TITLE
Adopt TypeVar defaults for giskard-checks generics

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/builtin/comparison.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/comparison.py
@@ -1,8 +1,9 @@
 from abc import ABC, abstractmethod
-from typing import Any, Self, override
+from typing import Any, Generic, Self, override
 
 from giskard.core import NOT_PROVIDED, NotProvided, provide_not_none
 from pydantic import Field, model_validator
+from typing_extensions import TypeVar
 
 from ..core import Trace
 from ..core.check import Check
@@ -10,9 +11,20 @@ from ..core.extraction import JSONPathStr, NoMatch, provided_or_resolve, resolve
 from ..core.result import CheckResult
 from ..utils.normalization import NormalizationForm, normalize_data
 
+InputType = TypeVar("InputType")
+OutputType = TypeVar("OutputType")
+TraceType = TypeVar(
+    "TraceType",
+    bound=Trace[Any, Any],
+    default=Trace[InputType, OutputType],
+)
+ExpectedType = TypeVar("ExpectedType", default=InputType | OutputType)
 
-class ComparisonCheck[InputType, OutputType, TraceType: Trace, ExpectedType](  # pyright: ignore[reportMissingTypeArgument]
-    ABC, Check[InputType, OutputType, TraceType]
+
+class ComparisonCheck(
+    ABC,
+    Check[InputType, OutputType, TraceType],
+    Generic[InputType, OutputType, TraceType, ExpectedType],
 ):
     """Base class for comparison checks.
 
@@ -126,8 +138,9 @@ class ComparisonCheck[InputType, OutputType, TraceType: Trace, ExpectedType](  #
 
 
 @Check.register("lesser_than")
-class LesserThan[InputType, OutputType, TraceType: Trace, ExpectedType](  # pyright: ignore[reportMissingTypeArgument]
-    ComparisonCheck[InputType, OutputType, TraceType, ExpectedType]
+class LesserThan(
+    ComparisonCheck[InputType, OutputType, TraceType, ExpectedType],
+    Generic[InputType, OutputType, TraceType, ExpectedType],
 ):
     """Check that validates if extracted values are less than an expected value.
 
@@ -169,8 +182,9 @@ class LesserThan[InputType, OutputType, TraceType: Trace, ExpectedType](  # pyri
 
 
 @Check.register("greater_than")
-class GreaterThan[InputType, OutputType, TraceType: Trace, ExpectedType](  # pyright: ignore[reportMissingTypeArgument]
-    ComparisonCheck[InputType, OutputType, TraceType, ExpectedType]
+class GreaterThan(
+    ComparisonCheck[InputType, OutputType, TraceType, ExpectedType],
+    Generic[InputType, OutputType, TraceType, ExpectedType],
 ):
     """Check that validates if extracted values are greater than an expected value.
 
@@ -212,8 +226,9 @@ class GreaterThan[InputType, OutputType, TraceType: Trace, ExpectedType](  # pyr
 
 
 @Check.register("lesser_than_equals")
-class LesserThanEquals[InputType, OutputType, TraceType: Trace, ExpectedType](  # pyright: ignore[reportMissingTypeArgument]
-    ComparisonCheck[InputType, OutputType, TraceType, ExpectedType]
+class LesserThanEquals(
+    ComparisonCheck[InputType, OutputType, TraceType, ExpectedType],
+    Generic[InputType, OutputType, TraceType, ExpectedType],
 ):
     """Check that validates if extracted values are less than or equal to an expected value.
 
@@ -255,8 +270,9 @@ class LesserThanEquals[InputType, OutputType, TraceType: Trace, ExpectedType](  
 
 
 @Check.register("greater_than_equals")
-class GreaterEquals[InputType, OutputType, TraceType: Trace, ExpectedType](  # pyright: ignore[reportMissingTypeArgument]
-    ComparisonCheck[InputType, OutputType, TraceType, ExpectedType]
+class GreaterEquals(
+    ComparisonCheck[InputType, OutputType, TraceType, ExpectedType],
+    Generic[InputType, OutputType, TraceType, ExpectedType],
 ):
     """Check that validates if extracted values are greater than or equal to an expected value.
 
@@ -298,8 +314,9 @@ class GreaterEquals[InputType, OutputType, TraceType: Trace, ExpectedType](  # p
 
 
 @Check.register("equals")
-class Equals[InputType, OutputType, TraceType: Trace, ExpectedType](  # pyright: ignore[reportMissingTypeArgument]
-    ComparisonCheck[InputType, OutputType, TraceType, ExpectedType]
+class Equals(
+    ComparisonCheck[InputType, OutputType, TraceType, ExpectedType],
+    Generic[InputType, OutputType, TraceType, ExpectedType],
 ):
     """Check that validates if extracted values equal an expected value.
 
@@ -341,8 +358,9 @@ class Equals[InputType, OutputType, TraceType: Trace, ExpectedType](  # pyright:
 
 
 @Check.register("not_equals")
-class NotEquals[InputType, OutputType, TraceType: Trace, ExpectedType](  # pyright: ignore[reportMissingTypeArgument]
-    ComparisonCheck[InputType, OutputType, TraceType, ExpectedType]
+class NotEquals(
+    ComparisonCheck[InputType, OutputType, TraceType, ExpectedType],
+    Generic[InputType, OutputType, TraceType, ExpectedType],
 ):
     """Check that validates if extracted values do not equal an expected value.
 

--- a/libs/giskard-checks/src/giskard/checks/builtin/comparison.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/comparison.py
@@ -5,19 +5,12 @@ from giskard.core import NOT_PROVIDED, NotProvided, provide_not_none
 from pydantic import Field, model_validator
 from typing_extensions import TypeVar
 
-from ..core import Trace
 from ..core.check import Check
 from ..core.extraction import JSONPathStr, NoMatch, provided_or_resolve, resolve
 from ..core.result import CheckResult
+from ..core.typevars import InputType, OutputType, TraceType
 from ..utils.normalization import NormalizationForm, normalize_data
 
-InputType = TypeVar("InputType")
-OutputType = TypeVar("OutputType")
-TraceType = TypeVar(
-    "TraceType",
-    bound=Trace[Any, Any],
-    default=Trace[InputType, OutputType],
-)
 ExpectedType = TypeVar("ExpectedType", default=InputType | OutputType)
 
 

--- a/libs/giskard-checks/src/giskard/checks/builtin/composition.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/composition.py
@@ -1,15 +1,25 @@
-from typing import override
+from typing import Any, Generic, override
 
 from pydantic import Field
+from typing_extensions import TypeVar
 
 from ..core import Trace
 from ..core.check import Check
 from ..core.result import CheckResult, CheckStatus
 
+InputType = TypeVar("InputType")
+OutputType = TypeVar("OutputType")
+TraceType = TypeVar(
+    "TraceType",
+    bound=Trace[Any, Any],
+    default=Trace[InputType, OutputType],
+)
+
 
 @Check.register("all_of")
-class AllOf[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
-    Check[InputType, OutputType, TraceType]
+class AllOf(
+    Check[InputType, OutputType, TraceType],
+    Generic[InputType, OutputType, TraceType],
 ):
     """Passes only when **all** inner checks pass (short-circuits on first failure).
 
@@ -67,8 +77,9 @@ class AllOf[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportM
 
 
 @Check.register("any_of")
-class AnyOf[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
-    Check[InputType, OutputType, TraceType]
+class AnyOf(
+    Check[InputType, OutputType, TraceType],
+    Generic[InputType, OutputType, TraceType],
 ):
     """Passes when **at least one** inner check passes (short-circuits on first pass).
 
@@ -141,8 +152,9 @@ class AnyOf[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportM
 
 
 @Check.register("not")
-class Not[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
-    Check[InputType, OutputType, TraceType]
+class Not(
+    Check[InputType, OutputType, TraceType],
+    Generic[InputType, OutputType, TraceType],
 ):
     """Inverts the result of an inner check.
 

--- a/libs/giskard-checks/src/giskard/checks/builtin/composition.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/composition.py
@@ -1,19 +1,10 @@
-from typing import Any, Generic, override
+from typing import Generic, override
 
 from pydantic import Field
-from typing_extensions import TypeVar
 
-from ..core import Trace
 from ..core.check import Check
 from ..core.result import CheckResult, CheckStatus
-
-InputType = TypeVar("InputType")
-OutputType = TypeVar("OutputType")
-TraceType = TypeVar(
-    "TraceType",
-    bound=Trace[Any, Any],
-    default=Trace[InputType, OutputType],
-)
+from ..core.typevars import InputType, OutputType, TraceType
 
 
 @Check.register("all_of")

--- a/libs/giskard-checks/src/giskard/checks/builtin/fn.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/fn.py
@@ -8,6 +8,7 @@ from typing_extensions import TypeVar
 from ..core import Trace
 from ..core.check import Check
 from ..core.result import CheckResult
+from ..core.typevars import InputType, OutputType, TraceType
 
 """Function-backed check implementation.
 
@@ -20,13 +21,6 @@ The callable can be synchronous or asynchronous and must return either:
 - a `CheckResult`: used as-is
 """
 
-InputType = TypeVar("InputType")
-OutputType = TypeVar("OutputType")
-TraceType = TypeVar(
-    "TraceType",
-    bound=Trace[Any, Any],
-    default=Trace[InputType, OutputType],
-)
 FnTraceType = TypeVar("FnTraceType", bound=Trace[Any, Any], default=Trace[Any, Any])
 
 

--- a/libs/giskard-checks/src/giskard/checks/builtin/fn.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/fn.py
@@ -1,8 +1,9 @@
 import inspect
 from collections.abc import Awaitable
-from typing import Any, Callable, override
+from typing import Any, Callable, Generic, override
 
 from pydantic import Field
+from typing_extensions import TypeVar
 
 from ..core import Trace
 from ..core.check import Check
@@ -19,11 +20,21 @@ The callable can be synchronous or asynchronous and must return either:
 - a `CheckResult`: used as-is
 """
 
+InputType = TypeVar("InputType")
+OutputType = TypeVar("OutputType")
+TraceType = TypeVar(
+    "TraceType",
+    bound=Trace[Any, Any],
+    default=Trace[InputType, OutputType],
+)
+FnTraceType = TypeVar("FnTraceType", bound=Trace[Any, Any], default=Trace[Any, Any])
+
 
 @Check.register("fn")
-class FnCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]@
-    Check[InputType, OutputType, TraceType]
-):  # pyright: ignore[reportMissingTypeArgument]
+class FnCheck(
+    Check[InputType, OutputType, TraceType],
+    Generic[InputType, OutputType, TraceType],
+):
     """A `Check` whose logic is a Python callable.
 
     Parameters are modeled as pydantic fields. At runtime, the `run` method will
@@ -75,9 +86,9 @@ class FnCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignore[repor
         )
 
 
-def from_fn[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
+def from_fn(
     fn: Callable[
-        [TraceType],
+        [FnTraceType],
         Awaitable[bool | CheckResult] | bool | CheckResult,
     ],
     *,
@@ -86,7 +97,7 @@ def from_fn[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportM
     success_message: str | None = None,
     failure_message: str | None = None,
     details: dict[str, Any] | None = None,
-) -> Check[InputType, OutputType, TraceType]:
+) -> Check[Any, Any, FnTraceType]:
     """Create an `FnCheck` from a callable.
 
     Example

--- a/libs/giskard-checks/src/giskard/checks/builtin/semantic_similarity.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/semantic_similarity.py
@@ -1,23 +1,14 @@
-from typing import Any, Generic, override
+from typing import Generic, override
 
 import numpy as np
 from giskard.core import provide_not_none
 from pydantic import Field
-from typing_extensions import TypeVar
 
-from ..core import Trace
 from ..core.check import Check
 from ..core.extraction import JSONPathStr, NoMatch, provided_or_resolve, resolve
 from ..core.mixin import WithEmbeddingMixin
 from ..core.result import CheckResult
-
-InputType = TypeVar("InputType")
-OutputType = TypeVar("OutputType")
-TraceType = TypeVar(
-    "TraceType",
-    bound=Trace[Any, Any],
-    default=Trace[InputType, OutputType],
-)
+from ..core.typevars import InputType, OutputType, TraceType
 
 
 def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:

--- a/libs/giskard-checks/src/giskard/checks/builtin/semantic_similarity.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/semantic_similarity.py
@@ -1,14 +1,23 @@
-from typing import override
+from typing import Any, Generic, override
 
 import numpy as np
 from giskard.core import provide_not_none
 from pydantic import Field
+from typing_extensions import TypeVar
 
 from ..core import Trace
 from ..core.check import Check
 from ..core.extraction import JSONPathStr, NoMatch, provided_or_resolve, resolve
 from ..core.mixin import WithEmbeddingMixin
 from ..core.result import CheckResult
+
+InputType = TypeVar("InputType")
+OutputType = TypeVar("OutputType")
+TraceType = TypeVar(
+    "TraceType",
+    bound=Trace[Any, Any],
+    default=Trace[InputType, OutputType],
+)
 
 
 def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
@@ -44,8 +53,10 @@ def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
 
 
 @Check.register("semantic_similarity")
-class SemanticSimilarity[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
-    Check[InputType, OutputType, TraceType], WithEmbeddingMixin
+class SemanticSimilarity(
+    Check[InputType, OutputType, TraceType],
+    WithEmbeddingMixin,
+    Generic[InputType, OutputType, TraceType],
 ):
     """Check that validates semantic similarity between outputs and reference text.
 

--- a/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
@@ -11,21 +11,12 @@ from typing import Any, Generic, Self, override
 import regex
 from giskard.core import provide_not_none
 from pydantic import Field, model_validator
-from typing_extensions import TypeVar
 
-from ..core import Trace
 from ..core.check import Check
 from ..core.extraction import JSONPathStr, NoMatch, provided_or_resolve
 from ..core.result import CheckResult
+from ..core.typevars import InputType, OutputType, TraceType
 from ..utils.normalization import NormalizationForm, normalize_string
-
-InputType = TypeVar("InputType")
-OutputType = TypeVar("OutputType")
-TraceType = TypeVar(
-    "TraceType",
-    bound=Trace[Any, Any],
-    default=Trace[InputType, OutputType],
-)
 
 
 class TextBasedCheck(

--- a/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
@@ -6,11 +6,12 @@ This module provides checks for text matching:
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Self, override
+from typing import Any, Generic, Self, override
 
 import regex
 from giskard.core import provide_not_none
 from pydantic import Field, model_validator
+from typing_extensions import TypeVar
 
 from ..core import Trace
 from ..core.check import Check
@@ -18,9 +19,19 @@ from ..core.extraction import JSONPathStr, NoMatch, provided_or_resolve
 from ..core.result import CheckResult
 from ..utils.normalization import NormalizationForm, normalize_string
 
+InputType = TypeVar("InputType")
+OutputType = TypeVar("OutputType")
+TraceType = TypeVar(
+    "TraceType",
+    bound=Trace[Any, Any],
+    default=Trace[InputType, OutputType],
+)
 
-class TextBasedCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
-    Check[InputType, OutputType, TraceType], ABC
+
+class TextBasedCheck(
+    Check[InputType, OutputType, TraceType],
+    ABC,
+    Generic[InputType, OutputType, TraceType],
 ):
     """Base class for checks that validate text against a target value.
 
@@ -137,8 +148,9 @@ class TextBasedCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignor
 
 
 @Check.register("string_matching")
-class StringMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
-    TextBasedCheck[InputType, OutputType, TraceType]
+class StringMatching(
+    TextBasedCheck[InputType, OutputType, TraceType],
+    Generic[InputType, OutputType, TraceType],
 ):
     """Check that validates if a keyword appears within a text string.
 
@@ -321,8 +333,9 @@ class StringMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignor
 
 
 @Check.register("regex_matching")
-class RegexMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
-    TextBasedCheck[InputType, OutputType, TraceType]
+class RegexMatching(
+    TextBasedCheck[InputType, OutputType, TraceType],
+    Generic[InputType, OutputType, TraceType],
 ):
     r"""Check that validates if a regex pattern matches within text.
 

--- a/libs/giskard-checks/src/giskard/checks/core/check.py
+++ b/libs/giskard-checks/src/giskard/checks/core/check.py
@@ -1,19 +1,10 @@
-from typing import Any, Generic
+from typing import Generic
 
 from giskard.core import Discriminated, discriminated_base
 from pydantic import Field
-from typing_extensions import TypeVar
 
-from .interaction import Trace
 from .result import CheckResult
-
-InputType = TypeVar("InputType")
-OutputType = TypeVar("OutputType")
-TraceType = TypeVar(
-    "TraceType",
-    bound=Trace[Any, Any],
-    default=Trace[InputType, OutputType],
-)
+from .typevars import InputType, OutputType, TraceType
 
 
 @discriminated_base

--- a/libs/giskard-checks/src/giskard/checks/core/check.py
+++ b/libs/giskard-checks/src/giskard/checks/core/check.py
@@ -1,14 +1,23 @@
+from typing import Any, Generic
+
 from giskard.core import Discriminated, discriminated_base
 from pydantic import Field
+from typing_extensions import TypeVar
 
 from .interaction import Trace
 from .result import CheckResult
 
+InputType = TypeVar("InputType")
+OutputType = TypeVar("OutputType")
+TraceType = TypeVar(
+    "TraceType",
+    bound=Trace[Any, Any],
+    default=Trace[InputType, OutputType],
+)
+
 
 @discriminated_base
-class Check[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
-    Discriminated
-):
+class Check(Discriminated, Generic[InputType, OutputType, TraceType]):
     """Base class for checks.
 
     Subclasses should be registered using the @Check.register("kind") decorator

--- a/libs/giskard-checks/src/giskard/checks/core/extraction.py
+++ b/libs/giskard-checks/src/giskard/checks/core/extraction.py
@@ -15,15 +15,8 @@ from jsonpath_ng import (
 )
 from jsonpath_ng.exceptions import JsonPathLexerError, JsonPathParserError
 from pydantic import AfterValidator, BaseModel, Field
-from typing_extensions import TypeVar
 
-from .interaction import Trace
-
-TraceType = TypeVar(
-    "TraceType",
-    bound=Trace[Any, Any],
-    default=Trace[Any, Any],
-)
+from .typevars import TraceType
 
 
 class _JSONPathStrMarker:

--- a/libs/giskard-checks/src/giskard/checks/core/extraction.py
+++ b/libs/giskard-checks/src/giskard/checks/core/extraction.py
@@ -15,8 +15,15 @@ from jsonpath_ng import (
 )
 from jsonpath_ng.exceptions import JsonPathLexerError, JsonPathParserError
 from pydantic import AfterValidator, BaseModel, Field
+from typing_extensions import TypeVar
 
 from .interaction import Trace
+
+TraceType = TypeVar(
+    "TraceType",
+    bound=Trace[Any, Any],
+    default=Trace[Any, Any],
+)
 
 
 class _JSONPathStrMarker:
@@ -78,7 +85,7 @@ def _is_list_expression(expression: JSONPath) -> bool:
     return False
 
 
-def resolve[TraceType: Trace](trace: TraceType, key: str) -> Any:  # pyright: ignore[reportMissingTypeArgument]
+def resolve(trace: TraceType, key: str) -> Any:
     expression: JSONPath = parse(key)
     matches: list[DatumInContext] = expression.find({"trace": trace.model_dump()})
 
@@ -88,7 +95,7 @@ def resolve[TraceType: Trace](trace: TraceType, key: str) -> Any:  # pyright: ig
     return matches[0].value if matches else NoMatch(key=key)
 
 
-def provided_or_resolve[TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
+def provided_or_resolve(
     trace: TraceType,
     key: str | NotProvided = NOT_PROVIDED,
     value: Any = NOT_PROVIDED,

--- a/libs/giskard-checks/src/giskard/checks/core/input_generator.py
+++ b/libs/giskard-checks/src/giskard/checks/core/input_generator.py
@@ -1,18 +1,12 @@
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING, Any, Generic
+from typing import TYPE_CHECKING, Generic
 
 from giskard.core import Discriminated, discriminated_base
-from typing_extensions import TypeVar
 
 if TYPE_CHECKING:
     from .interaction import Trace
 
-InputType = TypeVar("InputType")
-TraceType = TypeVar(
-    "TraceType",
-    bound="Trace[Any, Any]",
-    default="Trace[Any, Any]",
-)
+from .typevars import InputType, TraceType
 
 
 @discriminated_base

--- a/libs/giskard-checks/src/giskard/checks/core/input_generator.py
+++ b/libs/giskard-checks/src/giskard/checks/core/input_generator.py
@@ -1,13 +1,21 @@
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Generic
 
 from giskard.core import Discriminated, discriminated_base
+from typing_extensions import TypeVar
 
 if TYPE_CHECKING:
     from .interaction import Trace
 
+InputType = TypeVar("InputType")
+TraceType = TypeVar(
+    "TraceType",
+    bound="Trace[Any, Any]",
+    default="Trace[Any, Any]",
+)
+
 
 @discriminated_base
-class InputGenerator[InputType, TraceType: "Trace"](Discriminated):  # pyright: ignore[reportMissingTypeArgument]
+class InputGenerator(Discriminated, Generic[InputType, TraceType]):
     def __call__(self, trace: TraceType) -> AsyncGenerator[InputType, TraceType]:
         raise NotImplementedError

--- a/libs/giskard-checks/src/giskard/checks/core/interaction/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/core/interaction/__init__.py
@@ -1,6 +1,16 @@
-from .base import InteractionSpec
-from .interact import Interact
 from .interaction import Interaction
 from .trace import Trace
 
 __all__ = ["InteractionSpec", "Interact", "Interaction", "Trace"]
+
+
+def __getattr__(name: str):
+    if name == "InteractionSpec":
+        from .base import InteractionSpec
+
+        return InteractionSpec
+    if name == "Interact":
+        from .interact import Interact
+
+        return Interact
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/libs/giskard-checks/src/giskard/checks/core/interaction/base.py
+++ b/libs/giskard-checks/src/giskard/checks/core/interaction/base.py
@@ -1,19 +1,10 @@
 from collections.abc import AsyncGenerator
-from typing import Any, Generic
+from typing import Generic
 
 from giskard.core import Discriminated, discriminated_base
-from typing_extensions import TypeVar
 
 from .interaction import Interaction
-from .trace import Trace
-
-InputType = TypeVar("InputType")
-OutputType = TypeVar("OutputType")
-TraceType = TypeVar(
-    "TraceType",
-    bound=Trace[Any, Any],
-    default=Trace[InputType, OutputType],
-)
+from ..typevars import InputType, OutputType, TraceType
 
 
 @discriminated_base

--- a/libs/giskard-checks/src/giskard/checks/core/interaction/base.py
+++ b/libs/giskard-checks/src/giskard/checks/core/interaction/base.py
@@ -1,15 +1,23 @@
 from collections.abc import AsyncGenerator
+from typing import Any, Generic
 
 from giskard.core import Discriminated, discriminated_base
+from typing_extensions import TypeVar
 
 from .interaction import Interaction
 from .trace import Trace
 
+InputType = TypeVar("InputType")
+OutputType = TypeVar("OutputType")
+TraceType = TypeVar(
+    "TraceType",
+    bound=Trace[Any, Any],
+    default=Trace[InputType, OutputType],
+)
+
 
 @discriminated_base
-class InteractionSpec[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
-    Discriminated
-):
+class InteractionSpec(Discriminated, Generic[InputType, OutputType, TraceType]):
     """Base class for interaction specifications that generate interactions.
 
     An interaction spec produces one or more `Interaction` objects by yielding

--- a/libs/giskard-checks/src/giskard/checks/core/interaction/interact.py
+++ b/libs/giskard-checks/src/giskard/checks/core/interaction/interact.py
@@ -1,9 +1,10 @@
 from collections.abc import AsyncGenerator
-from typing import Any, cast, override
+from typing import Any, Generic, cast, override
 
 from giskard.checks.utils.injectable import ValueGenerator, ValueProvider
 from giskard.core.utils import NOT_PROVIDED, NotProvided
 from pydantic import Field, PrivateAttr, model_validator
+from typing_extensions import TypeVar
 
 from ..input_generator import InputGenerator
 from ..types import GeneratorType, ProviderType
@@ -11,10 +12,19 @@ from .base import InteractionSpec
 from .interaction import Interaction
 from .trace import Trace
 
+InputType = TypeVar("InputType")
+OutputType = TypeVar("OutputType")
+TraceType = TypeVar(
+    "TraceType",
+    bound=Trace[Any, Any],
+    default=Trace[InputType, OutputType],
+)
+
 
 @InteractionSpec.register("interact")
-class Interact[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
-    InteractionSpec[InputType, OutputType, TraceType]
+class Interact(
+    InteractionSpec[InputType, OutputType, TraceType],
+    Generic[InputType, OutputType, TraceType],
 ):
     """Defines how to interact with a system.
 

--- a/libs/giskard-checks/src/giskard/checks/core/interaction/interact.py
+++ b/libs/giskard-checks/src/giskard/checks/core/interaction/interact.py
@@ -4,21 +4,12 @@ from typing import Any, Generic, cast, override
 from giskard.checks.utils.injectable import ValueGenerator, ValueProvider
 from giskard.core.utils import NOT_PROVIDED, NotProvided
 from pydantic import Field, PrivateAttr, model_validator
-from typing_extensions import TypeVar
 
 from ..input_generator import InputGenerator
+from ..typevars import InputType, OutputType, TraceType
 from ..types import GeneratorType, ProviderType
 from .base import InteractionSpec
 from .interaction import Interaction
-from .trace import Trace
-
-InputType = TypeVar("InputType")
-OutputType = TypeVar("OutputType")
-TraceType = TypeVar(
-    "TraceType",
-    bound=Trace[Any, Any],
-    default=Trace[InputType, OutputType],
-)
 
 
 @InteractionSpec.register("interact")

--- a/libs/giskard-checks/src/giskard/checks/core/result.py
+++ b/libs/giskard-checks/src/giskard/checks/core/result.py
@@ -6,16 +6,8 @@ from pydantic import BaseModel, ConfigDict, Field, computed_field
 from rich.console import Console, ConsoleOptions, RenderResult
 from rich.panel import Panel
 from rich.rule import Rule
-from typing_extensions import TypeVar
-
-from .interaction import Trace
 from .protocols import RichConsoleProtocol, RichProtocol
-
-TraceType = TypeVar(
-    "TraceType",
-    bound=Trace[Any, Any],
-    default=Trace[Any, Any],
-)
+from .typevars import TraceType
 
 STATUS_MAPPING = {
     "total": {

--- a/libs/giskard-checks/src/giskard/checks/core/result.py
+++ b/libs/giskard-checks/src/giskard/checks/core/result.py
@@ -1,14 +1,21 @@
 from enum import Enum
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Generic
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field
 from rich.console import Console, ConsoleOptions, RenderResult
 from rich.panel import Panel
 from rich.rule import Rule
+from typing_extensions import TypeVar
 
 from .interaction import Trace
 from .protocols import RichConsoleProtocol, RichProtocol
+
+TraceType = TypeVar(
+    "TraceType",
+    bound=Trace[Any, Any],
+    default=Trace[Any, Any],
+)
 
 STATUS_MAPPING = {
     "total": {
@@ -220,7 +227,7 @@ class ScenarioStatus(str, Enum):
     SKIP = "skip"
 
 
-class ScenarioResult[TraceType: Trace](BaseResult, frozen=True):  # pyright: ignore[reportMissingTypeArgument]
+class ScenarioResult(BaseResult, Generic[TraceType], frozen=True):
     """Result of executing an entire scenario.
 
     Attributes

--- a/libs/giskard-checks/src/giskard/checks/core/scenario.py
+++ b/libs/giskard-checks/src/giskard/checks/core/scenario.py
@@ -1,7 +1,8 @@
-from typing import Any, Self
+from typing import Any, Generic, Self
 
 from giskard.core.utils import NOT_PROVIDED, NotProvided
 from pydantic import BaseModel, Field
+from typing_extensions import TypeVar
 
 from .check import Check
 from .input_generator import InputGenerator
@@ -9,8 +10,16 @@ from .interaction import Interact, InteractionSpec, Trace
 from .result import ScenarioResult
 from .types import GeneratorType, ProviderType
 
+InputType = TypeVar("InputType")
+OutputType = TypeVar("OutputType")
+TraceType = TypeVar(
+    "TraceType",
+    bound=Trace[Any, Any],
+    default=Trace[InputType, OutputType],
+)
 
-class Step[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: ignore[reportMissingTypeArgument]
+
+class Step(BaseModel, Generic[InputType, OutputType, TraceType]):
     """A scenario step: a sequence of interactions followed by checks.
 
     Each step corresponds to one TestCase at runtime: interactions are applied
@@ -27,7 +36,7 @@ class Step[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: igno
     )
 
 
-class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: ignore[reportMissingTypeArgument]
+class Scenario(BaseModel, Generic[InputType, OutputType, TraceType]):
     """A scenario composed of steps, each containing interacts and checks.
 
     A scenario executes steps sequentially, maintaining a shared trace that
@@ -112,7 +121,7 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
 
     def _append_step(self) -> Step[InputType, OutputType, TraceType]:
         """Append a new step."""
-        step = Step(interacts=[], checks=[])
+        step: Step[InputType, OutputType, TraceType] = Step(interacts=[], checks=[])
         self.steps.append(step)
         return step
 
@@ -165,7 +174,7 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
         Scenario
             Self for method chaining.
         """
-        interaction = Interact(
+        interaction: Interact[InputType, OutputType, TraceType] = Interact(
             inputs=inputs,
             outputs=outputs,
             metadata=metadata or {},

--- a/libs/giskard-checks/src/giskard/checks/core/scenario.py
+++ b/libs/giskard-checks/src/giskard/checks/core/scenario.py
@@ -2,21 +2,13 @@ from typing import Any, Generic, Self
 
 from giskard.core.utils import NOT_PROVIDED, NotProvided
 from pydantic import BaseModel, Field
-from typing_extensions import TypeVar
 
 from .check import Check
 from .input_generator import InputGenerator
 from .interaction import Interact, InteractionSpec, Trace
 from .result import ScenarioResult
+from .typevars import InputType, OutputType, TraceType
 from .types import GeneratorType, ProviderType
-
-InputType = TypeVar("InputType")
-OutputType = TypeVar("OutputType")
-TraceType = TypeVar(
-    "TraceType",
-    bound=Trace[Any, Any],
-    default=Trace[InputType, OutputType],
-)
 
 
 class Step(BaseModel, Generic[InputType, OutputType, TraceType]):

--- a/libs/giskard-checks/src/giskard/checks/core/testcase.py
+++ b/libs/giskard-checks/src/giskard/checks/core/testcase.py
@@ -6,15 +6,25 @@ execution to a `TestCaseRunner`. It offers a single `run()` method that returns 
 """
 
 from collections.abc import Sequence
+from typing import Any, Generic
 
 from pydantic import BaseModel, Field
+from typing_extensions import TypeVar
 
 from .check import Check
 from .interaction import Trace
 from .result import TestCaseResult
 
+InputType = TypeVar("InputType")
+OutputType = TypeVar("OutputType")
+TraceType = TypeVar(
+    "TraceType",
+    bound=Trace[Any, Any],
+    default=Trace[InputType, OutputType],
+)
 
-class TestCase[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: ignore[reportMissingTypeArgument]
+
+class TestCase(BaseModel, Generic[InputType, OutputType, TraceType]):
     """Bundle a trace with a set of checks to execute.
 
     **Note**: For most use cases, the fluent API (`Scenario(...).interact().check()`) is

--- a/libs/giskard-checks/src/giskard/checks/core/testcase.py
+++ b/libs/giskard-checks/src/giskard/checks/core/testcase.py
@@ -6,22 +6,13 @@ execution to a `TestCaseRunner`. It offers a single `run()` method that returns 
 """
 
 from collections.abc import Sequence
-from typing import Any, Generic
+from typing import Generic
 
 from pydantic import BaseModel, Field
-from typing_extensions import TypeVar
 
 from .check import Check
-from .interaction import Trace
 from .result import TestCaseResult
-
-InputType = TypeVar("InputType")
-OutputType = TypeVar("OutputType")
-TraceType = TypeVar(
-    "TraceType",
-    bound=Trace[Any, Any],
-    default=Trace[InputType, OutputType],
-)
+from .typevars import InputType, OutputType, TraceType
 
 
 class TestCase(BaseModel, Generic[InputType, OutputType, TraceType]):

--- a/libs/giskard-checks/src/giskard/checks/core/typevars.py
+++ b/libs/giskard-checks/src/giskard/checks/core/typevars.py
@@ -1,0 +1,13 @@
+from typing import Any
+
+from typing_extensions import TypeVar
+
+from .interaction.trace import Trace
+
+InputType = TypeVar("InputType")
+OutputType = TypeVar("OutputType")
+TraceType = TypeVar(
+    "TraceType",
+    bound=Trace[Any, Any],
+    default=Trace[InputType, OutputType],
+)

--- a/libs/giskard-checks/src/giskard/checks/generators/user.py
+++ b/libs/giskard-checks/src/giskard/checks/generators/user.py
@@ -1,12 +1,11 @@
 from collections.abc import AsyncGenerator
-from typing import Any, Generic
+from typing import Generic
 
 from pydantic import BaseModel, Field
-from typing_extensions import TypeVar
 
-from ..core import Trace
 from ..core.input_generator import InputGenerator
 from ..core.mixin import WithGeneratorMixin
+from ..core.typevars import TraceType
 
 
 class UserSimulatorOutput(BaseModel):
@@ -18,13 +17,6 @@ class UserSimulatorOutput(BaseModel):
         default=None,
         description="The message that the user would send. This should be None if goal_reached is True, otherwise it should contain the user's next message.",
     )
-
-
-TraceType = TypeVar(
-    "TraceType",
-    bound=Trace[Any, Any],
-    default=Trace[Any, Any],
-)
 
 
 @InputGenerator.register("user_simulator")

--- a/libs/giskard-checks/src/giskard/checks/generators/user.py
+++ b/libs/giskard-checks/src/giskard/checks/generators/user.py
@@ -1,6 +1,8 @@
 from collections.abc import AsyncGenerator
+from typing import Any, Generic
 
 from pydantic import BaseModel, Field
+from typing_extensions import TypeVar
 
 from ..core import Trace
 from ..core.input_generator import InputGenerator
@@ -18,9 +20,18 @@ class UserSimulatorOutput(BaseModel):
     )
 
 
+TraceType = TypeVar(
+    "TraceType",
+    bound=Trace[Any, Any],
+    default=Trace[Any, Any],
+)
+
+
 @InputGenerator.register("user_simulator")
-class UserSimulator[TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
-    InputGenerator[str, TraceType], WithGeneratorMixin
+class UserSimulator(
+    InputGenerator[str, TraceType],
+    WithGeneratorMixin,
+    Generic[TraceType],
 ):
     """User simulation with predefined or custom personas.
 

--- a/libs/giskard-checks/src/giskard/checks/judges/answer_relevance.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/answer_relevance.py
@@ -3,20 +3,12 @@ from typing import Any, Generic, override
 from giskard.agents.workflow import TemplateReference
 from giskard.core import provide_not_none
 from pydantic import Field
-from typing_extensions import TypeVar
 
-from ..core import Trace
 from ..core.check import Check
 from ..core.extraction import JSONPathStr, provided_or_resolve
+from ..core import Trace
+from ..core.typevars import InputType, OutputType, TraceType
 from .base import BaseLLMCheck
-
-InputType = TypeVar("InputType")
-OutputType = TypeVar("OutputType")
-TraceType = TypeVar(
-    "TraceType",
-    bound=Trace[Any, Any],
-    default=Trace[InputType, OutputType],
-)
 
 
 @Check.register("answer_relevance")

--- a/libs/giskard-checks/src/giskard/checks/judges/answer_relevance.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/answer_relevance.py
@@ -1,18 +1,28 @@
-from typing import Any, override
+from typing import Any, Generic, override
 
 from giskard.agents.workflow import TemplateReference
 from giskard.core import provide_not_none
 from pydantic import Field
+from typing_extensions import TypeVar
 
 from ..core import Trace
 from ..core.check import Check
 from ..core.extraction import JSONPathStr, provided_or_resolve
 from .base import BaseLLMCheck
 
+InputType = TypeVar("InputType")
+OutputType = TypeVar("OutputType")
+TraceType = TypeVar(
+    "TraceType",
+    bound=Trace[Any, Any],
+    default=Trace[InputType, OutputType],
+)
+
 
 @Check.register("answer_relevance")
-class AnswerRelevance[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
-    BaseLLMCheck[InputType, OutputType, TraceType]
+class AnswerRelevance(
+    BaseLLMCheck[InputType, OutputType, TraceType],
+    Generic[InputType, OutputType, TraceType],
 ):
     """LLM-based check that evaluates whether the model's answer is relevant to the question.
 

--- a/libs/giskard-checks/src/giskard/checks/judges/base.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/base.py
@@ -1,9 +1,10 @@
-from typing import Any, override
+from typing import Any, Generic, override
 
 from giskard.agents.chat import Message
 from giskard.agents.templates import MessageTemplate
 from giskard.agents.workflow import ChatWorkflow, TemplateReference
 from pydantic import BaseModel, Field
+from typing_extensions import TypeVar
 
 from ..core import Trace
 from ..core.check import Check
@@ -20,8 +21,19 @@ class LLMCheckResult(BaseModel):
     passed: bool = Field(..., description="Whether the check passed or failed")
 
 
-class BaseLLMCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
-    Check[InputType, OutputType, TraceType], WithGeneratorMixin
+InputType = TypeVar("InputType")
+OutputType = TypeVar("OutputType")
+TraceType = TypeVar(
+    "TraceType",
+    bound=Trace[Any, Any],
+    default=Trace[InputType, OutputType],
+)
+
+
+class BaseLLMCheck(
+    Check[InputType, OutputType, TraceType],
+    WithGeneratorMixin,
+    Generic[InputType, OutputType, TraceType],
 ):
     """Abstract base class for LLM-based checks.
 

--- a/libs/giskard-checks/src/giskard/checks/judges/base.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/base.py
@@ -4,12 +4,11 @@ from giskard.agents.chat import Message
 from giskard.agents.templates import MessageTemplate
 from giskard.agents.workflow import ChatWorkflow, TemplateReference
 from pydantic import BaseModel, Field
-from typing_extensions import TypeVar
 
-from ..core import Trace
 from ..core.check import Check
 from ..core.mixin import WithGeneratorMixin
 from ..core.result import CheckResult
+from ..core.typevars import InputType, OutputType, TraceType
 
 
 class LLMCheckResult(BaseModel):
@@ -19,15 +18,6 @@ class LLMCheckResult(BaseModel):
         default=None, description="Optional explanation for the result"
     )
     passed: bool = Field(..., description="Whether the check passed or failed")
-
-
-InputType = TypeVar("InputType")
-OutputType = TypeVar("OutputType")
-TraceType = TypeVar(
-    "TraceType",
-    bound=Trace[Any, Any],
-    default=Trace[InputType, OutputType],
-)
 
 
 class BaseLLMCheck(

--- a/libs/giskard-checks/src/giskard/checks/judges/conformity.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/conformity.py
@@ -1,16 +1,26 @@
-from typing import Any, override
+from typing import Any, Generic, override
 
 from giskard.agents.workflow import TemplateReference
 from pydantic import Field
+from typing_extensions import TypeVar
 
 from ..core import Trace
 from ..core.check import Check
 from .base import BaseLLMCheck
 
+InputType = TypeVar("InputType")
+OutputType = TypeVar("OutputType")
+TraceType = TypeVar(
+    "TraceType",
+    bound=Trace[Any, Any],
+    default=Trace[InputType, OutputType],
+)
+
 
 @Check.register("conformity")
-class Conformity[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
-    BaseLLMCheck[InputType, OutputType, TraceType]
+class Conformity(
+    BaseLLMCheck[InputType, OutputType, TraceType],
+    Generic[InputType, OutputType, TraceType],
 ):
     """LLM-based check that validates a trace against a given rule.
 

--- a/libs/giskard-checks/src/giskard/checks/judges/conformity.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/conformity.py
@@ -2,19 +2,11 @@ from typing import Any, Generic, override
 
 from giskard.agents.workflow import TemplateReference
 from pydantic import Field
-from typing_extensions import TypeVar
 
-from ..core import Trace
 from ..core.check import Check
+from ..core import Trace
+from ..core.typevars import InputType, OutputType, TraceType
 from .base import BaseLLMCheck
-
-InputType = TypeVar("InputType")
-OutputType = TypeVar("OutputType")
-TraceType = TypeVar(
-    "TraceType",
-    bound=Trace[Any, Any],
-    default=Trace[InputType, OutputType],
-)
 
 
 @Check.register("conformity")

--- a/libs/giskard-checks/src/giskard/checks/judges/groundedness.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/groundedness.py
@@ -3,20 +3,12 @@ from typing import Any, Generic, override
 from giskard.agents.workflow import TemplateReference
 from giskard.core import provide_not_none
 from pydantic import Field
-from typing_extensions import TypeVar
 
-from ..core import Trace
 from ..core.check import Check
 from ..core.extraction import JSONPathStr, provided_or_resolve
+from ..core import Trace
+from ..core.typevars import InputType, OutputType, TraceType
 from .base import BaseLLMCheck
-
-InputType = TypeVar("InputType")
-OutputType = TypeVar("OutputType")
-TraceType = TypeVar(
-    "TraceType",
-    bound=Trace[Any, Any],
-    default=Trace[InputType, OutputType],
-)
 
 
 @Check.register("groundedness")

--- a/libs/giskard-checks/src/giskard/checks/judges/groundedness.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/groundedness.py
@@ -1,18 +1,28 @@
-from typing import override
+from typing import Any, Generic, override
 
 from giskard.agents.workflow import TemplateReference
 from giskard.core import provide_not_none
 from pydantic import Field
+from typing_extensions import TypeVar
 
 from ..core import Trace
 from ..core.check import Check
 from ..core.extraction import JSONPathStr, provided_or_resolve
 from .base import BaseLLMCheck
 
+InputType = TypeVar("InputType")
+OutputType = TypeVar("OutputType")
+TraceType = TypeVar(
+    "TraceType",
+    bound=Trace[Any, Any],
+    default=Trace[InputType, OutputType],
+)
+
 
 @Check.register("groundedness")
-class Groundedness[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
-    BaseLLMCheck[InputType, OutputType, TraceType]
+class Groundedness(
+    BaseLLMCheck[InputType, OutputType, TraceType],
+    Generic[InputType, OutputType, TraceType],
 ):
     """LLM-based check that validates answers are grounded in context.
 

--- a/libs/giskard-checks/src/giskard/checks/judges/judge.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/judge.py
@@ -1,22 +1,13 @@
-from typing import Any, Generic, Self, override
+from typing import Generic, Self, override
 
 from giskard.agents.chat import Message
 from giskard.agents.templates import MessageTemplate
 from giskard.agents.workflow import TemplateReference
 from pydantic import Field, model_validator
-from typing_extensions import TypeVar
 
-from ..core import Trace
 from ..core.check import Check
+from ..core.typevars import InputType, OutputType, TraceType
 from .base import BaseLLMCheck
-
-InputType = TypeVar("InputType")
-OutputType = TypeVar("OutputType")
-TraceType = TypeVar(
-    "TraceType",
-    bound=Trace[Any, Any],
-    default=Trace[InputType, OutputType],
-)
 
 
 @Check.register("llm_judge")

--- a/libs/giskard-checks/src/giskard/checks/judges/judge.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/judge.py
@@ -1,18 +1,28 @@
-from typing import Self, override
+from typing import Any, Generic, Self, override
 
 from giskard.agents.chat import Message
 from giskard.agents.templates import MessageTemplate
 from giskard.agents.workflow import TemplateReference
 from pydantic import Field, model_validator
+from typing_extensions import TypeVar
 
 from ..core import Trace
 from ..core.check import Check
 from .base import BaseLLMCheck
 
+InputType = TypeVar("InputType")
+OutputType = TypeVar("OutputType")
+TraceType = TypeVar(
+    "TraceType",
+    bound=Trace[Any, Any],
+    default=Trace[InputType, OutputType],
+)
+
 
 @Check.register("llm_judge")
-class LLMJudge[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
-    BaseLLMCheck[InputType, OutputType, TraceType]
+class LLMJudge(
+    BaseLLMCheck[InputType, OutputType, TraceType],
+    Generic[InputType, OutputType, TraceType],
 ):
     """LLM-based check that evaluates interactions using a custom prompt.
 

--- a/libs/giskard-checks/src/giskard/checks/judges/toxicity.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/toxicity.py
@@ -3,11 +3,11 @@ from typing import Any, Generic, Literal, override
 from giskard.agents.workflow import TemplateReference
 from giskard.core import provide_not_none
 from pydantic import Field
-from typing_extensions import TypeVar
 
-from ..core import Trace
 from ..core.check import Check
 from ..core.extraction import JSONPathStr, provided_or_resolve
+from ..core import Trace
+from ..core.typevars import InputType, OutputType, TraceType
 from .base import BaseLLMCheck
 
 ToxicityCategory = Literal[
@@ -27,15 +27,6 @@ DEFAULT_TOXICITY_CATEGORIES: tuple[ToxicityCategory, ...] = (
     "sexual_content",
     "violence",
 )
-
-InputType = TypeVar("InputType")
-OutputType = TypeVar("OutputType")
-TraceType = TypeVar(
-    "TraceType",
-    bound=Trace[Any, Any],
-    default=Trace[InputType, OutputType],
-)
-
 
 @Check.register("toxicity")
 class Toxicity(

--- a/libs/giskard-checks/src/giskard/checks/judges/toxicity.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/toxicity.py
@@ -1,8 +1,9 @@
-from typing import Any, Literal, override
+from typing import Any, Generic, Literal, override
 
 from giskard.agents.workflow import TemplateReference
 from giskard.core import provide_not_none
 from pydantic import Field
+from typing_extensions import TypeVar
 
 from ..core import Trace
 from ..core.check import Check
@@ -27,10 +28,19 @@ DEFAULT_TOXICITY_CATEGORIES: tuple[ToxicityCategory, ...] = (
     "violence",
 )
 
+InputType = TypeVar("InputType")
+OutputType = TypeVar("OutputType")
+TraceType = TypeVar(
+    "TraceType",
+    bound=Trace[Any, Any],
+    default=Trace[InputType, OutputType],
+)
+
 
 @Check.register("toxicity")
-class Toxicity[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
-    BaseLLMCheck[InputType, OutputType, TraceType]
+class Toxicity(
+    BaseLLMCheck[InputType, OutputType, TraceType],
+    Generic[InputType, OutputType, TraceType],
 ):
     """LLM-based check that detects toxic, harmful, or offensive content.
 

--- a/libs/giskard-checks/src/giskard/checks/testing/runner.py
+++ b/libs/giskard-checks/src/giskard/checks/testing/runner.py
@@ -1,7 +1,9 @@
 import time
 import traceback
+from typing import Any
 
 from giskard.core import scoped_telemetry, telemetry, telemetry_tag
+from typing_extensions import TypeVar
 
 from .._telemetry_props import (
     check_kind_counts_from_sequence,
@@ -12,12 +14,12 @@ from ..core.check import Check
 from ..core.result import CheckResult, TestCaseResult
 from ..core.testcase import TestCase
 
+InputType = TypeVar("InputType")
+OutputType = TypeVar("OutputType")
+TraceType = TypeVar("TraceType", bound=Trace[Any, Any])
 
-async def _run_check[
-    InputType,
-    OutputType,
-    TraceType: Trace,  # pyright: ignore[reportMissingTypeArgument]
-](
+
+async def _run_check(
     trace: TraceType,
     check: Check[InputType, OutputType, TraceType],
     return_exception: bool = False,
@@ -57,7 +59,7 @@ class TestCaseRunner:
         pass
 
     @scoped_telemetry
-    async def run[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
+    async def run(
         self,
         test_case: TestCase[InputType, OutputType, TraceType],
         return_exception: bool = False,

--- a/libs/giskard-checks/src/giskard/checks/testing/runner.py
+++ b/libs/giskard-checks/src/giskard/checks/testing/runner.py
@@ -1,22 +1,13 @@
 import time
 import traceback
-from typing import Any
 
 from giskard.core import scoped_telemetry, telemetry_capture, telemetry_tag
-from typing_extensions import TypeVar
 
-from .._telemetry_props import (
-    check_kind_counts_from_sequence,
-    test_case_shape_properties,
-)
-from ..core import Trace
+from .._telemetry_props import check_kind_counts_from_sequence, test_case_shape_properties
 from ..core.check import Check
 from ..core.result import CheckResult, TestCaseResult
 from ..core.testcase import TestCase
-
-InputType = TypeVar("InputType")
-OutputType = TypeVar("OutputType")
-TraceType = TypeVar("TraceType", bound=Trace[Any, Any])
+from ..core.typevars import InputType, OutputType, TraceType
 
 
 async def _run_check(

--- a/libs/giskard-checks/src/giskard/checks/testing/spy.py
+++ b/libs/giskard-checks/src/giskard/checks/testing/spy.py
@@ -1,19 +1,9 @@
 from collections.abc import AsyncGenerator
-from typing import Any, Generic, override
+from typing import Generic, override
 from unittest.mock import MagicMock, patch
 
-from typing_extensions import TypeVar
-
-from ..core import Trace
 from ..core.interaction import Interaction, InteractionSpec
-
-InputType = TypeVar("InputType")
-OutputType = TypeVar("OutputType")
-TraceType = TypeVar(
-    "TraceType",
-    bound=Trace[Any, Any],
-    default=Trace[InputType, OutputType],
-)
+from ..core.typevars import InputType, OutputType, TraceType
 
 
 @InteractionSpec.register("with_spy")

--- a/libs/giskard-checks/src/giskard/checks/testing/spy.py
+++ b/libs/giskard-checks/src/giskard/checks/testing/spy.py
@@ -1,14 +1,25 @@
 from collections.abc import AsyncGenerator
-from typing import override
+from typing import Any, Generic, override
 from unittest.mock import MagicMock, patch
+
+from typing_extensions import TypeVar
 
 from ..core import Trace
 from ..core.interaction import Interaction, InteractionSpec
 
+InputType = TypeVar("InputType")
+OutputType = TypeVar("OutputType")
+TraceType = TypeVar(
+    "TraceType",
+    bound=Trace[Any, Any],
+    default=Trace[InputType, OutputType],
+)
+
 
 @InteractionSpec.register("with_spy")
-class WithSpy[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
-    InteractionSpec[InputType, OutputType, TraceType]
+class WithSpy(
+    InteractionSpec[InputType, OutputType, TraceType],
+    Generic[InputType, OutputType, TraceType],
 ):
     interaction_generator: InteractionSpec[InputType, OutputType, TraceType]
     target: str

--- a/libs/giskard-checks/tests/core/test_scenario.py
+++ b/libs/giskard-checks/tests/core/test_scenario.py
@@ -1180,12 +1180,17 @@ class TestScenarioExtendAndSerialization:
 
     async def test_scenario_with_steps_constructor(self):
         """Scenario can be built with explicit Step objects."""
-        scenario = Scenario(
+        scenario: Scenario[str, str, Trace[str, str]] = Scenario(
             name="steps_constructor",
             steps=[
-                Step(
+                Step[str, str, Trace[str, str]](
                     interacts=[Interact(inputs="Hello", outputs="Hi")],
-                    checks=[Equals(expected_value="Hi", key="trace.last.outputs")],
+                    checks=[
+                        Equals[str, str, Trace[str, str]](
+                            expected_value="Hi",
+                            key="trace.last.outputs",
+                        )
+                    ],
                 ),
             ],
         )

--- a/libs/giskard-checks/tests/scenarios/test_testcase.py
+++ b/libs/giskard-checks/tests/scenarios/test_testcase.py
@@ -28,11 +28,11 @@ class TestTestCaseNormalCases:
         trace = await Trace.from_interactions(
             Interaction(inputs="test_input", outputs="test_output")
         )
-        check = Equals(
+        check: Equals[str, str, Trace[str, str]] = Equals(
             expected_value="test_output",
             key="trace.interactions[-1].outputs",
         )
-        test_case = TestCase(
+        test_case: TestCase[str, str, Trace[str, str]] = TestCase(
             name="single_check",
             trace=trace,
             checks=[check],


### PR DESCRIPTION
  Hey @kevinmessiaen  #2410 
## What changed

  This updates `giskard-checks` generic base classes and related helpers to
  use module-local `typing_extensions.TypeVar(..., default=...)` defaults
  instead of relying on PEP 695 bounded parameters plus `# pyright:
  ignore[reportMissingTypeArgument]`.

  The change was applied across:
  - core check/scenario/testcase/result/input generator abstractions
  - interaction specs and helpers

- builtin checks such as composition, comparison, text matching, semantic
  similarity, and function-backed checks
  - LLM judges and user simulator helpers
  - test runner and spy utilities

  ## Why

  Issue #2410 identified that bounded generic parameters like `TraceType:
  Trace` forced callers to spell out all type arguments or rely on pyright
  suppressions. That created noise in the codebase and degraded ergonomics
  for common usages like:

  - `Check()`
  - `Scenario()`
  - `TestCase()`
  - `Interact()`
  - builtin combinators and judges without explicit generic arguments

  Using `TypeVar(default=...)` restores the intended typing behavior while
  keeping runtime behavior unchanged.

  ## Root cause

  PEP 695 native generic syntax supports bounds but does not support default
  type parameters. Because of that, classes using bounded `TraceType`
  parameters could not express the natural default of `Trace[InputType,
  OutputType]`, and the codebase had accumulated `reportMissingTypeArgument`
  suppressions as a workaround.

  ## Impact

  - callers can omit bounded trace type parameters in the common case
  - pyright suppressions for missing type arguments are no longer needed in
  the updated `giskard-checks` surface
  - public APIs remain the same from a runtime perspective
  - this is a typing-only ergonomics improvement; serialization and runtime
  behavior are unchanged

  ## Validation

  - `uv tool run basedpyright --level error libs/giskard-checks/src libs/
  giskard-checks/tests`
  - `uv run pytest libs/giskard-checks -m "not functional"`
  - `uv tool run ruff check libs/giskard-checks/src libs/giskard-checks/
  tests`
  - `uv tool run ruff format --check libs/giskard-checks/src libs/giskard-
  checks/tests`

  Results:
  - basedpyright: passed
  - pytest: `469 passed, 4 skipped`
  - ruff check: passed
  - ruff format check: passed