### PR TITLE
checks: support pydantic-compatible input types

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/core/input_generator.py
+++ b/libs/giskard-checks/src/giskard/checks/core/input_generator.py
@@ -1,5 +1,5 @@
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, Any, overload
 
 from giskard.core import Discriminated, discriminated_base
 from pydantic import BaseModel
@@ -18,7 +18,11 @@ class InputGenerator[TraceType: "Trace"](Discriminated):  # pyright: ignore[repo
     def __call__[T: BaseModel](
         self, trace: TraceType, input_type: type[T]
     ) -> AsyncGenerator[T, TraceType]: ...
+    @overload
+    def __call__[T](
+        self, trace: TraceType, input_type: T
+    ) -> AsyncGenerator[Any, TraceType]: ...
     def __call__(
-        self, trace: TraceType, input_type: type[str | BaseModel] | None = None
-    ) -> AsyncGenerator[str | BaseModel, TraceType]:
+        self, trace: TraceType, input_type: Any | None = None
+    ) -> AsyncGenerator[Any, TraceType]:
         raise NotImplementedError

--- a/libs/giskard-checks/src/giskard/checks/core/input_generator.py
+++ b/libs/giskard-checks/src/giskard/checks/core/input_generator.py
@@ -20,9 +20,9 @@ class InputGenerator[TraceType: "Trace"](Discriminated):  # pyright: ignore[repo
     ) -> AsyncGenerator[T, TraceType]: ...
     @overload
     def __call__[T](
-        self, trace: TraceType, input_type: T
-    ) -> AsyncGenerator[Any, TraceType]: ...
+        self, trace: TraceType, input_type: type[T]
+    ) -> AsyncGenerator[T, TraceType]: ...
     def __call__(
-        self, trace: TraceType, input_type: Any | None = None
+        self, trace: TraceType, input_type: type[Any] | None = None
     ) -> AsyncGenerator[Any, TraceType]:
         raise NotImplementedError

--- a/libs/giskard-checks/src/giskard/checks/core/interaction/interact.py
+++ b/libs/giskard-checks/src/giskard/checks/core/interaction/interact.py
@@ -13,12 +13,13 @@ from .interaction import Interaction
 from .trace import Trace
 
 
-def _infer_input_type(outputs: object) -> Any | None:
+def _infer_input_type(outputs: object) -> type | None:
     """Infer the input type from the first parameter annotation of a callable.
 
-    Returns any pydantic-compatible type except ``str``, which is the default
-    generator type. Returns ``None`` for non-callables and callables whose hints
-    cannot be resolved (e.g. forward references to undefined names).
+    Returns any pydantic-compatible type, including ``str``. Returns ``None``
+    for non-callables, callables with no annotation, and callables whose hints
+    cannot be resolved (e.g. forward references to undefined names) or whose
+    type is not supported by Pydantic.
     """
     if not callable(outputs):
         return None

--- a/libs/giskard-checks/src/giskard/checks/core/interaction/interact.py
+++ b/libs/giskard-checks/src/giskard/checks/core/interaction/interact.py
@@ -4,8 +4,7 @@ from typing import Any, cast, get_type_hints, override
 
 from giskard.checks.utils.injectable import ValueGenerator, ValueProvider
 from giskard.core.utils import NOT_PROVIDED, NotProvided
-from pydantic import BaseModel as PydanticBaseModel
-from pydantic import Field, PrivateAttr, model_validator
+from pydantic import Field, PrivateAttr, TypeAdapter, model_validator
 
 from ..input_generator import InputGenerator
 from ..types import GeneratorType, ProviderType
@@ -14,11 +13,11 @@ from .interaction import Interaction
 from .trace import Trace
 
 
-def _infer_input_type(outputs: object) -> type | None:
+def _infer_input_type(outputs: object) -> Any | None:
     """Infer the input type from the first parameter annotation of a callable.
 
-    Returns the type if it is a subclass of ``pydantic.BaseModel``, otherwise
-    ``None``.  Returns ``None`` for non-callables and callables whose hints
+    Returns any pydantic-compatible type except ``str``, which is the default
+    generator type. Returns ``None`` for non-callables and callables whose hints
     cannot be resolved (e.g. forward references to undefined names).
     """
     if not callable(outputs):
@@ -48,11 +47,13 @@ def _infer_input_type(outputs: object) -> type | None:
     if not param_hints:
         return None
     first_param_type = next(iter(param_hints.values()))
-    if isinstance(first_param_type, type) and issubclass(
-        first_param_type, PydanticBaseModel
-    ):
-        return first_param_type
-    return None
+    if first_param_type is str:
+        return None
+    try:
+        TypeAdapter(first_param_type)
+    except Exception:
+        return None
+    return first_param_type
 
 
 @InteractionSpec.register("interact")

--- a/libs/giskard-checks/src/giskard/checks/core/interaction/interact.py
+++ b/libs/giskard-checks/src/giskard/checks/core/interaction/interact.py
@@ -4,7 +4,7 @@ from typing import Any, cast, get_type_hints, override
 
 from giskard.checks.utils.injectable import ValueGenerator, ValueProvider
 from giskard.core.utils import NOT_PROVIDED, NotProvided
-from pydantic import Field, PrivateAttr, TypeAdapter, model_validator
+from pydantic import Field, PrivateAttr, PydanticUserError, TypeAdapter, model_validator
 
 from ..input_generator import InputGenerator
 from ..types import GeneratorType, ProviderType
@@ -47,11 +47,11 @@ def _infer_input_type(outputs: object) -> Any | None:
     if not param_hints:
         return None
     first_param_type = next(iter(param_hints.values()))
-    if first_param_type is str:
-        return None
     try:
         TypeAdapter(first_param_type)
-    except Exception:
+    except (PydanticUserError, TypeError):
+        # PydanticUserError: Raised if the type is not supported by Pydantic
+        # TypeError: Raised if first_param_type isn't a valid "type" (e.g. an instance)
         return None
     return first_param_type
 

--- a/libs/giskard-checks/src/giskard/checks/generators/base.py
+++ b/libs/giskard-checks/src/giskard/checks/generators/base.py
@@ -5,7 +5,7 @@ from giskard.agents.templates import MessageTemplate
 from giskard.agents.workflow import ChatWorkflow, TemplateReference
 from giskard.llm import chat
 from giskard.llm.types import ChatMessage
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, TypeAdapter, model_validator
 
 from ..core import Trace
 from ..core.exceptions import InputGenerationException
@@ -13,7 +13,7 @@ from ..core.input_generator import InputGenerator
 from ..core.mixin import WithGeneratorMixin
 
 
-class LLMGeneratorOutput[T: str | BaseModel](BaseModel):
+class LLMGeneratorOutput[T](BaseModel):
     goal_reached: bool = Field(
         ...,
         description="Whether the goal has been reached and no more messages are needed.",
@@ -56,9 +56,10 @@ class BaseLLMGenerator[TraceType: Trace](  # pyright: ignore[reportMissingTypeAr
 
     @override
     async def __call__(
-        self, trace: TraceType, input_type: type[str | BaseModel] | None = None
+        self, trace: TraceType, input_type: Any | None = None
     ) -> AsyncGenerator[Any, TraceType]:
         T = input_type or str
+        TypeAdapter(T)
         prompt = self.get_prompt()
 
         if isinstance(prompt, TemplateReference):

--- a/libs/giskard-checks/src/giskard/checks/generators/base.py
+++ b/libs/giskard-checks/src/giskard/checks/generators/base.py
@@ -5,7 +5,7 @@ from giskard.agents.templates import MessageTemplate
 from giskard.agents.workflow import ChatWorkflow, TemplateReference
 from giskard.llm import chat
 from giskard.llm.types import ChatMessage
-from pydantic import BaseModel, Field, TypeAdapter, model_validator
+from pydantic import BaseModel, Field, model_validator
 
 from ..core import Trace
 from ..core.exceptions import InputGenerationException
@@ -56,7 +56,7 @@ class BaseLLMGenerator[TraceType: Trace](  # pyright: ignore[reportMissingTypeAr
 
     @override
     async def __call__(
-        self, trace: TraceType, input_type: Any | None = None
+        self, trace: TraceType, input_type: type[Any] | None = None
     ) -> AsyncGenerator[Any, TraceType]:
         T = input_type or str
         prompt = self.get_prompt()

--- a/libs/giskard-checks/src/giskard/checks/generators/base.py
+++ b/libs/giskard-checks/src/giskard/checks/generators/base.py
@@ -59,7 +59,6 @@ class BaseLLMGenerator[TraceType: Trace](  # pyright: ignore[reportMissingTypeAr
         self, trace: TraceType, input_type: Any | None = None
     ) -> AsyncGenerator[Any, TraceType]:
         T = input_type or str
-        TypeAdapter(T)
         prompt = self.get_prompt()
 
         if isinstance(prompt, TemplateReference):

--- a/libs/giskard-checks/tests/core/test_input_generator.py
+++ b/libs/giskard-checks/tests/core/test_input_generator.py
@@ -18,11 +18,11 @@ class MyModel(BaseModel):
 
 @InputGenerator.register("test_typed_generator")
 class TypedGenerator(InputGenerator[ConcreteTrace]):
-    received_input_type: type | None = None
+    received_input_type: Any | None = None
 
     @override
     async def __call__(
-        self, trace: ConcreteTrace, input_type: type[str | BaseModel] | None = None
+        self, trace: ConcreteTrace, input_type: Any | None = None
     ) -> AsyncGenerator[Any, ConcreteTrace]:
         self.received_input_type = input_type
 

--- a/libs/giskard-checks/tests/core/test_input_generator.py
+++ b/libs/giskard-checks/tests/core/test_input_generator.py
@@ -18,11 +18,11 @@ class MyModel(BaseModel):
 
 @InputGenerator.register("test_typed_generator")
 class TypedGenerator(InputGenerator[ConcreteTrace]):
-    received_input_type: Any | None = None
+    received_input_type: type[Any] | None = None
 
     @override
     async def __call__(
-        self, trace: ConcreteTrace, input_type: Any | None = None
+        self, trace: ConcreteTrace, input_type: type[Any] | None = None
     ) -> AsyncGenerator[Any, ConcreteTrace]:
         self.received_input_type = input_type
 

--- a/libs/giskard-checks/tests/core/test_input_type_inference.py
+++ b/libs/giskard-checks/tests/core/test_input_type_inference.py
@@ -23,11 +23,11 @@ def test_infer_returns_none_for_callable_with_no_annotation():
     assert _infer_input_type(lambda x: x) is None
 
 
-def test_infer_returns_none_for_str_annotated_callable():
+def test_infer_returns_str_for_str_annotated_callable():
     def target(input: str) -> str:
         return input
 
-    assert _infer_input_type(target) is None
+    assert _infer_input_type(target) is str
 
 
 def test_infer_returns_base_model_type():
@@ -80,12 +80,36 @@ def test_infer_returns_base_model_type_for_callable_class():
     assert _infer_input_type(AgentAdapter()) is MyModel
 
 
-def test_infer_returns_none_for_callable_class_with_str_annotation():
+def test_infer_returns_str_for_callable_class_with_str_annotation():
     class AgentAdapter:
         def __call__(self, input: str) -> str:
             return input
 
-    assert _infer_input_type(AgentAdapter()) is None
+    assert _infer_input_type(AgentAdapter()) is str
+
+
+def test_infer_returns_none_for_pydantic_incompatible_type():
+    def target(input: object) -> str:  # type: ignore[misc]
+        return str(input)
+
+    # get_type_hints returns `object` which TypeAdapter handles fine;
+    # use an actual instance (not a type) to trigger a TypeError path.
+    class NotAType:
+        pass
+
+    not_a_type_instance = NotAType()
+
+    # Patch first_param_type to be an instance rather than a type to verify
+    # the TypeError branch: call _infer_input_type on a callable whose annotation
+    # resolves to an instance value isn't directly testable via normal hints.
+    # Instead, verify via a class with __annotations__ that produces a non-type value.
+    class WeirdCallable:
+        __annotations__ = {"input": not_a_type_instance}  # type: ignore[assignment]
+
+        def __call__(self, input):
+            return str(input)
+
+    assert _infer_input_type(WeirdCallable()) is None
 
 
 # --- Integration: Interact forwards input_type to InputGenerator ---
@@ -98,7 +122,7 @@ class RecordingTrace(Trace[str, str], frozen=True):
 
 @InputGenerator.register("recording_generator")
 class RecordingGenerator(InputGenerator[RecordingTrace]):
-    received_input_type: Any | None = None
+    received_input_type: type[Any] | None = None
 
     @override
     async def __call__(
@@ -123,7 +147,7 @@ async def test_interact_forwards_base_model_input_type_to_generator():
 
 
 @pytest.mark.asyncio
-async def test_interact_passes_none_input_type_for_str_annotated_target():
+async def test_interact_passes_str_input_type_for_str_annotated_target():
     gen = RecordingGenerator()
 
     def target(inputs: str) -> str:
@@ -133,7 +157,7 @@ async def test_interact_passes_none_input_type_for_str_annotated_target():
     trace = RecordingTrace()
     agen = interact.generate(trace)
     await anext(agen)
-    assert gen.received_input_type is None
+    assert gen.received_input_type is str
 
 
 @pytest.mark.asyncio

--- a/libs/giskard-checks/tests/core/test_input_type_inference.py
+++ b/libs/giskard-checks/tests/core/test_input_type_inference.py
@@ -37,6 +37,34 @@ def test_infer_returns_base_model_type():
     assert _infer_input_type(target) is MyModel
 
 
+def test_infer_returns_list_type():
+    def target(input: list[str]) -> str:
+        return ", ".join(input)
+
+    assert _infer_input_type(target) == list[str]
+
+
+def test_infer_returns_int_type():
+    def target(input: int) -> str:
+        return str(input)
+
+    assert _infer_input_type(target) is int
+
+
+def test_infer_returns_dict_type():
+    def target(input: dict[str, Any]) -> str:
+        return str(input)
+
+    assert _infer_input_type(target) == dict[str, Any]
+
+
+def test_infer_returns_optional_base_model_type():
+    def target(input: MyModel | None) -> str:
+        return "" if input is None else input.content
+
+    assert _infer_input_type(target) == MyModel | None
+
+
 def test_infer_returns_none_for_forward_ref_that_cannot_resolve():
     def target(input: "UnresolvableType") -> str:  # noqa: F821 # pyright: ignore[reportUndefinedVariable]
         return str(input)
@@ -70,7 +98,7 @@ class RecordingTrace(Trace[str, str], frozen=True):
 
 @InputGenerator.register("recording_generator")
 class RecordingGenerator(InputGenerator[RecordingTrace]):
-    received_input_type: type | None = None
+    received_input_type: Any | None = None
 
     @override
     async def __call__(
@@ -106,3 +134,17 @@ async def test_interact_passes_none_input_type_for_str_annotated_target():
     agen = interact.generate(trace)
     await anext(agen)
     assert gen.received_input_type is None
+
+
+@pytest.mark.asyncio
+async def test_interact_forwards_list_input_type_to_generator():
+    gen = RecordingGenerator()
+
+    def target(inputs: list[str]) -> str:
+        return ", ".join(inputs)
+
+    interact = Interact(inputs=gen, outputs=target)
+    trace = RecordingTrace()
+    agen = interact.generate(trace)
+    await anext(agen)
+    assert gen.received_input_type == list[str]

--- a/libs/giskard-checks/tests/generators/test_llm_generator.py
+++ b/libs/giskard-checks/tests/generators/test_llm_generator.py
@@ -156,6 +156,40 @@ async def test_llm_generator_produces_base_model_when_input_type_provided():
 
 
 @pytest.mark.asyncio
+async def test_llm_generator_yields_list_when_input_type_is_list():
+    mock_gen = MockGenerator(
+        responses=[
+            {
+                "goal_reached": False,
+                "schema_issue": None,
+                "message": ["hello", "there"],
+            },
+        ]
+    )
+    gen = LLMGenerator(generator=mock_gen, prompt="Say hello.", max_steps=1)
+    trace = LLMTrace()
+    agen = gen(trace, input_type=list[str])
+    msg = await anext(agen)
+    assert msg == ["hello", "there"]
+    assert isinstance(msg, list)
+
+
+@pytest.mark.asyncio
+async def test_llm_generator_yields_int_when_input_type_is_int():
+    mock_gen = MockGenerator(
+        responses=[
+            {"goal_reached": False, "schema_issue": None, "message": 7},
+        ]
+    )
+    gen = LLMGenerator(generator=mock_gen, prompt="Pick a number.", max_steps=1)
+    trace = LLMTrace()
+    agen = gen(trace, input_type=int)
+    msg = await anext(agen)
+    assert msg == 7
+    assert isinstance(msg, int)
+
+
+@pytest.mark.asyncio
 async def test_llm_generator_raises_on_schema_issue():
     mock_gen = MockGenerator(
         responses=[


### PR DESCRIPTION
  Closes #2449

  ## Summary
  - Broaden `_infer_input_type` to return Pydantic-compatible annotations beyond `BaseModel`
  - Relax `InputGenerator.__call__` and `LLMGeneratorOutput` typing for non-BaseModel inputs
  - Validate generator input types with Pydantic `TypeAdapter`
  - Add tests for `list[str]`, `int`, `dict[str, Any]`, and `MyModel | None`

  ## Testing
  - `uv run -m pytest -q libs/giskard-checks/tests/core/test_input_type_inference.py libs/giskard-checks/tests/core/
  test_input_generator.py libs/giskard-checks/tests/generators/test_llm_generator.py`
  - `uv run ruff check ...`
  - `uv run basedpyright ...`