### PR TITLE
fix: export ResponseFunctionToolCall 🤖🤖🤖🤖

### DIFF
--- a/libs/giskard-llm/src/giskard/llm/__init__.py
+++ b/libs/giskard-llm/src/giskard/llm/__init__.py
@@ -23,6 +23,7 @@ from .types import (
     EmbeddingUsage,
     FunctionCallOutputParam,
     FunctionDefParam,
+    ResponseFunctionToolCall,
     ResponseOutputItem,
     ResponseOutputText,
     ResponseResult,
@@ -66,7 +67,7 @@ __all__ = [
     # Types — Response
     "ResponseResult",
     "ResponseOutputText",
-    "ResponseOutputFunctionCall",
+    "ResponseFunctionToolCall",
     "ResponseOutputItem",
     # Errors
     "LLMError",

--- a/libs/giskard-llm/tests/test_types.py
+++ b/libs/giskard-llm/tests/test_types.py
@@ -1,3 +1,5 @@
+import giskard.llm as llm
+from giskard.llm import ResponseFunctionToolCall
 from giskard.llm.types import (
     AssistantMessage,
     Choice,
@@ -8,6 +10,16 @@ from giskard.llm.types import (
     ToolCall,
     ToolCallFunction,
 )
+from giskard.llm.types import (
+    ResponseFunctionToolCall as TypesResponseFunctionToolCall,
+)
+
+
+def test_top_level_llm_exports_response_function_tool_call():
+    assert ResponseFunctionToolCall is TypesResponseFunctionToolCall
+    assert llm.ResponseFunctionToolCall is TypesResponseFunctionToolCall
+    assert "ResponseFunctionToolCall" in llm.__all__
+    assert "ResponseOutputFunctionCall" not in llm.__all__
 
 
 def test_completion_response_model_dump():


### PR DESCRIPTION
## Summary
- re-export `ResponseFunctionToolCall` from the top-level `giskard.llm` package
- replace the phantom `ResponseOutputFunctionCall` entry in `giskard.llm.__all__`
- add a regression test for the public API export

Closes #2457

## Verification
- `uv run python -c "import giskard.llm as llm; assert 'ResponseFunctionToolCall' in dir(llm); assert 'ResponseOutputFunctionCall' not in llm.__all__"`\n- `uv run pytest libs/giskard-llm/tests/test_types.py`\n- `make format`\n- `make check`\n- `make test-unit PACKAGE=giskard-llm`