### PR TITLE
fix: correct issue template version command

### DIFF
--- a/.github/ISSUE_TEMPLATE/giskard_bug_template.yaml
+++ b/.github/ISSUE_TEMPLATE/giskard_bug_template.yaml
@@ -33,7 +33,7 @@ body:
     id: giskard-lib-version
     attributes:
       label: Giskard Library Version
-      description: You can  obtain the Giskard library version with `python -c "import giskard ; print(giskard.__version__)"`
+      description: For pip/uv installs, run `python -c "import importlib.metadata as m; print(m.version('giskard'))"`; for source check the version in `pyproject.toml`.
       placeholder: e.g., 3.0.0a1
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/giskard_bug_template.yaml
+++ b/.github/ISSUE_TEMPLATE/giskard_bug_template.yaml
@@ -33,7 +33,7 @@ body:
     id: giskard-lib-version
     attributes:
       label: Giskard Library Version
-      description: For pip/uv installs, run `python -c "import importlib.metadata as m; print(m.version('giskard'))"`; for source check the version in `pyproject.toml`.
+      description: For pip installs, run `pip show giskard`; for uv installs, run `uv pip show giskard`; for source check the version in `pyproject.toml`.
       placeholder: e.g., 3.0.0a1
     validations:
       required: true


### PR DESCRIPTION
closes #2515
  ## Summary
  - fix the bug report template command for retrieving the Giskard version
  - replace the broken `giskard.__version__` example with `importlib.metadata.version("giskard")`
  - clarify that source checkouts should use the version from `pyproject.toml`

  ## Why
  The current issue template asks users to run:

  ```bash
  python -c "import giskard ; print(giskard.__version__)"

  but giskard.__version__ is not exposed, so that command fails and makes bug reporting harder.

  ## Testing

  - verified the updated issue template text in .github/ISSUE_TEMPLATE/giskard_bug_template.yaml
