### PR TITLE
feat(checks): add Sentiment built-in check (closes #2364)

### DIFF
--- a/libs/giskard-checks/pyproject.toml
+++ b/libs/giskard-checks/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
     "rich>=14.2.0,<16",
 ]
 
+[project.optional-dependencies]
+nlp = ["textblob>=0.18.0"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests", "src"]
 addopts = "--doctest-modules"

--- a/libs/giskard-checks/src/giskard/checks/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/__init__.py
@@ -20,6 +20,7 @@ from .builtin import (
     NotEquals,
     RegexMatching,
     SemanticSimilarity,
+    Sentiment,
     StringMatching,
     from_fn,
 )
@@ -113,6 +114,7 @@ __all__ = [
     "Groundedness",
     "LLMJudge",
     "SemanticSimilarity",
+    "Sentiment",
     "Toxicity",
     "StringMatching",
     "RegexMatching",

--- a/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
@@ -25,6 +25,7 @@ from .comparison import (
 from .composition import AllOf, AnyOf, Not
 from .fn import FnCheck, from_fn
 from .json_valid import JsonValid
+from .nlp_metrics import Sentiment
 from .semantic_similarity import SemanticSimilarity
 from .text_matching import RegexMatching, StringMatching
 
@@ -48,6 +49,7 @@ __all__ = [
     "Conformity",
     "LLMJudge",
     "SemanticSimilarity",
+    "Sentiment",
     "Toxicity",
     "BaseLLMCheck",
     "LLMCheckResult",

--- a/libs/giskard-checks/src/giskard/checks/builtin/nlp_metrics.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/nlp_metrics.py
@@ -151,7 +151,14 @@ class Sentiment[InputType, OutputType, TraceType: Trace](  # pyright: ignore[rep
 
         textblob = require_optional("textblob", "nlp", feature="the Sentiment check")
 
-        polarity = float(textblob.TextBlob(text).sentiment.polarity)
+        try:
+            polarity = float(textblob.TextBlob(text).sentiment.polarity)
+        except LookupError as exc:
+            raise LookupError(
+                "TextBlob's sentiment analysis requires NLTK corpora that are "
+                "not available in this environment. Run: "
+                "python -m textblob.download_corpora"
+            ) from exc
         label = _polarity_to_label(polarity)
 
         details = {

--- a/libs/giskard-checks/src/giskard/checks/builtin/nlp_metrics.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/nlp_metrics.py
@@ -1,0 +1,197 @@
+"""NLP-based metric checks.
+
+Lightweight, locally-computed checks that do not require an LLM API call.
+
+- :class:`Sentiment` — validates the sentiment polarity of text against an
+  expected label or a numeric polarity range, using the ``textblob`` library.
+"""
+
+from typing import Literal, override
+
+from giskard.core import provide_not_none
+from pydantic import Field
+
+from ..core import Trace
+from ..core.check import Check
+from ..core.exceptions import require_optional
+from ..core.extraction import JSONPathStr, NoMatch, provided_or_resolve
+from ..core.result import CheckResult, CheckStatus, Metric
+
+_SENTIMENT_LABELS = Literal["positive", "negative", "neutral"]
+_POLARITY_LABEL_THRESHOLD = 0.05
+
+
+def _polarity_to_label(polarity: float) -> _SENTIMENT_LABELS:
+    """Map a TextBlob polarity score to a sentiment label.
+
+    Parameters
+    ----------
+    polarity : float
+        Polarity score in the closed range ``[-1.0, 1.0]``.
+
+    Returns
+    -------
+    _SENTIMENT_LABELS
+        ``"positive"`` if polarity > 0.05, ``"negative"`` if polarity < -0.05,
+        ``"neutral"`` otherwise.
+    """
+    if polarity > _POLARITY_LABEL_THRESHOLD:
+        return "positive"
+    if polarity < -_POLARITY_LABEL_THRESHOLD:
+        return "negative"
+    return "neutral"
+
+
+@Check.register("sentiment")
+class Sentiment[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
+    Check[InputType, OutputType, TraceType]
+):
+    """Check that validates the sentiment of the output text.
+
+    Uses the :mod:`textblob` library to compute a polarity score in the
+    closed range ``[-1.0, 1.0]`` without any LLM API call. The check can
+    assert an expected sentiment label, a polarity-score range, or both.
+
+    Requires the ``nlp`` extra: ``pip install 'giskard-checks[nlp]'``.
+
+    Attributes
+    ----------
+    text : str | None
+        The text to analyse. If ``None``, the text is extracted from the
+        trace using ``text_key``.
+    text_key : JSONPathStr
+        JSONPath expression used to extract the text from the trace.
+        Defaults to ``"trace.last.outputs"``.
+    expected : Literal["positive", "negative", "neutral"] | None
+        Expected sentiment label. The check fails if the computed label
+        differs. ``None`` skips the label assertion.
+    min_score : float | None
+        Minimum acceptable polarity score (inclusive). ``None`` skips the
+        lower-bound assertion.
+    max_score : float | None
+        Maximum acceptable polarity score (inclusive). ``None`` skips the
+        upper-bound assertion.
+
+    Examples
+    --------
+    Assert that the output is positive:
+
+    >>> from giskard.checks import Sentiment
+    >>> check = Sentiment(expected="positive")
+
+    Assert that the polarity score stays above a threshold:
+
+    >>> check = Sentiment(min_score=0.3)
+    """
+
+    text: str | None = Field(
+        default=None,
+        description="The text to analyse. If None, extracted from trace via text_key.",
+    )
+    text_key: JSONPathStr = Field(
+        default="trace.last.outputs",
+        description="JSONPath expression to extract the text from the trace.",
+    )
+    expected: _SENTIMENT_LABELS | None = Field(
+        default=None,
+        description=(
+            "Expected sentiment label: 'positive', 'negative' or 'neutral'. "
+            "If None, no label assertion is performed."
+        ),
+    )
+    min_score: float | None = Field(
+        default=None,
+        ge=-1.0,
+        le=1.0,
+        description="Minimum acceptable polarity score (inclusive, in [-1.0, 1.0]).",
+    )
+    max_score: float | None = Field(
+        default=None,
+        ge=-1.0,
+        le=1.0,
+        description="Maximum acceptable polarity score (inclusive, in [-1.0, 1.0]).",
+    )
+
+    @override
+    async def run(self, trace: TraceType) -> CheckResult:
+        """Compute sentiment and validate it against the configured assertions.
+
+        Parameters
+        ----------
+        trace : Trace
+            The trace containing interaction history.
+
+        Returns
+        -------
+        CheckResult
+            Result with status, message, the polarity as a metric, and
+            the sentiment label plus inputs in ``details``.
+        """
+        text = provided_or_resolve(
+            trace, key=self.text_key, value=provide_not_none(self.text)
+        )
+        if isinstance(text, NoMatch):
+            return CheckResult.failure(
+                message=f"No value found for text key '{self.text_key}'.",
+                details={"text_key": self.text_key},
+            )
+        if text is None or text == "":
+            return CheckResult.failure(
+                message="No text found to analyse.",
+                details={"text_key": self.text_key, "text": text},
+            )
+        if not isinstance(text, str):
+            return CheckResult.failure(
+                message=(
+                    f"Value for text is not a string, expected string but got "
+                    f"{type(text).__name__}."
+                ),
+                details={"text_key": self.text_key, "text": text},
+            )
+
+        textblob = require_optional("textblob", "nlp", feature="the Sentiment check")
+
+        polarity = float(textblob.TextBlob(text).sentiment.polarity)
+        label = _polarity_to_label(polarity)
+
+        details = {
+            "text": text,
+            "sentiment_label": label,
+            "polarity": polarity,
+            "expected": self.expected,
+            "min_score": self.min_score,
+            "max_score": self.max_score,
+        }
+        metrics = [Metric(name="sentiment_polarity", value=polarity)]
+
+        if self.expected is not None and label != self.expected:
+            return CheckResult(
+                status=CheckStatus.FAIL,
+                message=(
+                    f"Sentiment is '{label}' (polarity {polarity:.4f}) but "
+                    f"expected '{self.expected}'."
+                ),
+                details=details,
+                metrics=metrics,
+            )
+
+        if self.min_score is not None or self.max_score is not None:
+            low = self.min_score if self.min_score is not None else -1.0
+            high = self.max_score if self.max_score is not None else 1.0
+            if polarity < low or polarity > high:
+                return CheckResult(
+                    status=CheckStatus.FAIL,
+                    message=(
+                        f"Polarity {polarity:.4f} is outside the required "
+                        f"range [{low}, {high}]."
+                    ),
+                    details=details,
+                    metrics=metrics,
+                )
+
+        return CheckResult(
+            status=CheckStatus.PASS,
+            message=f"Sentiment is '{label}' (polarity {polarity:.4f}).",
+            details=details,
+            metrics=metrics,
+        )

--- a/libs/giskard-checks/src/giskard/checks/core/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/core/__init__.py
@@ -1,5 +1,9 @@
 from .check import Check
-from .exceptions import InputGenerationException
+from .exceptions import (
+    InputGenerationException,
+    OptionalDependencyError,
+    require_optional,
+)
 from .extraction import resolve
 from .interaction import Interact, Interaction, InteractionSpec, Trace
 from .result import (
@@ -29,5 +33,7 @@ __all__ = [
     "TestCaseResult",
     "TestCase",
     "InputGenerationException",
+    "OptionalDependencyError",
+    "require_optional",
     "resolve",
 ]

--- a/libs/giskard-checks/src/giskard/checks/core/exceptions.py
+++ b/libs/giskard-checks/src/giskard/checks/core/exceptions.py
@@ -1,2 +1,60 @@
+"""Custom exceptions for giskard-checks."""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+
+
 class InputGenerationException(Exception):
     """Raised when an input generator cannot produce a valid input (e.g. schema incompatibility)."""
+
+
+class OptionalDependencyError(ImportError):
+    """Raised when a built-in check needs a package that is not installed.
+
+    Subclasses :class:`ImportError` so callers can catch either type. The
+    message always tells the user how to install the missing package via the
+    appropriate ``giskard-checks[<extra>]`` pip extra.
+    """
+
+
+def require_optional(
+    package: str, extra: str, *, feature: str | None = None
+) -> ModuleType:
+    """Import an optional dependency or raise :class:`OptionalDependencyError`.
+
+    Built-in checks that depend on libraries outside the core dependency set
+    (for example NLP helpers such as ``textblob`` or ``textstat``) should call
+    this from inside :meth:`Check.run` to keep construction cheap and to give
+    users a uniform install hint when the package is missing.
+
+    Parameters
+    ----------
+    package : str
+        The importable / pip name of the optional package, e.g. ``"textblob"``.
+    extra : str
+        The name of the ``giskard-checks`` pip extra that installs ``package``
+        (e.g. ``"nlp"``). Surfaced verbatim in the error message.
+    feature : str, optional
+        Human-readable name of the feature that needs ``package``. Defaults
+        to ``package`` itself when omitted.
+
+    Returns
+    -------
+    ModuleType
+        The imported module, ready to use.
+
+    Raises
+    ------
+    OptionalDependencyError
+        If ``package`` cannot be imported.
+    """
+    try:
+        return importlib.import_module(package)
+    except ImportError as exc:
+        feature_name = feature or package
+        raise OptionalDependencyError(
+            f"The '{package}' package is required for {feature_name} but is not "
+            f"installed. Install it with: pip install 'giskard-checks[{extra}]'"
+        ) from exc

--- a/libs/giskard-checks/tests/builtin/test_sentiment.py
+++ b/libs/giskard-checks/tests/builtin/test_sentiment.py
@@ -1,0 +1,64 @@
+"""Tests for the Sentiment built-in check."""
+
+import sys
+
+import pytest
+from giskard.checks import CheckStatus, Interaction, Sentiment, Trace
+from giskard.checks.core import OptionalDependencyError
+
+POSITIVE = "I absolutely love this product, it is fantastic!"
+NEGATIVE = "Terrible experience, completely disappointed."
+NEUTRAL = "The package arrived on Tuesday."
+
+
+async def test_label_match_passes() -> None:
+    """Expected label matches the analysed polarity."""
+    result = await Sentiment(text=POSITIVE, expected="positive").run(Trace())
+    assert result.status == CheckStatus.PASS
+    assert result.details["sentiment_label"] == "positive"
+
+
+async def test_label_mismatch_fails() -> None:
+    """Expected label differs from the analysed polarity."""
+    result = await Sentiment(text=NEGATIVE, expected="positive").run(Trace())
+    assert result.status == CheckStatus.FAIL
+    assert "expected 'positive'" in (result.message or "")
+
+
+async def test_score_within_range_passes() -> None:
+    """Polarity inside the configured score window."""
+    result = await Sentiment(text=POSITIVE, min_score=0.3).run(Trace())
+    assert result.status == CheckStatus.PASS
+    [metric] = result.metrics
+    assert metric.name == "sentiment_polarity"
+    assert metric.value >= 0.3
+
+
+async def test_score_out_of_range_fails() -> None:
+    """Polarity outside the configured score window."""
+    result = await Sentiment(text=NEGATIVE, min_score=0.0).run(Trace())
+    assert result.status == CheckStatus.FAIL
+    assert "outside the required range" in (result.message or "")
+
+
+async def test_extracts_text_from_trace_default_key() -> None:
+    """When `text` is not given, the default `text_key` is used."""
+    interaction = Interaction(inputs="How was it?", outputs=POSITIVE)
+    result = await Sentiment(expected="positive").run(Trace(interactions=[interaction]))
+    assert result.status == CheckStatus.PASS
+
+
+async def test_missing_text_returns_failure() -> None:
+    """No text in trace and no direct `text` → failure with a clear message."""
+    result = await Sentiment(expected="positive").run(Trace())
+    assert result.status == CheckStatus.FAIL
+    assert "No value found for text key" in (result.message or "")
+
+
+async def test_missing_textblob_raises_optional_dependency_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``textblob`` is unavailable, the check raises OptionalDependencyError."""
+    monkeypatch.setitem(sys.modules, "textblob", None)
+    with pytest.raises(OptionalDependencyError, match=r"giskard-checks\[nlp\]"):
+        await Sentiment(text=POSITIVE).run(Trace())

--- a/uv.lock
+++ b/uv.lock
@@ -898,6 +898,11 @@ dependencies = [
     { name = "rich" },
 ]
 
+[package.optional-dependencies]
+nlp = [
+    { name = "textblob" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "giskard-agents", editable = "libs/giskard-agents" },
@@ -909,7 +914,9 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12,<3" },
     { name = "regex", specifier = ">=2026.1.15" },
     { name = "rich", specifier = ">=14.2.0,<16" },
+    { name = "textblob", marker = "extra == 'nlp'", specifier = ">=0.18.0" },
 ]
+provides-extras = ["nlp"]
 
 [[package]]
 name = "giskard-core"
@@ -1320,6 +1327,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
 name = "jsonpath-ng"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1683,6 +1699,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
+name = "nltk"
+version = "3.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "joblib" },
+    { name = "regex" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
 ]
 
 [[package]]
@@ -2658,6 +2689,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "textblob"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nltk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/c0/b7f426679211e965f8bf6b65e5eafeda51842502a6ae989b9616895d5fb5/textblob-0.20.0.tar.gz", hash = "sha256:ae9bef3a16cecb4aae3e995cc8c6fe98a9d2a6ffdd58990dcd68e817e8d66b9e", size = 639377, upload-time = "2026-04-01T13:50:20.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/6e/d487f271c30700354f55b5e56339f38942ab3cb9b6f1464288e252ae3fef/textblob-0.20.0-py3-none-any.whl", hash = "sha256:f32e5240a17a98a8d026cdf7add8f5e0c7d4f1f2e91dad77bc9493e5ab3c6bd5", size = 624962, upload-time = "2026-04-01T13:50:19.423Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Adds a built-in `Sentiment` check that validates the sentiment of a model output against an expected label (`positive` / `negative` / `neutral`) and/or a polarity score range. Sentiment is computed locally with [`textblob`](https://textblob.readthedocs.io/) — no LLM API call — once the new `nlp` extra is installed (`pip install 'giskard-checks[nlp]'`).

Also lands a small, reusable optional-dependency guard in `giskard.checks.core`:

- `OptionalDependencyError(ImportError)`
- `require_optional(package, extra, *, feature=None) -> ModuleType`

so future NLP-style checks (e.g. local toxicity via `detoxify`, `Readability` via `textstat`) can surface a uniform pip-install hint when their extra isn't installed.

### Usage

```python
from giskard.checks import Sentiment, Scenario

Sentiment(expected="positive")
Sentiment(min_score=0.3)
Sentiment(expected="negative", max_score=-0.1)
```

## Related Issue

Closes #2364. Builds on prior closed PRs #2386 and #2399.

### Maintainer feedback from #2386 addressed in this PR

| # | @davidberenstein1957 comment | Where it's addressed |
|---|---|---|
| 1 | *"can we create a more uniform utils for this to use for additional potential libraries in other checks"* | New `require_optional` helper in `core/exceptions.py`, re-exported from `giskard.checks.core`. |
| 2 | *"can we fix this empty line"* in `__all__` | No stray blank lines in `checks/__init__.py`. |
| 3 | *"could this be re-used as fixture among tests?"* | Sample texts defined once as module constants (`POSITIVE`/`NEGATIVE`/`NEUTRAL`). |
| 4 | *"don't we always know that polarity_score corresponds to a label … skip the polarity score assertion if we test for labels"* | Each test asserts either label/status **or** score/status — never both. |
| 5 | *"can we simplify some of these tests? We don't need that many"* | 7 focused tests in ~70 lines (down from 301 in #2386). |

Also addresses the gemini-code-assist bot suggestions:
- `_polarity_to_label` returns `_SENTIMENT_LABELS` (not generic `str`).
- No unnecessary `# type: ignore` comments.
- `None` bounds render as `-1.0` / `1.0` in messages instead of literal `None`.
- Pydantic `ge=-1.0, le=1.0` on `min_score` / `max_score`.

## Type of Change

- [x] 🚀 New feature (non-breaking change which adds functionality)

## Coding agents

This PR is human-driven (no autonomous agent), so the title intentionally omits the four-robot suffix.

## Checklist

- [x] I've read the `CODE_OF_CONDUCT.md` document.
- [x] I've read the `CONTRIBUTING.md` guide.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [x] I've updated the `uv.lock` running `uv lock`.