### PR TITLE
fix(checks): record input generation errors

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
@@ -6,6 +6,7 @@ updated Trace objects via the async generator protocol.
 """
 
 import time
+import traceback
 from typing import Any, cast
 
 from giskard.core import (
@@ -150,7 +151,29 @@ class ScenarioRunner:
         )
 
         for step in steps:
-            trace = await trace.with_interactions(*step.interacts)
+            try:
+                trace = await trace.with_interactions(*step.interacts)
+            except Exception as e:
+                if not return_exception:
+                    raise
+
+                steps_results.append(
+                    TestCaseResult(
+                        results=[
+                            CheckResult.error(
+                                message=f"Input generation failed with error: {str(e)}",
+                                details={
+                                    "check_name": "Input generation",
+                                    "traceback": traceback.format_exc(),
+                                    "exception_type": type(e).__name__,
+                                    "phase": "input_generation",
+                                },
+                            )
+                        ],
+                        duration_ms=0,
+                    )
+                )
+                break
 
             test_case = TestCase(
                 trace=trace,

--- a/libs/giskard-checks/tests/core/test_scenario.py
+++ b/libs/giskard-checks/tests/core/test_scenario.py
@@ -779,7 +779,7 @@ class TestScenarioErrorHandling:
         assert result.errored
 
     async def test_generator_raises_exception_after_yield(self):
-        """Test that generator exceptions from InteractionSpec propagate."""
+        """Test that generator exceptions from InteractionSpec propagate by default."""
         check1 = MockCheck(result=CheckResult.success(message="Check 1"))
         generator_error_component = GeneratorErrorComponent()
         check2 = MockCheck(result=CheckResult.success(message="Check 2"))
@@ -794,6 +794,31 @@ class TestScenarioErrorHandling:
                 .check(check2)
                 .run()
             )
+
+    async def test_generator_exception_returns_error_result(self):
+        """Test that generator exceptions become error results when requested."""
+        check1 = MockCheck(result=CheckResult.success(message="Check 1"))
+        generator_error_component = GeneratorErrorComponent()
+        check2 = MockCheck(result=CheckResult.success(message="Check 2"))
+
+        result = await (
+            Scenario("generator_exception")
+            .check(check1)
+            .add_interaction(generator_error_component)
+            .check(check2)
+            .run(return_exception=True)
+        )
+
+        assert len(result.steps) == 2
+        assert result.steps[0].passed
+        assert result.steps[1].errored
+        error = result.steps[1].results[0]
+        assert error.message == "Input generation failed with error: Generator error"
+        assert error.details["check_name"] == "Input generation"
+        assert error.details["exception_type"] == "RuntimeError"
+        assert error.details["phase"] == "input_generation"
+        assert "Generator error" in error.details["traceback"]
+        assert result.errored
 
     async def test_all_executed_results_collected(self):
         """Test that all checks in a step are executed and results collected."""

--- a/libs/giskard-checks/tests/core/test_suite.py
+++ b/libs/giskard-checks/tests/core/test_suite.py
@@ -229,6 +229,37 @@ async def test_suite_parallel_fail_fast_when_return_exception_is_false():
 
 
 @pytest.mark.asyncio
+async def test_suite_records_input_generation_errors_when_return_exception_is_true():
+    async def flaky_target(inputs):
+        if inputs == "boom":
+            raise RuntimeError("boom")
+        return inputs
+
+    suite = Suite(name="input_generation_error_suite", target=flaky_target)
+    suite.append(Scenario("boom").interact("boom"))
+    suite.append(
+        Scenario("ok")
+        .interact("ok")
+        .check(Equals(expected_value="ok", key="trace.last.outputs"))
+    )
+
+    result = await suite.run(return_exception=True)
+
+    assert len(result.results) == 2
+    assert result.results[0].errored
+    assert result.results[0].steps[0].results[0].message == (
+        "Input generation failed with error: boom"
+    )
+    assert result.results[0].steps[0].results[0].details["check_name"] == (
+        "Input generation"
+    )
+    assert result.results[0].steps[0].results[0].details["exception_type"] == (
+        "RuntimeError"
+    )
+    assert result.results[1].passed
+
+
+@pytest.mark.asyncio
 async def test_suite_parallel_telemetry_includes_flag(monkeypatch):
     events = []
 


### PR DESCRIPTION
## Summary
- convert scenario input-generation exceptions into errored check results when `return_exception=True`
- keep the default `return_exception=False` behavior raising the original exception
- add scenario and suite regression tests for recorded generator errors and suite continuation

## Testing
- `uv run ruff format libs/giskard-checks/src/giskard/checks/scenarios/runner.py libs/giskard-checks/tests/core/test_scenario.py libs/giskard-checks/tests/core/test_suite.py`
- `uv run ruff check libs/giskard-checks/src/giskard/checks/scenarios/runner.py libs/giskard-checks/tests/core/test_scenario.py libs/giskard-checks/tests/core/test_suite.py`
- `uv run pytest libs/giskard-checks/tests/core/test_scenario.py -k 'generator_exception'`
- `uv run pytest libs/giskard-checks/tests/core/test_suite.py -k 'input_generation_errors or parallel_fail_fast'`
- `make test-unit PACKAGE=giskard-checks`

Closes #2523
