### PR TITLE
feat(checks): add progress bar to suite runs

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/core/result.py
+++ b/libs/giskard-checks/src/giskard/checks/core/result.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from enum import Enum
 from pathlib import Path
 from typing import Any, ClassVar
@@ -6,6 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field, computed_field
 from rich.console import Console, ConsoleOptions, RenderResult
 from rich.panel import Panel
 from rich.rule import Rule
+from rich.text import Text
 
 from .interaction import Trace
 from .protocols import RichConsoleProtocol, RichProtocol
@@ -36,6 +38,33 @@ STATUS_MAPPING = {
         "symbol": "s",
     },
 }
+
+STATUS_SUMMARY_ORDER: tuple[tuple[str, str], ...] = (
+    ("error", "errored"),
+    ("fail", "failed"),
+    ("skip", "skipped"),
+    ("pass", "passed"),
+)
+
+
+def format_status_count_parts(counts: Mapping[str, int]) -> list[str]:
+    """Build Rich markup fragments for non-zero status counts in summary order."""
+    return [
+        f"[{STATUS_MAPPING[key]['color']} bold]{counts[key]} {label}"
+        f"[/{STATUS_MAPPING[key]['color']} bold]"
+        for key, label in STATUS_SUMMARY_ORDER
+        if counts.get(key)
+    ]
+
+
+def format_status_count_text(
+    counts: Mapping[str, int], *, prefix: str = ""
+) -> Text | None:
+    """Colored counts line, or ``None`` when every count is zero."""
+    parts = format_status_count_parts(counts)
+    if not parts:
+        return None
+    return Text.from_markup(prefix + ", ".join(parts))
 
 
 def _pluralize(count: int, word: str, plural: str | None = None) -> str:
@@ -455,31 +484,15 @@ class TestCaseResult(BaseResult, frozen=True):
         for result in self.results:
             yield from result.__rich_console__(console, options)
 
-        # Build subtitle with counts
-        counts = {
-            "errored": sum(1 for r in self.results if r.errored),
-            "failed": sum(1 for r in self.results if r.failed),
-            "skipped": sum(1 for r in self.results if r.skipped),
-            "passed": sum(1 for r in self.results if r.passed),
+        status_counts = {
+            "error": sum(1 for r in self.results if r.errored),
+            "fail": sum(1 for r in self.results if r.failed),
+            "skip": sum(1 for r in self.results if r.skipped),
+            "pass": sum(1 for r in self.results if r.passed),
         }
-        count_parts: list[str] = []
-        if counts["errored"]:
-            count_parts.append(
-                f"[{STATUS_MAPPING['error']['color']} bold]{counts['errored']} errored[/{STATUS_MAPPING['error']['color']} bold]"
-            )
-        if counts["failed"]:
-            count_parts.append(
-                f"[{STATUS_MAPPING['fail']['color']} bold]{counts['failed']} failed[/{STATUS_MAPPING['fail']['color']} bold]"
-            )
-        if counts["skipped"]:
-            count_parts.append(
-                f"[{STATUS_MAPPING['skip']['color']} bold]{counts['skipped']} skipped[/{STATUS_MAPPING['skip']['color']} bold]"
-            )
-        if counts["passed"]:
-            count_parts.append(
-                f"[{STATUS_MAPPING['pass']['color']} bold]{counts['passed']} passed[/{STATUS_MAPPING['pass']['color']} bold]"
-            )
-        subtitle = ", ".join(count_parts) + f" in {self.duration_ms}ms"
+        subtitle = ", ".join(format_status_count_parts(status_counts)) + (
+            f" in {self.duration_ms}ms"
+        )
 
         yield Rule(subtitle, style=f"{status['color']} bold")
 
@@ -597,26 +610,18 @@ class SuiteResult(BaseResult, frozen=True):
         yield Rule(style="bold blue")
 
         # Summary metrics
-        count_parts = []
-        count_parts.append(
+        count_parts = [
             f"[{STATUS_MAPPING['total']['color']} bold]{len(self.results)} total[/{STATUS_MAPPING['total']['color']} bold]"
+        ]
+        count_parts.extend(
+            format_status_count_parts(
+                {
+                    "error": self.errored_count,
+                    "fail": self.failed_count,
+                    "skip": self.skipped_count,
+                    "pass": self.passed_count,
+                }
+            )
         )
-        if self.errored_count:
-            count_parts.append(
-                f"[{STATUS_MAPPING['error']['color']} bold]{self.errored_count} errored[/{STATUS_MAPPING['error']['color']} bold]"
-            )
-        if self.failed_count:
-            count_parts.append(
-                f"[{STATUS_MAPPING['fail']['color']} bold]{self.failed_count} failed[/{STATUS_MAPPING['fail']['color']} bold]"
-            )
-        if self.skipped_count:
-            count_parts.append(
-                f"[{STATUS_MAPPING['skip']['color']} bold]{self.skipped_count} skipped[/{STATUS_MAPPING['skip']['color']} bold]"
-            )
-        if self.passed_count:
-            count_parts.append(
-                f"[{STATUS_MAPPING['pass']['color']} bold]{self.passed_count} passed[/{STATUS_MAPPING['pass']['color']} bold]"
-            )
-
         summary = ", ".join(count_parts)
         yield f"Summary: {summary} | Pass Rate: [default bold]{self.pass_rate:.1%}[/default bold] | Total Duration: {self.duration_ms}ms"

--- a/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
@@ -197,7 +197,7 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
         return_exception: bool = False,
         parallel: bool = False,
         max_concurrency: int | None = None,
-        progress: bool = True,
+        verbose: bool = True,
     ) -> SuiteResult:
         """Run all scenarios in the suite.
 
@@ -214,7 +214,7 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
             Max concurrent scenarios when ``parallel=True`` (positive int).
             ``None`` (default) is unbounded: all scenarios start at once, so the
             provider's rate limits become the effective cap.
-        progress : bool
+        verbose : bool
             If True (default), display a progress bar showing which scenario is
             currently running. Set to False for non-interactive environments.
 
@@ -255,7 +255,7 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
             )
 
             start_time = time.perf_counter()
-            with self._progress_bar(enabled=progress) as tracker:
+            with self._progress_bar(enabled=verbose) as tracker:
                 if parallel:
                     results = await self._run_parallel(
                         target, return_exception, max_concurrency, tracker

--- a/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
@@ -24,10 +24,11 @@ from rich.text import Text
 from .._telemetry_props import suite_shape_properties
 from ..core.interaction import Trace
 from ..core.result import (
-    STATUS_MAPPING,
+    STATUS_SUMMARY_ORDER,
     ScenarioResult,
     ScenarioStatus,
     SuiteResult,
+    format_status_count_text,
 )
 from ..core.scenario import Scenario
 from ..core.types import ProviderType
@@ -49,14 +50,6 @@ class _OverallOnly(ProgressColumn):
         return self._column.render(task)
 
 
-_STATUS_COUNT_LABELS: tuple[tuple[str, str], ...] = (
-    ("error", "errored"),
-    ("fail", "failed"),
-    ("skip", "skipped"),
-    ("pass", "passed"),
-)
-
-
 class _SuiteProgress(Progress):
     """Progress display that appends a live status-count summary below the rows.
 
@@ -65,26 +58,18 @@ class _SuiteProgress(Progress):
     under the task rows, mirroring the final suite summary.
     """
 
-    def __init__(self, *columns: ProgressColumn, **kwargs: Any) -> None:
+    def __init__(self, *columns: ProgressColumn, disable: bool = False) -> None:
         # Set before super().__init__(): it renders get_renderables(), which reads _counts.
-        self._counts: dict[str, int] = {"pass": 0, "fail": 0, "error": 0, "skip": 0}
+        self._counts: dict[str, int] = {key: 0 for key, _ in STATUS_SUMMARY_ORDER}
         self._overall_id: TaskID | None = None
-        super().__init__(*columns, **kwargs)
-
-    @property
-    def _overall(self) -> TaskID:
-        assert self._overall_id is not None, "overall task not started"
-        return self._overall_id
+        super().__init__(*columns, disable=disable)
 
     def start_overall(self, total: int) -> None:
         self._overall_id = self.add_task("Running scenarios", total=total, overall=True)
 
-    def complete_overall(self, total: int) -> None:
-        self.update(self._overall, completed=total)
-        self.refresh()
-
     def describe(self, text: str) -> None:
-        self.update(self._overall, description=text)
+        if self._overall_id is not None:
+            self.update(self._overall_id, description=text)
 
     def record(self, status: ScenarioStatus) -> None:
         """Tally one finished scenario and advance the overall bar."""
@@ -103,15 +88,7 @@ class _SuiteProgress(Progress):
 
     def _summary_renderable(self) -> Text | None:
         """Colored counts line, or ``None`` until at least one scenario has finished."""
-        parts = [
-            f"[{STATUS_MAPPING[key]['color']} bold]{self._counts[key]} {label}"
-            f"[/{STATUS_MAPPING[key]['color']} bold]"
-            for key, label in _STATUS_COUNT_LABELS
-            if self._counts[key]
-        ]
-        if not parts:
-            return None
-        return Text.from_markup("  " + ", ".join(parts))
+        return format_status_count_text(self._counts, prefix="  ")
 
     def get_renderables(self) -> Iterable[RenderableType]:
         yield self.make_tasks_table(self.tasks)
@@ -287,16 +264,15 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
     def _progress_bar(self, enabled: bool) -> Iterator[_SuiteProgress]:
         """Yield a progress tracker; a disabled no-op display when ``enabled`` is False."""
         with _SuiteProgress(
-            SpinnerColumn(),
+            _OverallOnly(SpinnerColumn()),
             TextColumn("[progress.description]{task.description}"),
             _OverallOnly(BarColumn()),
             _OverallOnly(MofNCompleteColumn()),
-            TimeElapsedColumn(),
+            _OverallOnly(TimeElapsedColumn()),
             disable=not enabled,
         ) as progress:
             progress.start_overall(len(self.scenarios))
             yield progress
-            progress.complete_overall(len(self.scenarios))
 
     async def _run_serial(
         self,

--- a/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from contextlib import contextmanager, nullcontext
 from typing import Any, Generic, Self, TypeVar
 
@@ -23,7 +23,12 @@ from rich.text import Text
 
 from .._telemetry_props import suite_shape_properties
 from ..core.interaction import Trace
-from ..core.result import ScenarioResult, SuiteResult
+from ..core.result import (
+    STATUS_MAPPING,
+    ScenarioResult,
+    ScenarioStatus,
+    SuiteResult,
+)
 from ..core.scenario import Scenario
 from ..core.types import ProviderType
 
@@ -42,6 +47,77 @@ class _OverallOnly(ProgressColumn):
         if not task.fields.get("overall"):
             return Text("")
         return self._column.render(task)
+
+
+_STATUS_COUNT_LABELS: tuple[tuple[str, str], ...] = (
+    ("error", "errored"),
+    ("fail", "failed"),
+    ("skip", "skipped"),
+    ("pass", "passed"),
+)
+
+
+class _SuiteProgress(Progress):
+    """Progress display that appends a live status-count summary below the rows.
+
+    As scenarios finish, ``record`` tallies their outcomes and the overridden
+    ``get_renderables`` draws a colored ``errored, failed, skipped, passed`` line
+    under the task rows, mirroring the final suite summary.
+    """
+
+    def __init__(self, *columns: ProgressColumn, **kwargs: Any) -> None:
+        # Set before super().__init__(): it renders get_renderables(), which reads _counts.
+        self._counts: dict[str, int] = {"pass": 0, "fail": 0, "error": 0, "skip": 0}
+        self._overall_id: TaskID | None = None
+        super().__init__(*columns, **kwargs)
+
+    @property
+    def _overall(self) -> TaskID:
+        assert self._overall_id is not None, "overall task not started"
+        return self._overall_id
+
+    def start_overall(self, total: int) -> None:
+        self._overall_id = self.add_task("Running scenarios", total=total, overall=True)
+
+    def complete_overall(self, total: int) -> None:
+        self.update(self._overall, completed=total)
+        self.refresh()
+
+    def describe(self, text: str) -> None:
+        self.update(self._overall, description=text)
+
+    def record(self, status: ScenarioStatus) -> None:
+        """Tally one finished scenario and advance the overall bar."""
+        self._counts[status.value] += 1
+        if self._overall_id is not None:
+            self.advance(self._overall_id)
+
+    @contextmanager
+    def scenario_row(self, name: str) -> Iterator[None]:
+        """Show a row for one scenario while it runs, then remove it."""
+        task_id = self.add_task(f"  ↳ {name}", total=None)
+        try:
+            yield
+        finally:
+            self.remove_task(task_id)
+
+    def _summary_renderable(self) -> Text | None:
+        """Colored counts line, or ``None`` until at least one scenario has finished."""
+        parts = [
+            f"[{STATUS_MAPPING[key]['color']} bold]{self._counts[key]} {label}"
+            f"[/{STATUS_MAPPING[key]['color']} bold]"
+            for key, label in _STATUS_COUNT_LABELS
+            if self._counts[key]
+        ]
+        if not parts:
+            return None
+        return Text.from_markup("  " + ", ".join(parts))
+
+    def get_renderables(self) -> Iterable[RenderableType]:
+        yield self.make_tasks_table(self.tasks)
+        summary = self._summary_renderable()
+        if summary is not None:
+            yield summary
 
 
 class Suite(BaseModel, Generic[InputType, OutputType]):
@@ -208,9 +284,9 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
         return suite_result
 
     @contextmanager
-    def _progress_bar(self, enabled: bool) -> Iterator[tuple[Progress, TaskID]]:
-        """Yield ``(progress, task_id)``; disabled when ``enabled`` is False so calls are no-ops."""
-        with Progress(
+    def _progress_bar(self, enabled: bool) -> Iterator[_SuiteProgress]:
+        """Yield a progress tracker; a disabled no-op display when ``enabled`` is False."""
+        with _SuiteProgress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
             _OverallOnly(BarColumn()),
@@ -218,27 +294,24 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
             TimeElapsedColumn(),
             disable=not enabled,
         ) as progress:
-            task_id = progress.add_task(
-                "Running scenarios", total=len(self.scenarios), overall=True
-            )
-            yield progress, task_id
-            progress.update(task_id, completed=len(self.scenarios))
-            progress.refresh()
+            progress.start_overall(len(self.scenarios))
+            yield progress
+            progress.complete_overall(len(self.scenarios))
 
     async def _run_serial(
         self,
         target: Any,
         return_exception: bool,
-        tracker: tuple[Progress, TaskID],
+        progress: _SuiteProgress,
     ) -> list[ScenarioResult[Trace[Any, Any]]]:
-        progress, overall_id = tracker
         results: list[ScenarioResult[Trace[Any, Any]]] = []
         for scenario in self.scenarios:
-            progress.update(overall_id, description=f"Running: {scenario.name}")
-            results.append(
-                await scenario.run(target=target, return_exception=return_exception)
+            progress.describe(f"Running: {scenario.name}")
+            result = await scenario.run(
+                target=target, return_exception=return_exception
             )
-            progress.advance(overall_id)
+            results.append(result)
+            progress.record(result.status)
         return results
 
     async def _run_parallel(
@@ -246,26 +319,21 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
         target: Any,
         return_exception: bool,
         max_concurrency: int | None,
-        tracker: tuple[Progress, TaskID],
+        progress: _SuiteProgress,
     ) -> list[ScenarioResult[Trace[Any, Any]]]:
         semaphore = (
             asyncio.Semaphore(max_concurrency) if max_concurrency else nullcontext()
         )
-        progress, overall_id = tracker
 
         async def run_scenario(
             scenario: Scenario[InputType, OutputType, Trace[Any, Any]],
         ) -> ScenarioResult[Trace[Any, Any]]:
             async with semaphore:
-                # Show a row per scenario while it runs, so all in-flight ones appear.
-                sub_id = progress.add_task(f"  ↳ {scenario.name}", total=None)
-                try:
+                with progress.scenario_row(scenario.name):
                     result = await scenario.run(
                         target=target, return_exception=return_exception
                     )
-                finally:
-                    progress.remove_task(sub_id)
-                progress.advance(overall_id)
+                progress.record(result.status)
             return result
 
         try:

--- a/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
@@ -1,11 +1,25 @@
 import asyncio
 import time
-from contextlib import nullcontext
+from collections.abc import Iterator
+from contextlib import contextmanager, nullcontext
 from typing import Any, Generic, Self, TypeVar
 
 from giskard.core import telemetry_capture, telemetry_run_context, telemetry_tag
 from giskard.core.utils import NOT_PROVIDED, NotProvided
 from pydantic import BaseModel, Field
+from rich.console import RenderableType
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    ProgressColumn,
+    SpinnerColumn,
+    Task,
+    TaskID,
+    TextColumn,
+    TimeElapsedColumn,
+)
+from rich.text import Text
 
 from .._telemetry_props import suite_shape_properties
 from ..core.interaction import Trace
@@ -15,6 +29,19 @@ from ..core.types import ProviderType
 
 InputType = TypeVar("InputType", infer_variance=True)
 OutputType = TypeVar("OutputType", infer_variance=True)
+
+
+class _OverallOnly(ProgressColumn):
+    """Render the wrapped column only for the overall task, not per-scenario rows."""
+
+    def __init__(self, column: ProgressColumn) -> None:
+        super().__init__()
+        self._column: ProgressColumn = column
+
+    def render(self, task: "Task") -> RenderableType:
+        if not task.fields.get("overall"):
+            return Text("")
+        return self._column.render(task)
 
 
 class Suite(BaseModel, Generic[InputType, OutputType]):
@@ -94,6 +121,7 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
         return_exception: bool = False,
         parallel: bool = False,
         max_concurrency: int | None = None,
+        progress: bool = True,
     ) -> SuiteResult:
         """Run all scenarios in the suite.
 
@@ -107,8 +135,12 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
         parallel : bool
             If True, run all scenarios concurrently while preserving result order.
         max_concurrency : int | None
-            Optional upper bound on concurrent scenario runs when ``parallel=True``.
-            Must be a positive integer when provided.
+            Max concurrent scenarios when ``parallel=True`` (positive int).
+            ``None`` (default) is unbounded: all scenarios start at once, so the
+            provider's rate limits become the effective cap.
+        progress : bool
+            If True (default), display a progress bar showing which scenario is
+            currently running. Set to False for non-interactive environments.
 
         Returns
         -------
@@ -147,12 +179,13 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
             )
 
             start_time = time.perf_counter()
-            if parallel:
-                results = await self._run_parallel(
-                    target, return_exception, max_concurrency
-                )
-            else:
-                results = await self._run_serial(target, return_exception)
+            with self._progress_bar(enabled=progress) as tracker:
+                if parallel:
+                    results = await self._run_parallel(
+                        target, return_exception, max_concurrency, tracker
+                    )
+                else:
+                    results = await self._run_serial(target, return_exception, tracker)
             end_time = time.perf_counter()
 
             suite_result = SuiteResult(
@@ -174,33 +207,66 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
 
         return suite_result
 
+    @contextmanager
+    def _progress_bar(self, enabled: bool) -> Iterator[tuple[Progress, TaskID]]:
+        """Yield ``(progress, task_id)``; disabled when ``enabled`` is False so calls are no-ops."""
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            _OverallOnly(BarColumn()),
+            _OverallOnly(MofNCompleteColumn()),
+            TimeElapsedColumn(),
+            disable=not enabled,
+        ) as progress:
+            task_id = progress.add_task(
+                "Running scenarios", total=len(self.scenarios), overall=True
+            )
+            yield progress, task_id
+            progress.update(task_id, completed=len(self.scenarios))
+            progress.refresh()
+
     async def _run_serial(
         self,
         target: Any,
         return_exception: bool,
+        tracker: tuple[Progress, TaskID],
     ) -> list[ScenarioResult[Trace[Any, Any]]]:
-        return [
-            await scenario.run(target=target, return_exception=return_exception)
-            for scenario in self.scenarios
-        ]
+        progress, overall_id = tracker
+        results: list[ScenarioResult[Trace[Any, Any]]] = []
+        for scenario in self.scenarios:
+            progress.update(overall_id, description=f"Running: {scenario.name}")
+            results.append(
+                await scenario.run(target=target, return_exception=return_exception)
+            )
+            progress.advance(overall_id)
+        return results
 
     async def _run_parallel(
         self,
         target: Any,
         return_exception: bool,
         max_concurrency: int | None,
+        tracker: tuple[Progress, TaskID],
     ) -> list[ScenarioResult[Trace[Any, Any]]]:
         semaphore = (
             asyncio.Semaphore(max_concurrency) if max_concurrency else nullcontext()
         )
+        progress, overall_id = tracker
 
         async def run_scenario(
             scenario: Scenario[InputType, OutputType, Trace[Any, Any]],
         ) -> ScenarioResult[Trace[Any, Any]]:
             async with semaphore:
-                return await scenario.run(
-                    target=target, return_exception=return_exception
-                )
+                # Show a row per scenario while it runs, so all in-flight ones appear.
+                sub_id = progress.add_task(f"  ↳ {scenario.name}", total=None)
+                try:
+                    result = await scenario.run(
+                        target=target, return_exception=return_exception
+                    )
+                finally:
+                    progress.remove_task(sub_id)
+                progress.advance(overall_id)
+            return result
 
         try:
             async with asyncio.TaskGroup() as task_group:

--- a/libs/giskard-checks/tests/core/test_suite.py
+++ b/libs/giskard-checks/tests/core/test_suite.py
@@ -316,14 +316,14 @@ def test_progress_counter_appears_only_on_the_overall_row():
 
 @pytest.mark.asyncio
 async def test_suite_progress_can_be_disabled(monkeypatch):
-    """`progress=False` builds a disabled bar so its calls are no-ops."""
+    """`verbose=False` builds a disabled bar so its calls are no-ops."""
     bars = []
     monkeypatch.setattr(Progress, "__enter__", lambda self: bars.append(self) or self)
 
     suite = Suite(name="progress_off_suite", target=lambda inputs: inputs)
     suite.append(Scenario("a").interact("a"))
 
-    await suite.run(progress=False)
+    await suite.run(verbose=False)
 
     assert bars[0].disable is True
 

--- a/libs/giskard-checks/tests/core/test_suite.py
+++ b/libs/giskard-checks/tests/core/test_suite.py
@@ -4,7 +4,8 @@ from contextlib import nullcontext
 
 import pytest
 from giskard.checks import Equals, Scenario, Suite
-from giskard.checks.scenarios.suite import _OverallOnly
+from giskard.checks.core.result import ScenarioStatus
+from giskard.checks.scenarios.suite import _OverallOnly, _SuiteProgress
 from rich.progress import MofNCompleteColumn, Progress
 
 
@@ -342,3 +343,59 @@ async def test_suite_parallel_progress_shows_a_row_per_scenario(monkeypatch):
 
     assert "  ↳ alpha" in rows
     assert "  ↳ beta" in rows
+
+
+def test_progress_summary_shows_all_nonzero_counts_in_order():
+    """The live summary line lists errored, failed, skipped, passed in that order."""
+    progress = _SuiteProgress(disable=True)
+    for _ in range(19):
+        progress.record(ScenarioStatus.PASS)
+    for _ in range(5):
+        progress.record(ScenarioStatus.FAIL)
+    for _ in range(2):
+        progress.record(ScenarioStatus.SKIP)
+    progress.record(ScenarioStatus.ERROR)
+
+    summary = progress._summary_renderable()
+    assert summary is not None
+    assert summary.plain.strip() == "1 errored, 5 failed, 2 skipped, 19 passed"
+
+
+def test_progress_summary_omits_zero_counts():
+    """Statuses with no occurrences are not shown."""
+    progress = _SuiteProgress(disable=True)
+    for _ in range(3):
+        progress.record(ScenarioStatus.PASS)
+    progress.record(ScenarioStatus.FAIL)
+
+    summary = progress._summary_renderable()
+    assert summary is not None
+    assert summary.plain.strip() == "1 failed, 3 passed"
+
+
+def test_progress_summary_absent_before_any_scenario_completes():
+    """No summary line until at least one scenario has finished."""
+    progress = _SuiteProgress(disable=True)
+    assert progress._summary_renderable() is None
+
+
+@pytest.mark.asyncio
+async def test_suite_progress_records_each_scenario_outcome(monkeypatch):
+    """Each finished scenario feeds its status into the live counts, in order."""
+    recorded = []
+    monkeypatch.setattr(
+        _SuiteProgress, "record", lambda self, status: recorded.append(status)
+    )
+
+    passing = Scenario("s1").interact("a", "a")
+    failing = (
+        Scenario("s2")
+        .interact("b", "c")
+        .check(Equals(expected_value="b", key="trace.last.outputs"))
+    )
+    suite = Suite(name="record_suite")
+    suite.append(passing).append(failing)
+
+    await suite.run()
+
+    assert recorded == [ScenarioStatus.PASS, ScenarioStatus.FAIL]

--- a/libs/giskard-checks/tests/core/test_suite.py
+++ b/libs/giskard-checks/tests/core/test_suite.py
@@ -4,6 +4,8 @@ from contextlib import nullcontext
 
 import pytest
 from giskard.checks import Equals, Scenario, Suite
+from giskard.checks.scenarios.suite import _OverallOnly
+from rich.progress import MofNCompleteColumn, Progress
 
 
 @pytest.fixture
@@ -292,3 +294,51 @@ async def test_suite_parallel_rejects_invalid_max_concurrency():
 
     with pytest.raises(ValueError, match="max_concurrency must be greater than 0"):
         await suite.run(parallel=True, max_concurrency=0)
+
+
+def test_progress_counter_appears_only_on_the_overall_row():
+    """The counter shows on the overall summary row and is blank on scenario rows."""
+    column = _OverallOnly(MofNCompleteColumn())
+    with Progress(column, disable=True) as progress:
+        overall_id = progress.add_task("overall", total=3, completed=1, overall=True)
+        scenario_id = progress.add_task("scenario", total=None)
+        by_id = {task.id: task for task in progress.tasks}
+
+    assert column.render(by_id[overall_id]).plain == "1/3"
+    assert column.render(by_id[scenario_id]).plain == ""
+
+
+@pytest.mark.asyncio
+async def test_suite_progress_can_be_disabled(monkeypatch):
+    """`progress=False` builds a disabled bar so its calls are no-ops."""
+    bars = []
+    monkeypatch.setattr(Progress, "__enter__", lambda self: bars.append(self) or self)
+
+    suite = Suite(name="progress_off_suite", target=lambda inputs: inputs)
+    suite.append(Scenario("a").interact("a"))
+
+    await suite.run(progress=False)
+
+    assert bars[0].disable is True
+
+
+@pytest.mark.asyncio
+async def test_suite_parallel_progress_shows_a_row_per_scenario(monkeypatch):
+    """Parallel mode adds one progress row per running scenario."""
+    rows = []
+    original_add_task = Progress.add_task
+
+    def record_row(self, description, **kwargs):
+        rows.append(description)
+        return original_add_task(self, description, **kwargs)
+
+    monkeypatch.setattr(Progress, "add_task", record_row)
+
+    suite = Suite(name="progress_rows_suite", target=lambda inputs: inputs)
+    for name in ("alpha", "beta"):
+        suite.append(Scenario(name).interact("hi"))
+
+    await suite.run(parallel=True)
+
+    assert "  ↳ alpha" in rows
+    assert "  ↳ beta" in rows

--- a/libs/giskard-checks/tests/core/test_suite.py
+++ b/libs/giskard-checks/tests/core/test_suite.py
@@ -7,6 +7,7 @@ from giskard.checks import Equals, Scenario, Suite
 from giskard.checks.core.result import ScenarioStatus
 from giskard.checks.scenarios.suite import _OverallOnly, _SuiteProgress
 from rich.progress import MofNCompleteColumn, Progress
+from rich.text import Text
 
 
 @pytest.fixture
@@ -305,8 +306,12 @@ def test_progress_counter_appears_only_on_the_overall_row():
         scenario_id = progress.add_task("scenario", total=None)
         by_id = {task.id: task for task in progress.tasks}
 
-    assert column.render(by_id[overall_id]).plain == "1/3"
-    assert column.render(by_id[scenario_id]).plain == ""
+    overall = column.render(by_id[overall_id])
+    scenario = column.render(by_id[scenario_id])
+    assert isinstance(overall, Text)
+    assert isinstance(scenario, Text)
+    assert overall.plain == "1/3"
+    assert scenario.plain == ""
 
 
 @pytest.mark.asyncio

--- a/libs/giskard-checks/tests/core/test_suite.py
+++ b/libs/giskard-checks/tests/core/test_suite.py
@@ -350,38 +350,41 @@ async def test_suite_parallel_progress_shows_a_row_per_scenario(monkeypatch):
     assert "  ↳ beta" in rows
 
 
-def test_progress_summary_shows_all_nonzero_counts_in_order():
-    """The live summary line lists errored, failed, skipped, passed in that order."""
+@pytest.mark.parametrize(
+    ("records", "expected"),
+    [
+        ([], None),
+        (
+            [
+                ScenarioStatus.FAIL,
+                ScenarioStatus.PASS,
+                ScenarioStatus.PASS,
+                ScenarioStatus.PASS,
+            ],
+            "1 failed, 3 passed",
+        ),
+        (
+            [ScenarioStatus.ERROR]
+            + [ScenarioStatus.SKIP] * 2
+            + [ScenarioStatus.FAIL] * 5
+            + [ScenarioStatus.PASS] * 19,
+            "1 errored, 5 failed, 2 skipped, 19 passed",
+        ),
+    ],
+    ids=["empty", "omits_zero_counts", "all_nonzero_in_order"],
+)
+def test_progress_summary_renderable(records, expected):
+    """Live summary lists errored, failed, skipped, passed; omits zeros; absent when empty."""
     progress = _SuiteProgress(disable=True)
-    for _ in range(19):
-        progress.record(ScenarioStatus.PASS)
-    for _ in range(5):
-        progress.record(ScenarioStatus.FAIL)
-    for _ in range(2):
-        progress.record(ScenarioStatus.SKIP)
-    progress.record(ScenarioStatus.ERROR)
+    for status in records:
+        progress.record(status)
 
     summary = progress._summary_renderable()
-    assert summary is not None
-    assert summary.plain.strip() == "1 errored, 5 failed, 2 skipped, 19 passed"
-
-
-def test_progress_summary_omits_zero_counts():
-    """Statuses with no occurrences are not shown."""
-    progress = _SuiteProgress(disable=True)
-    for _ in range(3):
-        progress.record(ScenarioStatus.PASS)
-    progress.record(ScenarioStatus.FAIL)
-
-    summary = progress._summary_renderable()
-    assert summary is not None
-    assert summary.plain.strip() == "1 failed, 3 passed"
-
-
-def test_progress_summary_absent_before_any_scenario_completes():
-    """No summary line until at least one scenario has finished."""
-    progress = _SuiteProgress(disable=True)
-    assert progress._summary_renderable() is None
+    if expected is None:
+        assert summary is None
+    else:
+        assert summary is not None
+        assert summary.plain.strip() == expected
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

This PR adds a progress bar to `Suite` run, making it easier to track which `Scenario` is being executed (or more than one if `parallel=True`).

<img width="2034" height="592" alt="CleanShot 2026-06-04 at 19 41 27@2x" src="https://github.com/user-attachments/assets/4692a448-1700-4d64-aabe-9935e7d4243c" />

## Related Issue
#2473 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix