### PR TITLE
fix: share schema-name sanitizer and simplify LiteLLM generator

### DIFF
--- a/libs/giskard-agents/src/giskard/agents/generators/litellm_generator.py
+++ b/libs/giskard-agents/src/giskard/agents/generators/litellm_generator.py
@@ -11,6 +11,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, cast, override
 
 from giskard.llm.types import AssistantMessage, ChatMessage, Choice, CompletionResponse
+from giskard.llm.utils import sanitize_schema_name
 from pydantic import Field
 
 from ..tools import Tool
@@ -35,6 +36,13 @@ def _import_litellm() -> Any:
             "LiteLLMGenerator requires the optional 'litellm' dependency. "
             "Install it with: pip install giskard-agents[litellm]"
         ) from exc
+
+
+def _sanitize_response_format_name(converted: dict[str, Any]) -> None:
+    """Sanitize ``converted['json_schema']['name']`` in place when present."""
+    json_schema = converted.get("json_schema")
+    if isinstance(json_schema, dict) and json_schema.get("name"):
+        json_schema["name"] = sanitize_schema_name(json_schema["name"])
 
 
 @CompletionMiddleware.register("litellm_retry")
@@ -98,6 +106,21 @@ class LiteLLMGenerator(BaseGenerator):
         data = raw if isinstance(raw, dict) else raw.model_dump()
         return AssistantMessage.model_validate(data)
 
+    def _normalize_response_format(
+        self, litellm: Any, wire_params: dict[str, Any]
+    ) -> None:
+        """Pre-convert ``response_format`` to litellm's wire dict with a safe name."""
+        response_format = wire_params.get("response_format")
+        if response_format is None:
+            return
+
+        converted = litellm.utils.type_to_response_format_param(response_format)
+        if not isinstance(converted, dict):
+            return
+
+        _sanitize_response_format_name(converted)
+        wire_params["response_format"] = converted
+
     @override
     async def _call_model(
         self,
@@ -113,6 +136,7 @@ class LiteLLMGenerator(BaseGenerator):
             wire_params["tools"] = wire_tools
         if metadata:
             wire_params["metadata"] = metadata
+        self._normalize_response_format(litellm, wire_params)
 
         raw = cast(
             "ModelResponse",

--- a/libs/giskard-agents/tests/test_litellm_generator.py
+++ b/libs/giskard-agents/tests/test_litellm_generator.py
@@ -5,15 +5,24 @@ mocked ``litellm.acompletion``. They are marked ``litellm`` so they are
 automatically skipped when the optional ``litellm`` extra is not installed.
 """
 
+import re
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
-from giskard.agents.generators.base import GenerationParams
+from giskard.agents.generators.base import BaseGenerator, GenerationParams
+from giskard.agents.generators.litellm_generator import (
+    LiteLLMGenerator,
+    LiteLLMRetryMiddleware,
+    RetryPolicy,
+)
+from pydantic import BaseModel
 
 litellm = pytest.importorskip("litellm")
 
 pytestmark = pytest.mark.litellm
+
+_USER_MESSAGE = [{"role": "user", "content": "Hi"}]
 
 
 def _make_litellm_response(content: str = "Mock response") -> Any:
@@ -31,22 +40,16 @@ def _make_litellm_response(content: str = "Mock response") -> Any:
 
 
 @pytest.fixture
-def mock_litellm_response() -> Any:
-    return _make_litellm_response()
+def mock_acompletion() -> Any:
+    """Patch ``litellm.acompletion`` with a canned response and yield the mock."""
+    with patch("litellm.acompletion", return_value=_make_litellm_response()) as mock:
+        yield mock
 
 
-async def test_litellm_generator_completion(mock_litellm_response: Any) -> None:
+async def test_litellm_generator_completion(mock_acompletion: Any) -> None:
     """``LiteLLMGenerator._call_model`` routes through ``litellm.acompletion``."""
-    from giskard.agents.generators.litellm_generator import LiteLLMGenerator
-
     generator = LiteLLMGenerator(model="gemini/gemini-3.5-flash")
-    with patch(
-        "litellm.acompletion",
-        return_value=mock_litellm_response,
-    ) as mock_acompletion:
-        response = await generator.complete(
-            messages=[{"role": "user", "content": "Hi"}]
-        )
+    response = await generator.complete(messages=_USER_MESSAGE)
 
     assert response.choices[0].message.role == "assistant"
     assert response.choices[0].message.content == "Mock response"
@@ -55,23 +58,38 @@ async def test_litellm_generator_completion(mock_litellm_response: Any) -> None:
     assert mock_acompletion.call_args.kwargs["model"] == "gemini/gemini-3.5-flash"
 
 
-async def test_litellm_generator_forwards_params(mock_litellm_response: Any) -> None:
+async def test_litellm_generator_forwards_params(mock_acompletion: Any) -> None:
     """Generator params and call-site params are merged and forwarded."""
-    from giskard.agents.generators.litellm_generator import LiteLLMGenerator
-
     generator = LiteLLMGenerator(model="test-model").with_params(temperature=0.3)
-    with patch(
-        "litellm.acompletion",
-        return_value=mock_litellm_response,
-    ) as mock_acompletion:
-        await generator.complete(
-            messages=[{"role": "user", "content": "Hi"}],
-            params=GenerationParams(max_tokens=50),
-        )
+    await generator.complete(
+        messages=_USER_MESSAGE, params=GenerationParams(max_tokens=50)
+    )
 
     kwargs = mock_acompletion.call_args.kwargs
     assert kwargs["temperature"] == 0.3
     assert kwargs["max_tokens"] == 50
+
+
+async def test_litellm_generator_sanitizes_response_format_schema_name(
+    mock_acompletion: Any,
+) -> None:
+    """Bracketed generic model names are sanitized to a provider-safe schema name."""
+
+    class _Wrapper[T](BaseModel):
+        value: T | None = None
+
+    assert _Wrapper[str].__name__ == "_Wrapper[str]"
+
+    generator = LiteLLMGenerator(model="azure/gpt-4o")
+    await generator.complete(
+        messages=_USER_MESSAGE,
+        params=GenerationParams(response_format=_Wrapper[str]),
+    )
+
+    response_format = mock_acompletion.call_args.kwargs["response_format"]
+    assert isinstance(response_format, dict)
+    name = response_format["json_schema"]["name"]
+    assert re.fullmatch(r"[a-zA-Z0-9_-]+", name), name
 
 
 @pytest.mark.parametrize(
@@ -86,11 +104,6 @@ def test_litellm_retry_middleware_should_retry(
     status_code: int, expected: bool
 ) -> None:
     """Retry middleware defers to ``litellm._should_retry`` via ``status_code``."""
-    from giskard.agents.generators.litellm_generator import (
-        LiteLLMRetryMiddleware,
-        RetryPolicy,
-    )
-
     mw = LiteLLMRetryMiddleware(retry_policy=RetryPolicy(max_attempts=2))
     err = Exception("boom")
     err.status_code = status_code  # pyright: ignore[reportAttributeAccessIssue]
@@ -100,9 +113,6 @@ def test_litellm_retry_middleware_should_retry(
 
 def test_litellm_generator_registered_as_kind() -> None:
     """The real ``LiteLLMGenerator`` owns the ``"litellm"`` discriminator kind."""
-    from giskard.agents.generators.base import BaseGenerator
-    from giskard.agents.generators.litellm_generator import LiteLLMGenerator
-
     instance = LiteLLMGenerator(model="gemini/gemini-3.5-flash")
     dumped = instance.model_dump()
     assert dumped["kind"] == "litellm"

--- a/libs/giskard-agents/tests/test_litellm_generator.py
+++ b/libs/giskard-agents/tests/test_litellm_generator.py
@@ -16,13 +16,14 @@ from giskard.agents.generators.litellm_generator import (
     LiteLLMRetryMiddleware,
     RetryPolicy,
 )
+from giskard.llm.types import UserMessageParam
 from pydantic import BaseModel
 
 litellm = pytest.importorskip("litellm")
 
 pytestmark = pytest.mark.litellm
 
-_USER_MESSAGE = [{"role": "user", "content": "Hi"}]
+_USER_MESSAGE: list[UserMessageParam] = [{"role": "user", "content": "Hi"}]
 
 
 def _make_litellm_response(content: str = "Mock response") -> Any:

--- a/libs/giskard-llm/src/giskard/llm/translators/openai_chat.py
+++ b/libs/giskard-llm/src/giskard/llm/translators/openai_chat.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, cast
 
@@ -9,6 +8,7 @@ from giskard.llm.types import (
     ToolDef,
 )
 from giskard.llm.types._base import _BaseModel
+from giskard.llm.utils import sanitize_schema_name
 from pydantic import BaseModel, field_validator
 
 if TYPE_CHECKING:
@@ -27,7 +27,6 @@ logger = logging.getLogger(__name__)
 
 PROVIDER = "openai"
 _PROVIDER = "openai/chat"
-_INVALID_SCHEMA_NAME_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
 KNOWN_COMPLETION_PARAMS = frozenset(
     {"temperature", "max_tokens", "timeout", "tools", "response_format", "metadata"}
 )
@@ -55,7 +54,7 @@ class OpenAIChatParams(_BaseModel):
             return {
                 "type": "json_schema",
                 "json_schema": {
-                    "name": _INVALID_SCHEMA_NAME_CHARS.sub("_", v.__name__),
+                    "name": sanitize_schema_name(v.__name__),
                     "schema": schema,
                 },
             }

--- a/libs/giskard-llm/src/giskard/llm/utils/__init__.py
+++ b/libs/giskard-llm/src/giskard/llm/utils/__init__.py
@@ -2,9 +2,11 @@
 
 from .arguments import deserialize_arguments, serialize_arguments
 from .compact import compact
+from .schema import sanitize_schema_name
 
 __all__ = [
     "compact",
     "deserialize_arguments",
+    "sanitize_schema_name",
     "serialize_arguments",
 ]

--- a/libs/giskard-llm/src/giskard/llm/utils/schema.py
+++ b/libs/giskard-llm/src/giskard/llm/utils/schema.py
@@ -1,0 +1,10 @@
+import re
+
+# OpenAI/Azure reject schema names not matching ``^[a-zA-Z0-9_-]+$`` (e.g. the
+# brackets parametrized generics like ``LLMGeneratorOutput[str]`` carry).
+_INVALID_SCHEMA_NAME_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
+
+
+def sanitize_schema_name(name: str) -> str:
+    """Replace characters a provider would reject in a JSON-schema name."""
+    return _INVALID_SCHEMA_NAME_CHARS.sub("_", name)


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Coding agents

Autonomous agents with no human in the loop must read **[AUTONOMOUS.md](https://github.com/Giskard-AI/giskard-oss/blob/main/AUTONOMOUS.md)** before opening a PR.

**PR title:** agent-opened PRs **must** end the title with **`🤖🤖🤖🤖`** (exactly four robot emojis). Do not omit — that suffix is how the expedited agent PR workflow picks up the PR.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [ ] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been
  modified)
