### PR TITLE
feat(giskard-checks): add giskard CLI for running check scenarios 🤖🤖🤖🤖

### DIFF
--- a/libs/giskard-checks/pyproject.toml
+++ b/libs/giskard-checks/pyproject.toml
@@ -17,12 +17,18 @@ dependencies = [
     "rich>=14.2.0,<16",
 ]
 
+[project.scripts]
+giskard = "giskard.checks.cli:main"
+
 [project.optional-dependencies]
 readability = [
     "textstat>=0.7.0",
 ]
 regorus = ["celine-regorus>=0.9.1"]
-all = ["giskard-checks[regorus]"] # Install all optional dependencies
+yaml = [
+    "pyyaml>=6.0.2,<7",
+]
+all = ["giskard-checks[regorus,yaml]"] # Install all optional dependencies
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "src"]

--- a/libs/giskard-checks/src/giskard/checks/cli.py
+++ b/libs/giskard-checks/src/giskard/checks/cli.py
@@ -10,8 +10,6 @@ from pydantic import TypeAdapter, ValidationError
 from rich.console import Console
 from rich.table import Table
 
-from giskard.core.discriminated import _REGISTRY
-
 from . import builtin, judges, testing  # noqa: F401
 from .core.check import Check
 from .core.importing import python_reference_path
@@ -157,8 +155,11 @@ def _write_text_output(output: str, path: Path | None) -> None:
         print(output)
         return
 
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(output, encoding="utf-8")
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(output, encoding="utf-8")
+    except OSError as exc:
+        raise CliError(f"Failed to write output to {path}: {exc}") from exc
 
 
 def _result_exit_code(result: ScenarioResult[Any] | SuiteResult) -> int:
@@ -260,9 +261,7 @@ def _validate_command(args: argparse.Namespace) -> int:
 
 
 def _iter_registered_checks() -> list[tuple[str, type[Any]]]:
-    metadata = getattr(Check, "__pydantic_generic_metadata__", {})
-    origin = metadata.get("origin") or Check
-    registered = dict(_REGISTRY._reverse_kinds.get(origin, {}))
+    registered = Check.list_registered_types()
     checks = [
         (kind, cls)
         for kind, cls in registered.items()

--- a/libs/giskard-checks/src/giskard/checks/cli.py
+++ b/libs/giskard-checks/src/giskard/checks/cli.py
@@ -1,0 +1,404 @@
+import argparse
+import asyncio
+import inspect
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+from pydantic import TypeAdapter, ValidationError
+from rich.console import Console
+from rich.table import Table
+
+from giskard.core.discriminated import _REGISTRY
+
+from . import builtin, judges, testing  # noqa: F401
+from .core.check import Check
+from .core.importing import python_reference_path
+from .core.result import ScenarioResult, SuiteResult
+from .core.scenario import Scenario
+from .scenarios.suite import Suite
+
+console = Console()
+error_console = Console(stderr=True)
+
+
+class CliError(Exception):
+    """Raised for expected CLI errors with a specific exit code.
+
+    Parameters
+    ----------
+    message : str
+        Human-readable error description.
+    exit_code : int, optional
+        Process exit code to use, by default 2.
+    """
+
+    def __init__(self, message: str, exit_code: int = 2):
+        super().__init__(message)
+        self.exit_code = exit_code
+
+
+@dataclass(frozen=True)
+class LoadedDefinition:
+    """A parsed and validated scenario or suite definition.
+
+    Attributes
+    ----------
+    kind : str
+        Either ``"scenario"`` or ``"suite"``.
+    value : Scenario | Suite
+        The validated definition object.
+    path : Path
+        Absolute path to the source file.
+    """
+
+    kind: str
+    value: Scenario[Any, Any, Any] | Suite[Any, Any]
+    path: Path
+
+
+def _load_yaml(raw: str, path: Path) -> Any:
+    try:
+        import yaml
+    except ImportError as exc:
+        raise CliError(
+            "YAML support requires PyYAML. Install `giskard-checks[yaml]` or use a JSON definition file."
+        ) from exc
+
+    try:
+        return yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise CliError(f"Failed to parse {path.name}: {exc}") from exc
+
+
+def _load_file(path: Path) -> Any:
+    if not path.exists():
+        raise CliError(f"Definition file not found: {path}")
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise CliError(f"Unable to read definition file {path}: {exc}") from exc
+
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise CliError(f"Failed to parse {path.name}: {exc}") from exc
+
+    if suffix in {".yaml", ".yml"}:
+        return _load_yaml(raw, path)
+
+    raise CliError(
+        f"Unsupported file type for {path.name}. Expected .json, .yaml, or .yml."
+    )
+
+
+def load_definition(path_str: str) -> LoadedDefinition:
+    """Load and validate a scenario or suite definition file.
+
+    Parameters
+    ----------
+    path_str : str
+        Path to a ``.json``, ``.yaml``, or ``.yml`` definition file.
+
+    Returns
+    -------
+    LoadedDefinition
+        The kind, validated value, and resolved absolute path.
+
+    Raises
+    ------
+    CliError
+        If the file cannot be found, read, parsed, or validated.
+    """
+    path = Path(path_str).expanduser().resolve()
+    payload = _load_file(path)
+
+    if not isinstance(payload, dict):
+        raise CliError(f"Definition file {path.name} must contain a top-level object.")
+
+    if "scenarios" not in payload and "steps" not in payload:
+        raise CliError(
+            f"Unable to determine definition type for {path.name}. Expected top-level 'steps' or 'scenarios'."
+        )
+
+    definition_kind = "suite" if "scenarios" in payload else "scenario"
+    adapter: TypeAdapter[Suite[Any, Any] | Scenario[Any, Any, Any]]
+    if definition_kind == "suite":
+        adapter = TypeAdapter(Suite[Any, Any])
+    else:
+        adapter = TypeAdapter(Scenario[Any, Any, Any])
+
+    try:
+        with python_reference_path(path):
+            definition = adapter.validate_python(payload, context={"path": path})
+    except ValidationError as exc:
+        raise CliError(f"Invalid definition in {path.name}:\n{exc}") from exc
+
+    if definition_kind == "scenario":
+        return LoadedDefinition("scenario", definition, path)
+
+    return LoadedDefinition("suite", definition, path)
+
+
+def _build_suite_result(
+    result: ScenarioResult[Any] | SuiteResult,
+) -> SuiteResult:
+    if isinstance(result, SuiteResult):
+        return result
+    return SuiteResult(results=[result], duration_ms=result.duration_ms)
+
+
+def _write_text_output(output: str, path: Path | None) -> None:
+    if path is None:
+        print(output)
+        return
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(output, encoding="utf-8")
+
+
+def _result_exit_code(result: ScenarioResult[Any] | SuiteResult) -> int:
+    suite_result = _build_suite_result(result)
+    return 0 if not suite_result.failures_and_errors else 1
+
+
+def _render_json(result: ScenarioResult[Any] | SuiteResult) -> str:
+    return json.dumps(result.model_dump(mode="json"), indent=2, default=str)
+
+
+def _run_command(args: argparse.Namespace) -> int:
+    """Execute the ``giskard run`` sub-command.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Parsed CLI arguments containing ``path``, ``format``, and ``output``.
+
+    Returns
+    -------
+    int
+        0 if all checks passed, 1 if any check failed or errored.
+    """
+    loaded = load_definition(args.path)
+    execution = asyncio.run(
+        cast(Any, loaded.value).run(return_exception=True)  # pyright: ignore[reportAttributeAccessIssue]
+    )
+
+    output_path = Path(args.output).expanduser().resolve() if args.output else None
+    if args.format == "rich":
+        if output_path is not None:
+            raise CliError(
+                "The rich format does not support --output. Use json or junit."
+            )
+        console.print(execution)
+    elif args.format == "json":
+        _write_text_output(_render_json(execution), output_path)
+    elif args.format == "junit":
+        if output_path:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+        xml = _build_suite_result(execution).to_junit_xml(path=output_path)
+        if output_path is None:
+            print(xml)
+    else:
+        raise CliError(f"Unsupported output format: {args.format}")
+
+    return _result_exit_code(execution)
+
+
+def _validate_summary(loaded: LoadedDefinition) -> dict[str, Any]:
+    if loaded.kind == "scenario":
+        scenario = cast(Scenario[Any, Any, Any], loaded.value)
+        return {
+            "valid": True,
+            "type": "scenario",
+            "name": scenario.name,
+            "steps": len(scenario.steps),
+        }
+
+    suite = cast(Suite[Any, Any], loaded.value)
+    return {
+        "valid": True,
+        "type": "suite",
+        "name": suite.name,
+        "scenarios": len(suite.scenarios),
+    }
+
+
+def _validate_command(args: argparse.Namespace) -> int:
+    """Execute the ``giskard validate`` sub-command.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Parsed CLI arguments containing ``path`` and ``format``.
+
+    Returns
+    -------
+    int
+        0 on success, 2 if the definition is invalid.
+    """
+    loaded = load_definition(args.path)
+    summary = _validate_summary(loaded)
+
+    if args.format == "json":
+        print(json.dumps(summary, indent=2))
+    else:
+        if loaded.kind == "scenario":
+            console.print(
+                f"[green]Valid scenario[/green] '{summary['name']}' with {summary['steps']} step(s)."
+            )
+        else:
+            console.print(
+                f"[green]Valid suite[/green] '{summary['name']}' with {summary['scenarios']} scenario(s)."
+            )
+
+    return 0
+
+
+def _iter_registered_checks() -> list[tuple[str, type[Any]]]:
+    metadata = getattr(Check, "__pydantic_generic_metadata__", {})
+    origin = metadata.get("origin") or Check
+    registered = dict(_REGISTRY._reverse_kinds.get(origin, {}))
+    checks = [
+        (kind, cls)
+        for kind, cls in registered.items()
+        if cls.__module__.startswith("giskard.checks.")
+        and ".testing." not in cls.__module__
+        and ".tests." not in cls.__module__
+    ]
+    return sorted(checks, key=lambda item: item[0])
+
+
+def _list_checks_command(args: argparse.Namespace) -> int:
+    """Execute the ``giskard list checks`` sub-command.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Parsed CLI arguments containing ``format``.
+
+    Returns
+    -------
+    int
+        Always 0.
+    """
+    registered_checks = _iter_registered_checks()
+    if args.format == "json":
+        payload = [
+            {
+                "kind": kind,
+                "class_name": cls.__name__,
+                "module": cls.__module__,
+                "summary": (inspect.getdoc(cls) or "").splitlines()[0]
+                if inspect.getdoc(cls)
+                else "",
+            }
+            for kind, cls in registered_checks
+        ]
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    table = Table(title="Available Checks")
+    table.add_column("Kind")
+    table.add_column("Class")
+    table.add_column("Summary")
+    for kind, cls in registered_checks:
+        doc = inspect.getdoc(cls) or ""
+        summary = doc.splitlines()[0] if doc else ""
+        table.add_row(kind, cls.__name__, summary)
+    console.print(table)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the top-level argument parser for the ``giskard`` CLI.
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        Configured parser with ``run``, ``validate``, and ``list`` sub-commands.
+    """
+    parser = argparse.ArgumentParser(
+        prog="giskard",
+        description="Run and validate Giskard scenarios and suites from YAML or JSON.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser(
+        "run", help="Run a scenario or suite definition from YAML or JSON."
+    )
+    run_parser.add_argument("path", help="Path to a .yaml, .yml, or .json definition.")
+    run_parser.add_argument(
+        "--format",
+        choices=("rich", "json", "junit"),
+        default="rich",
+        help="Output format for run results.",
+    )
+    run_parser.add_argument(
+        "--output",
+        help="Optional file path for json or junit output.",
+    )
+    run_parser.set_defaults(handler=_run_command)
+
+    validate_parser = subparsers.add_parser(
+        "validate", help="Validate a scenario or suite definition without running it."
+    )
+    validate_parser.add_argument(
+        "path", help="Path to a .yaml, .yml, or .json definition."
+    )
+    validate_parser.add_argument(
+        "--format",
+        choices=("rich", "json"),
+        default="rich",
+        help="Output format for validation results.",
+    )
+    validate_parser.set_defaults(handler=_validate_command)
+
+    list_parser = subparsers.add_parser(
+        "list", help="List available objects exposed by the CLI."
+    )
+    list_subparsers = list_parser.add_subparsers(dest="list_command", required=True)
+    checks_parser = list_subparsers.add_parser(
+        "checks", help="List built-in checks that can be referenced in definitions."
+    )
+    checks_parser.add_argument(
+        "--format",
+        choices=("table", "json"),
+        default="table",
+        help="Output format for the checks listing.",
+    )
+    checks_parser.set_defaults(handler=_list_checks_command)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the ``giskard`` CLI.
+
+    Parameters
+    ----------
+    argv : list[str] | None, optional
+        Argument list to parse. Defaults to ``sys.argv[1:]`` when ``None``.
+
+    Returns
+    -------
+    int
+        Process exit code: 0 on success, 1 on check failures, 2 on usage errors.
+    """
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        handler = args.handler
+        return handler(args)
+    except CliError as exc:
+        error_console.print(f"[red]{exc}[/red]")
+        return exc.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/libs/giskard-checks/src/giskard/checks/core/importing.py
+++ b/libs/giskard-checks/src/giskard/checks/core/importing.py
@@ -1,0 +1,155 @@
+import importlib
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from pathlib import Path
+from typing import Any
+
+_REFERENCE_PATH: ContextVar[Path | None] = ContextVar(
+    "giskard_checks_reference_path", default=None
+)
+
+
+@contextmanager
+def python_reference_path(path: Path | None) -> Iterator[None]:
+    """Context manager that sets the reference path for Python target resolution.
+
+    Parameters
+    ----------
+    path : Path | None
+        Path to the definition file being loaded. The file's parent directory
+        is used as the first search path for resolving ``python:`` references.
+
+    Yields
+    ------
+    None
+    """
+    token = _REFERENCE_PATH.set(path)
+    try:
+        yield
+    finally:
+        _REFERENCE_PATH.reset(token)
+
+
+def validation_reference_path(value: Any) -> Path | None:
+    """Return the active reference path for use in Pydantic validators.
+
+    Parameters
+    ----------
+    value : Any
+        A ``Path`` to use directly, or any other value which causes the
+        function to fall back to the context-variable path.
+
+    Returns
+    -------
+    Path | None
+        The ``Path`` if *value* is already a ``Path``, otherwise the value
+        stored in the ``_REFERENCE_PATH`` context variable.
+    """
+    if isinstance(value, Path):
+        return value
+    return _REFERENCE_PATH.get()
+
+
+def _module_search_paths(path: Path | None) -> list[str]:
+    if path is None:
+        return []
+
+    search_paths = [str(path.parent.resolve()), str(Path.cwd().resolve())]
+    unique_paths: list[str] = []
+    for candidate in search_paths:
+        if candidate not in unique_paths:
+            unique_paths.append(candidate)
+    return unique_paths
+
+
+def _module_belongs_to_search_path(module: Any, search_path: str) -> bool:
+    module_file = getattr(module, "__file__", None)
+    if module_file is None:
+        return False
+
+    return Path(module_file).resolve().is_relative_to(Path(search_path))
+
+
+def _module_belongs_to_search_paths(module: Any, search_paths: list[str]) -> bool:
+    return any(
+        _module_belongs_to_search_path(module, search_path)
+        for search_path in search_paths
+    )
+
+
+def _module_exists_in_search_path(module_name: str, search_path: str) -> bool:
+    module_parts = module_name.split(".")
+    module_root = Path(search_path).resolve().joinpath(*module_parts)
+    return (
+        module_root.with_suffix(".py").exists()
+        or (module_root / "__init__.py").exists()
+    )
+
+
+def resolve_python_reference(value: str, *, path: Path | None = None) -> Any:
+    """Resolve a ``python:module.symbol`` reference to a callable.
+
+    Parameters
+    ----------
+    value : str
+        A reference string of the form ``python:module.attribute``.
+    path : Path | None, optional
+        Path to the definition file. The file's parent directory is prepended
+        to ``sys.path`` so that modules local to the definition can be found.
+
+    Returns
+    -------
+    Any
+        The resolved attribute from the imported module.
+
+    Raises
+    ------
+    ValueError
+        If *value* does not start with ``python:``, if the format is invalid,
+        if the module cannot be imported, or if the attribute does not exist.
+    """
+    if not value.startswith("python:"):
+        raise ValueError(
+            f"Unsupported Python reference '{value}'. Expected 'python:module.symbol'."
+        )
+
+    import_path = value.removeprefix("python:")
+    module_name, _, attribute_path = import_path.rpartition(".")
+    if not module_name or not attribute_path:
+        raise ValueError(
+            f"Invalid Python reference '{value}'. Expected 'python:module.symbol'."
+        )
+
+    search_paths = _module_search_paths(path)
+    original_sys_path = sys.path[:]
+    try:
+        for search_path in reversed(search_paths):
+            if search_path not in sys.path:
+                sys.path.insert(0, search_path)
+
+        cached_module = sys.modules.get(module_name)
+        if cached_module is not None and search_paths:
+            preferred_search_path = search_paths[0]
+            if _module_exists_in_search_path(module_name, preferred_search_path):
+                if not _module_belongs_to_search_path(
+                    cached_module, preferred_search_path
+                ):
+                    sys.modules.pop(module_name, None)
+
+        importlib.invalidate_caches()
+        module = importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:
+        raise ValueError(
+            f"Could not import module '{module_name}' for Python reference '{value}': {exc}"
+        ) from exc
+    finally:
+        sys.path[:] = original_sys_path
+
+    try:
+        return getattr(module, attribute_path)
+    except AttributeError as exc:
+        raise ValueError(
+            f"Could not resolve attribute '{attribute_path}' for Python reference '{value}'."
+        ) from exc

--- a/libs/giskard-checks/src/giskard/checks/core/importing.py
+++ b/libs/giskard-checks/src/giskard/checks/core/importing.py
@@ -1,10 +1,13 @@
 import importlib
 import sys
+import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from pathlib import Path
 from typing import Any
+
+_import_lock = threading.Lock()
 
 _REFERENCE_PATH: ContextVar[Path | None] = ContextVar(
     "giskard_checks_reference_path", default=None
@@ -72,13 +75,6 @@ def _module_belongs_to_search_path(module: Any, search_path: str) -> bool:
     return Path(module_file).resolve().is_relative_to(Path(search_path))
 
 
-def _module_belongs_to_search_paths(module: Any, search_paths: list[str]) -> bool:
-    return any(
-        _module_belongs_to_search_path(module, search_path)
-        for search_path in search_paths
-    )
-
-
 def _module_exists_in_search_path(module_name: str, search_path: str) -> bool:
     module_parts = module_name.split(".")
     module_root = Path(search_path).resolve().joinpath(*module_parts)
@@ -123,29 +119,30 @@ def resolve_python_reference(value: str, *, path: Path | None = None) -> Any:
         )
 
     search_paths = _module_search_paths(path)
-    original_sys_path = sys.path[:]
-    try:
-        for search_path in reversed(search_paths):
-            if search_path not in sys.path:
-                sys.path.insert(0, search_path)
+    with _import_lock:
+        original_sys_path = sys.path[:]
+        try:
+            for search_path in reversed(search_paths):
+                if search_path not in sys.path:
+                    sys.path.insert(0, search_path)
 
-        cached_module = sys.modules.get(module_name)
-        if cached_module is not None and search_paths:
-            preferred_search_path = search_paths[0]
-            if _module_exists_in_search_path(module_name, preferred_search_path):
-                if not _module_belongs_to_search_path(
-                    cached_module, preferred_search_path
-                ):
-                    sys.modules.pop(module_name, None)
+            cached_module = sys.modules.get(module_name)
+            if cached_module is not None and search_paths:
+                preferred_search_path = search_paths[0]
+                if _module_exists_in_search_path(module_name, preferred_search_path):
+                    if not _module_belongs_to_search_path(
+                        cached_module, preferred_search_path
+                    ):
+                        sys.modules.pop(module_name, None)
 
-        importlib.invalidate_caches()
-        module = importlib.import_module(module_name)
-    except ModuleNotFoundError as exc:
-        raise ValueError(
-            f"Could not import module '{module_name}' for Python reference '{value}': {exc}"
-        ) from exc
-    finally:
-        sys.path[:] = original_sys_path
+            importlib.invalidate_caches()
+            module = importlib.import_module(module_name)
+        except ModuleNotFoundError as exc:
+            raise ValueError(
+                f"Could not import module '{module_name}' for Python reference '{value}': {exc}"
+            ) from exc
+        finally:
+            sys.path[:] = original_sys_path
 
     try:
         return getattr(module, attribute_path)

--- a/libs/giskard-checks/src/giskard/checks/core/scenario.py
+++ b/libs/giskard-checks/src/giskard/checks/core/scenario.py
@@ -1,9 +1,10 @@
 from typing import Any, Self
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationInfo, field_validator
 from pydantic.experimental.missing_sentinel import MISSING
 
 from .check import Check
+from .importing import resolve_python_reference, validation_reference_path
 from .input_generator import InputGenerator
 from .interaction import Interact, InteractionSpec, Trace
 from .result import ScenarioResult
@@ -122,6 +123,62 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
         default_factory=list,
         description="Flat 'Key:Value' labels for grouping and Hub upload alignment.",
     )
+
+    @field_validator("target", mode="before")
+    @classmethod
+    def _load_target_reference(cls, value: Any, info: ValidationInfo) -> Any:
+        """Resolve a ``python:module.symbol`` string into a callable target.
+
+        Parameters
+        ----------
+        value : Any
+            The raw field value from deserialisation. Passed through unchanged
+            unless it is a ``str`` beginning with ``python:``.
+        info : ValidationInfo
+            Pydantic validation context. When a ``"path"`` key is present the
+            corresponding ``Path`` is used as the definition-file location for
+            module resolution.
+
+        Returns
+        -------
+        Any
+            The resolved callable, or *value* unchanged when it is not a string.
+        """
+        if not isinstance(value, str):
+            return value
+
+        path = validation_reference_path(
+            info.context.get("path") if isinstance(info.context, dict) else None
+        )
+        return resolve_python_reference(value, path=path)
+
+    @field_validator("trace_type", mode="before")
+    @classmethod
+    def _load_trace_type_reference(cls, value: Any, info: ValidationInfo) -> Any:
+        """Resolve a ``python:module.symbol`` string into a trace type class.
+
+        Parameters
+        ----------
+        value : Any
+            The raw field value from deserialisation. Passed through unchanged
+            unless it is a ``str`` beginning with ``python:``.
+        info : ValidationInfo
+            Pydantic validation context. When a ``"path"`` key is present the
+            corresponding ``Path`` is used as the definition-file location for
+            module resolution.
+
+        Returns
+        -------
+        Any
+            The resolved class, or *value* unchanged when it is not a string.
+        """
+        if not isinstance(value, str):
+            return value
+
+        path = validation_reference_path(
+            info.context.get("path") if isinstance(info.context, dict) else None
+        )
+        return resolve_python_reference(value, path=path)
 
     def __init__(
         self,

--- a/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager, nullcontext
 from typing import Any, Generic, Self, TypeVar
 
 from giskard.core import telemetry_capture, telemetry_run_context, telemetry_tag
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationInfo, field_validator
 from pydantic.experimental.missing_sentinel import MISSING
 from rich.console import RenderableType
 from rich.progress import (
@@ -21,6 +21,7 @@ from rich.progress import (
 )
 from rich.text import Text
 
+from ..core.importing import resolve_python_reference, validation_reference_path
 from .._telemetry_props import suite_shape_properties
 from ..core.interaction import Trace
 from ..core.result import (
@@ -138,6 +139,34 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
         default=MISSING,
         description="Suite-level target SUT that will override any scenario-level target.",
     )
+
+    @field_validator("target", mode="before")
+    @classmethod
+    def _load_target_reference(cls, value: Any, info: ValidationInfo) -> Any:
+        """Resolve a ``python:module.symbol`` string into a callable target.
+
+        Parameters
+        ----------
+        value : Any
+            The raw field value from deserialisation. Passed through unchanged
+            unless it is a ``str`` beginning with ``python:``.
+        info : ValidationInfo
+            Pydantic validation context. When a ``"path"`` key is present the
+            corresponding ``Path`` is used as the definition-file location for
+            module resolution.
+
+        Returns
+        -------
+        Any
+            The resolved callable, or *value* unchanged when it is not a string.
+        """
+        if not isinstance(value, str):
+            return value
+
+        path = validation_reference_path(
+            info.context.get("path") if isinstance(info.context, dict) else None
+        )
+        return resolve_python_reference(value, path=path)
 
     def append(
         self,

--- a/libs/giskard-checks/tests/cli/data/invalid_target.json
+++ b/libs/giskard-checks/tests/cli/data/invalid_target.json
@@ -1,0 +1,14 @@
+{
+  "name": "broken_test",
+  "target": "python:missing_targets.missing",
+  "steps": [
+    {
+      "interacts": [
+        {
+          "kind": "interact",
+          "inputs": "hello"
+        }
+      ]
+    }
+  ]
+}

--- a/libs/giskard-checks/tests/cli/data/scenario.json
+++ b/libs/giskard-checks/tests/cli/data/scenario.json
@@ -1,0 +1,20 @@
+{
+  "name": "basic_test",
+  "target": "python:targets.explain_python",
+  "steps": [
+    {
+      "interacts": [
+        {
+          "kind": "interact",
+          "inputs": "What is Python?"
+        }
+      ],
+      "checks": [
+        {
+          "kind": "string_matching",
+          "keyword": "programming language"
+        }
+      ]
+    }
+  ]
+}

--- a/libs/giskard-checks/tests/cli/data/scenario.yaml
+++ b/libs/giskard-checks/tests/cli/data/scenario.yaml
@@ -1,0 +1,9 @@
+name: basic_test
+target: python:targets.explain_python
+steps:
+  - interacts:
+      - kind: interact
+        inputs: What is Python?
+    checks:
+      - kind: string_matching
+        keyword: programming language

--- a/libs/giskard-checks/tests/cli/data/suite.json
+++ b/libs/giskard-checks/tests/cli/data/suite.json
@@ -1,0 +1,26 @@
+{
+  "name": "cli_suite",
+  "target": "python:targets.echo",
+  "scenarios": [
+    {
+      "name": "suite_case",
+      "steps": [
+        {
+          "interacts": [
+            {
+              "kind": "interact",
+              "inputs": "hello"
+            }
+          ],
+          "checks": [
+            {
+              "kind": "equals",
+              "key": "trace.last.outputs",
+              "expected_value": "hello"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/libs/giskard-checks/tests/cli/data/targets.py
+++ b/libs/giskard-checks/tests/cli/data/targets.py
@@ -1,0 +1,6 @@
+def explain_python(inputs):
+    return "Python is a programming language."
+
+
+def echo(inputs):
+    return inputs

--- a/libs/giskard-checks/tests/cli/data/trace_type.json
+++ b/libs/giskard-checks/tests/cli/data/trace_type.json
@@ -1,0 +1,5 @@
+{
+  "name": "custom_trace_test",
+  "trace_type": "python:trace_types.CustomTrace",
+  "steps": []
+}

--- a/libs/giskard-checks/tests/cli/data/trace_types.py
+++ b/libs/giskard-checks/tests/cli/data/trace_types.py
@@ -1,0 +1,5 @@
+from giskard.checks import Trace
+
+
+class CustomTrace(Trace[str, str], frozen=True):
+    pass

--- a/libs/giskard-checks/tests/cli/test_cli.py
+++ b/libs/giskard-checks/tests/cli/test_cli.py
@@ -1,0 +1,178 @@
+import json
+from pathlib import Path
+
+import pytest
+from giskard.checks.cli import main
+
+DATA_DIR = Path(__file__).parent / "data"
+
+
+def test_help_lists_commands(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit):
+        main(["--help"])
+
+    captured = capsys.readouterr()
+    assert "run" in captured.out
+    assert "validate" in captured.out
+    assert "list" in captured.out
+
+
+def test_list_checks_includes_string_matching(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(["list", "checks"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "string_matching" in captured.out
+    assert "regex_matching" in captured.out
+
+
+def test_validate_scenario_json(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main(["validate", str(DATA_DIR / "scenario.json")])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Valid scenario" in captured.out
+    assert "basic_test" in captured.out
+
+
+def test_validate_scenario_yaml_when_pyyaml_is_available(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    pytest.importorskip("yaml")
+
+    exit_code = main(["validate", str(DATA_DIR / "scenario.yaml")])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Valid scenario" in captured.out
+    assert "basic_test" in captured.out
+
+
+def test_run_scenario_json_output(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main(["run", str(DATA_DIR / "scenario.json"), "--format", "json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert payload["scenario_name"] == "basic_test"
+    assert payload["status"] == "pass"
+
+
+def test_run_suite_json_writes_junit_output(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    output_path = tmp_path / "reports" / "results.xml"
+
+    exit_code = main(
+        [
+            "run",
+            str(DATA_DIR / "suite.json"),
+            "--format",
+            "junit",
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    capsys.readouterr()
+    assert exit_code == 0
+    assert output_path.exists()
+    assert "<testsuite" in output_path.read_text(encoding="utf-8")
+
+
+def test_validate_scenario_with_trace_type_string(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(["validate", str(DATA_DIR / "trace_type.json")])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Valid scenario" in captured.out
+    assert "custom_trace_test" in captured.out
+
+
+def test_run_prefers_definition_directory_targets_over_cwd_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    cwd_dir = tmp_path / "cwd_case"
+    cwd_dir.mkdir()
+    (cwd_dir / "targets.py").write_text(
+        "\n".join(
+            [
+                "def explain_python(inputs):",
+                '    return "Wrong answer from cwd."',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    cached_scenario_path = cwd_dir / "cached.json"
+    cached_scenario_path.write_text(
+        json.dumps(
+            {
+                "name": "cached_target",
+                "target": "python:targets.explain_python",
+                "steps": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    scenario_dir = tmp_path / "scenario_case"
+    scenario_dir.mkdir()
+    (scenario_dir / "targets.py").write_text(
+        "\n".join(
+            [
+                "def explain_python(inputs):",
+                '    return "Python is a programming language."',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    scenario_path = scenario_dir / "scenario.json"
+    scenario_path.write_text(
+        json.dumps(
+            {
+                "name": "basic_test",
+                "target": "python:targets.explain_python",
+                "steps": [
+                    {
+                        "interacts": [
+                            {"kind": "interact", "inputs": "What is Python?"}
+                        ],
+                        "checks": [
+                            {
+                                "kind": "string_matching",
+                                "keyword": "programming language",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(cwd_dir)
+    assert main(["validate", str(cached_scenario_path)]) == 0
+    capsys.readouterr()
+
+    exit_code = main(["run", str(scenario_path), "--format", "json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert (
+        payload["final_trace"]["last"]["outputs"] == "Python is a programming language."
+    )
+
+
+def test_validate_reports_invalid_target(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main(["validate", str(DATA_DIR / "invalid_target.json")])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "Could not import module 'missing_targets'" in captured.err

--- a/libs/giskard-core/src/giskard/core/discriminated.py
+++ b/libs/giskard-core/src/giskard/core/discriminated.py
@@ -89,6 +89,32 @@ class Discriminated(BaseModel):
         return decorator
 
     @classmethod
+    def list_registered_kinds(cls) -> tuple[str, ...]:
+        """Return registered discriminator kinds for this discriminated base.
+
+        Returns
+        -------
+        tuple[str, ...]
+            Sorted tuple of kind strings registered under this base class.
+        """
+        metadata = getattr(cls, "__pydantic_generic_metadata__", {})
+        origin = metadata.get("origin") or cls
+        return tuple(sorted(_REGISTRY._reverse_kinds.get(origin, {})))
+
+    @classmethod
+    def list_registered_types(cls) -> dict[str, type[Any]]:
+        """Return registered discriminator kinds and their concrete types.
+
+        Returns
+        -------
+        dict[str, type[Any]]
+            Mapping of kind string to concrete subclass for this base class.
+        """
+        metadata = getattr(cls, "__pydantic_generic_metadata__", {})
+        origin = metadata.get("origin") or cls
+        return dict(_REGISTRY._reverse_kinds.get(origin, {}))
+
+    @classmethod
     def __get_pydantic_core_schema__(
         cls, source: Any, handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:


### PR DESCRIPTION
## Description
Adds `giskard run <scenario_file>` CLI command for running and validating checks from the terminal.

This PR adds:
- `giskard run <file>` — run a scenario or suite from YAML/JSON
- `giskard validate <file>` — validate a definition without running it
- `giskard list checks` — list all registered built-in checks
- Output formats: rich terminal (default), JSON, and JUnit XML
- `python:module.symbol` target and trace_type resolution for YAML/JSON definitions
- Optional YAML support via `giskard-checks[yaml]` (`pyyaml` extra)

Also adds `list_registered_kinds` / `list_registered_types` class-methods to `Discriminated` for public registry introspection.

## Related Issue
Closes #2376

## Type of Change
- [x] 🚀 New feature

## Checklist
- [x] Read CODE_OF_CONDUCT.md
- [x] Read CONTRIBUTING.md
- [x] Written tests for all new methods/classes
- [x] Written NumPy-format docstrings for new methods/classes
- [x] Updated uv.lock (if pyproject.toml changed)