### PR TITLE
fix(giskard-checks): make SuiteResult failure-detail limit configurable

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/core/result.py
+++ b/libs/giskard-checks/src/giskard/checks/core/result.py
@@ -493,6 +493,8 @@ class SuiteResult(BaseResult, frozen=True):
         Scenario results produced during the suite execution.
     duration_ms : int
         Total execution time in milliseconds.
+    n_loggable_failures : int
+        Maximum number of failures/errors to display in detailed output (default 20).
     passed_count : int
         Number of scenarios that passed.
     failed_count : int
@@ -509,6 +511,10 @@ class SuiteResult(BaseResult, frozen=True):
         ..., description="List of scenario results"
     )
     duration_ms: int = Field(..., description="Total execution time in milliseconds")
+    n_loggable_failures: int = Field(
+        default=20,
+        description="Maximum number of failures/errors to display in detailed output.",
+    )
 
     @computed_field
     @property
@@ -568,7 +574,7 @@ class SuiteResult(BaseResult, frozen=True):
         failures_and_errors = self.failures_and_errors
 
         if failures_and_errors:
-            n_loggable_failures = 20  # TODO: make this configurable
+            n_loggable_failures = self.n_loggable_failures
 
             # Details
             yield Rule("FAILURES", characters="=", style="grey")

--- a/libs/giskard-checks/src/giskard/checks/core/result.py
+++ b/libs/giskard-checks/src/giskard/checks/core/result.py
@@ -513,7 +513,8 @@ class SuiteResult(BaseResult, frozen=True):
     duration_ms: int = Field(..., description="Total execution time in milliseconds")
     n_loggable_failures: int = Field(
         default=20,
-        description="Maximum number of failures/errors to display in detailed output.",
+        ge=0,
+        description="Maximum number of failures/errors to display in detailed output (must be >= 0).",
     )
 
     @computed_field

--- a/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
@@ -33,6 +33,8 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
         List of scenarios to execute.
     target : Any | NotProvided
         Optional suite-level target SUT.
+    n_loggable_failures : int
+        Maximum number of failures/errors to display in detailed output (default 20, must be >= 0).
 
     Examples
     --------
@@ -61,6 +63,11 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
     ) = Field(
         default=NOT_PROVIDED,
         description="Suite-level target SUT that will override any scenario-level target.",
+    )
+    n_loggable_failures: int = Field(
+        default=20,
+        ge=0,
+        description="Maximum number of failures/errors to display in detailed suite output (must be >= 0).",
     )
 
     def append(
@@ -158,6 +165,7 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
             suite_result = SuiteResult(
                 results=results,
                 duration_ms=int((end_time - start_time) * 1000),
+                n_loggable_failures=self.n_loggable_failures,
             )
 
             telemetry_capture(

--- a/libs/giskard-checks/tests/core/test_result.py
+++ b/libs/giskard-checks/tests/core/test_result.py
@@ -110,6 +110,15 @@ class TestSuiteResultNLoggableFailures:
         # With 25 failures and limit of 3, we should see "... and 22 more"
         assert "... and 22 more" in output
 
+    def test_negative_limit_is_rejected(self) -> None:
+        """Passing a negative n_loggable_failures should raise a validation error."""
+        with pytest.raises(ValueError, match="greater than or equal to 0"):
+            SuiteResult(
+                results=[],
+                duration_ms=0,
+                n_loggable_failures=-1,
+            )
+
     def test_limit_exceeds_failures_no_ellipsis(self) -> None:
         """When failures are fewer than the limit, no '... and N more' line."""
         scenarios = [_make_failing_scenario(f"scenario_{i}") for i in range(5)]

--- a/libs/giskard-checks/tests/core/test_result.py
+++ b/libs/giskard-checks/tests/core/test_result.py
@@ -1,0 +1,130 @@
+"""Tests for result classes (CheckResult, TestCaseResult, ScenarioResult, SuiteResult)."""
+
+import pytest
+from rich.console import Console
+
+from giskard.checks import (
+    CheckResult,
+    CheckStatus,
+    Metric,
+    ScenarioResult,
+    SuiteResult,
+    TestCaseResult,
+    Trace,
+)
+
+
+def _make_failing_scenario(name: str) -> ScenarioResult:
+    """Create a ScenarioResult with a single failing check."""
+    return ScenarioResult(
+        scenario_name=name,
+        steps=[
+            TestCaseResult(
+                results=[
+                    CheckResult(
+                        status=CheckStatus.FAIL,
+                        message=f"Failure in {name}",
+                        details={"check_name": f"check_{name}"},
+                    ),
+                ],
+                duration_ms=10,
+            ),
+        ],
+        duration_ms=10,
+        final_trace=Trace(),
+    )
+
+
+class TestSuiteResultNLoggableFailures:
+    """Tests for the configurable ``n_loggable_failures`` parameter."""
+
+    def test_default_limit_is_20(self) -> None:
+        """The default value of n_loggable_failures should be 20."""
+        result = SuiteResult(
+            results=[],
+            duration_ms=0,
+        )
+        assert result.n_loggable_failures == 20
+
+    def test_custom_limit_via_constructor(self) -> None:
+        """Setting n_loggable_failures=5 should override the default."""
+        result = SuiteResult(
+            results=[],
+            duration_ms=0,
+            n_loggable_failures=5,
+        )
+        assert result.n_loggable_failures == 5
+
+    def test_custom_limit_zero(self) -> None:
+        """Setting n_loggable_failures=0 should suppress all failure details."""
+        result = SuiteResult(
+            results=[],
+            duration_ms=0,
+            n_loggable_failures=0,
+        )
+        assert result.n_loggable_failures == 0
+
+    def test_custom_limit_large_value(self) -> None:
+        """Setting n_loggable_failures to a large value should work."""
+        result = SuiteResult(
+            results=[],
+            duration_ms=0,
+            n_loggable_failures=100,
+        )
+        assert result.n_loggable_failures == 100
+
+    def test_default_limit_in_console_output(self) -> None:
+        """When defaults are used, the limit in __rich_console__ should be 20."""
+        scenarios = [_make_failing_scenario(f"scenario_{i}") for i in range(25)]
+        result = SuiteResult(
+            results=scenarios,
+            duration_ms=100,
+        )
+
+        # Render the result to a string
+        console = Console(width=120)
+        with console.capture() as capture:
+            console.print(result)
+
+        output = capture.get()
+
+        # With 25 failures and default limit of 20, we should see "... and 5 more"
+        assert "... and 5 more" in output
+
+    def test_custom_limit_in_console_output(self) -> None:
+        """A custom limit should restrict how many failures are displayed."""
+        scenarios = [_make_failing_scenario(f"scenario_{i}") for i in range(25)]
+        result = SuiteResult(
+            results=scenarios,
+            duration_ms=100,
+            n_loggable_failures=3,
+        )
+
+        # Render the result to a string
+        console = Console(width=120)
+        with console.capture() as capture:
+            console.print(result)
+
+        output = capture.get()
+
+        # With 25 failures and limit of 3, we should see "... and 22 more"
+        assert "... and 22 more" in output
+
+    def test_limit_exceeds_failures_no_ellipsis(self) -> None:
+        """When failures are fewer than the limit, no '... and N more' line."""
+        scenarios = [_make_failing_scenario(f"scenario_{i}") for i in range(5)]
+        result = SuiteResult(
+            results=scenarios,
+            duration_ms=100,
+            n_loggable_failures=10,
+        )
+
+        console = Console(width=120)
+        with console.capture() as capture:
+            console.print(result)
+
+        output = capture.get()
+
+        # All 5 failures fit within the limit of 10 — no "and ... more"
+        assert "and 5 more" not in output
+        assert "and 10 more" not in output

--- a/libs/giskard-checks/tests/core/test_suite.py
+++ b/libs/giskard-checks/tests/core/test_suite.py
@@ -292,3 +292,42 @@ async def test_suite_parallel_rejects_invalid_max_concurrency():
 
     with pytest.raises(ValueError, match="max_concurrency must be greater than 0"):
         await suite.run(parallel=True, max_concurrency=0)
+
+
+def test_suite_passes_n_loggable_failures_to_result():
+    """Suite.n_loggable_failures should be passed through to SuiteResult."""
+    suite = Suite(
+        name="custom_limit_suite",
+        target=lambda inputs: inputs,
+        n_loggable_failures=5,
+    )
+    assert suite.n_loggable_failures == 5
+
+
+def test_suite_n_loggable_failures_default():
+    """Default n_loggable_failures on Suite should be 20."""
+    suite = Suite(name="default_limit_suite")
+    assert suite.n_loggable_failures == 20
+
+
+def test_suite_rejects_negative_n_loggable_failures():
+    """Suite should reject negative n_loggable_failures."""
+    with pytest.raises(ValueError, match="greater than or equal to 0"):
+        Suite(
+            name="negative_limit_suite",
+            n_loggable_failures=-1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_suite_run_passes_n_loggable_failures():
+    """Suite.run() should pass n_loggable_failures to the SuiteResult."""
+    suite = Suite(
+        name="pass_through_suite",
+        target=lambda inputs: inputs,
+        n_loggable_failures=3,
+    )
+    suite.append(Scenario("a").interact("hello"))
+
+    result = await suite.run()
+    assert result.n_loggable_failures == 3


### PR DESCRIPTION
## Summary

- Added `n_loggable_failures` parameter to `SuiteResult.__init__()` with default value 20
- Replaced hardcoded limit in `__rich_console__` with the configurable parameter
- Added test coverage for default and custom limit values

Fixes #2417

## Test Plan

- [ ] Default limit (20) behavior preserved
- [ ] Custom limit correctly restricts displayed failures
- [ ] Existing SuiteResult tests continue to pass