### PR TITLE
fix(agents): surface unknown tool calls

### DIFF
--- a/libs/giskard-agents/src/giskard/agents/workflow.py
+++ b/libs/giskard-agents/src/giskard/agents/workflow.py
@@ -174,7 +174,9 @@ class _StepRunner:
 
         for tool_call in chat.last.tool_calls:
             if tool_call.function.name not in self._workflow.tools:
-                continue  # TODO: raise an error?
+                raise WorkflowError(
+                    f"Unknown tool call requested by generator: {tool_call.function.name}"
+                )
 
             tool = self._workflow.tools[tool_call.function.name]
             tool_content = await tool.run(
@@ -468,6 +470,10 @@ class ChatWorkflow(BaseModel, Generic[OutputType]):
     ) -> Chat[OutputType]:
         # Raise an error if the error mode is RAISE.
         if self.error_policy == ErrorPolicy.RAISE:
+            if isinstance(err, WorkflowError):
+                if err.last_step is None:
+                    err.last_step = last_step
+                raise err
             raise WorkflowError(
                 "Step processing failed",
                 last_step=last_step,

--- a/libs/giskard-agents/tests/test_workflow_error_handling.py
+++ b/libs/giskard-agents/tests/test_workflow_error_handling.py
@@ -5,7 +5,14 @@ import pytest
 from giskard import agents
 from giskard.agents.errors import WorkflowError
 from giskard.agents.workflow import ErrorPolicy
-from giskard.llm.types import AssistantMessage, ChatMessage, Choice, CompletionResponse
+from giskard.llm.types import (
+    AssistantMessage,
+    ChatMessage,
+    Choice,
+    CompletionResponse,
+    ToolCall,
+    ToolCallFunction,
+)
 from pydantic import Field, PrivateAttr
 
 
@@ -62,6 +69,40 @@ async def test_run_skips_error():
     assert chat.last.content == "Hello!"
     assert chat.last.role == "user"
     assert chat.failed
+
+
+async def test_unknown_tool_call_raises_error():
+    class UnknownToolGenerator(agents.generators.BaseGenerator):
+        @override
+        async def _call_model(
+            self,
+            messages: Sequence[ChatMessage],
+            params: agents.generators.GenerationParams,
+            metadata: dict[str, Any] | None = None,
+        ) -> CompletionResponse:
+            return CompletionResponse(
+                choices=[
+                    Choice(
+                        message=AssistantMessage(
+                            tool_calls=[
+                                ToolCall(
+                                    id="tc_unknown",
+                                    function=ToolCallFunction(
+                                        name="missing_tool", arguments={}
+                                    ),
+                                )
+                            ]
+                        ),
+                        finish_reason="tool_calls",
+                        index=0,
+                    )
+                ]
+            )
+
+    workflow = agents.ChatWorkflow(generator=UnknownToolGenerator())
+
+    with pytest.raises(WorkflowError, match="Unknown tool call requested by generator"):
+        _ = await workflow.chat("Hello!", role="user").run()
 
 
 async def test_run_many_raises_error():


### PR DESCRIPTION
## Summary
- raise a WorkflowError when a generator requests an unregistered tool
- preserve explicit WorkflowError messages instead of rewrapping them as a generic step failure
- add coverage for the unknown-tool path

## Testing
- uv run pytest libs/giskard-agents/tests/test_workflow_error_handling.py -q

Closes #2413