### PR TITLE
ci: disable bare, openai, and anthropic provider tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -112,13 +112,11 @@ jobs:
       matrix:
         # One cell per routing prefix we want to exercise end-to-end.
         # `extras` is the giskard-llm optional-dependency group to install;
-        # aliases share an install (bare/azure_ai reuse openai/azure, gemini reuses google).
+        # aliases share an install (azure_ai reuses azure, gemini reuses google).
+        # bare, openai, and anthropic are disabled (no active API keys).
         include:
-          - { python-version: "3.12", provider: openai,    extras: openai    }
-          - { python-version: "3.12", provider: bare,      extras: openai    }
           - { python-version: "3.12", provider: google,    extras: google    }
           - { python-version: "3.12", provider: gemini,    extras: google    }
-          - { python-version: "3.12", provider: anthropic, extras: anthropic }
           - { python-version: "3.12", provider: azure,     extras: azure     }
           - { python-version: "3.12", provider: azure_ai,  extras: azure     }
     name: llm / ${{ matrix.provider }} / ${{ matrix.python-version }}
@@ -139,9 +137,7 @@ jobs:
         run: uv pip install "giskard-llm[$EXTRAS]"
       - name: Run functional tests
         env:
-          OPENAI_API_KEY: ${{ (matrix.provider == 'openai' || matrix.provider == 'bare') && secrets.OPENAI_API_KEY || '' }}
           GOOGLE_API_KEY: ${{ (matrix.provider == 'google' || matrix.provider == 'gemini') && secrets.GEMINI_API_KEY || '' }}
-          ANTHROPIC_API_KEY: ${{ matrix.provider == 'anthropic' && secrets.ANTHROPIC_API_KEY || '' }}
           AZURE_API_KEY: ${{ matrix.provider == 'azure' && secrets.AZURE_API_KEY || '' }}
           AZURE_API_BASE: ${{ matrix.provider == 'azure' && secrets.AZURE_API_BASE || '' }}
           AZURE_API_VERSION: ${{ matrix.provider == 'azure' && secrets.AZURE_API_VERSION || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,20 +93,18 @@ jobs:
       - name: Run checks
         run: make check
 
-      # OpenAI credentials; TEST_PROVIDER=openai makes libs/giskard-llm/tests/conftest.py
-      # skip non-OpenAI provider tests (bare is included via groups). Full `make test` still
-      # runs other workspace packages—only giskard-llm reads TEST_PROVIDER for now.
-      - name: Install OpenAI extras for functional tests
+      - name: Install Azure AI extras for functional tests
         run: |
-          uv pip install "giskard-llm[openai]"
-          uv pip install "giskard-agents[openai]"
+          uv pip install "giskard-llm[azure]"
+          uv pip install "giskard-agents[litellm]"
       - name: Run tests
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          TEST_MODEL: "openai/gpt-4.1-nano"
-          TEST_PROVIDER: openai
-          TEST_LITELLM_MODEL: "openai/gpt-4.1-nano"
-          TEST_EMBEDDING_MODEL: "openai/text-embedding-3-small"
+          AZURE_AI_API_KEY: ${{ secrets.AZURE_AI_API_KEY }}
+          AZURE_AI_ENDPOINT: ${{ secrets.AZURE_AI_ENDPOINT }}
+          TEST_MODEL: "azure_ai/gpt-4.1-nano"
+          TEST_PROVIDER: azure_ai
+          TEST_LITELLM_MODEL: "azure_ai/gpt-4.1-nano"
+          TEST_EMBEDDING_MODEL: "azure_ai/text-embedding-3-small"
         run: |
           make test
 


### PR DESCRIPTION
## Summary

- Remove `bare`, `openai`, and `anthropic` from the `test-llm-functional` matrix in `integration-tests.yml` (no active API keys for these providers)
- Drop the now-dead `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` env vars from the functional test step
- Switch `release.yml` from OpenAI to Azure AI (`azure_ai/gpt-4.1-nano`) for the full test run during releases

## Test plan

- [ ] Verify `integration-tests.yml` matrix no longer spawns `bare`, `openai`, or `anthropic` jobs
- [ ] Verify `release.yml` installs `giskard-llm[azure]` + `giskard-agents[litellm]` and uses `AZURE_AI_API_KEY` / `AZURE_AI_ENDPOINT`
- [ ] Dry-run a release to confirm the Azure AI functional tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)