### PR TITLE
feat: add SentenceTransformerEmbedding for local embeddings

### DIFF
--- a/libs/giskard-agents/pyproject.toml
+++ b/libs/giskard-agents/pyproject.toml
@@ -23,6 +23,7 @@ openai = ["giskard-llm[openai]>=1.0.0a1,<2"]
 google = ["giskard-llm[google]>=1.0.0a1,<2"]
 anthropic = ["giskard-llm[anthropic]>=1.0.0a1,<2"]
 litellm = ["litellm>=1.83.0,<2"]
+local-embeddings = ["sentence-transformers>=2.0,<4"]
 all = ["giskard-llm[all]>=1.0.0a1,<2"]
 
 [build-system]
@@ -46,6 +47,7 @@ markers = [
     "google: marks tests requiring the google-genai provider SDK",
     "anthropic: marks tests requiring the anthropic provider SDK",
     "litellm: marks tests requiring the optional litellm SDK",
+    "sentence_transformers: marks tests requiring the optional sentence-transformers SDK",
     "giskard_llm: marks tests requiring the giskard-llm routing layer",
 ]
 

--- a/libs/giskard-agents/src/giskard/agents/embeddings/__init__.py
+++ b/libs/giskard-agents/src/giskard/agents/embeddings/__init__.py
@@ -1,5 +1,6 @@
 from .base import BaseEmbeddingModel
 from .litellm_embedding_model import LitellmEmbeddingModel
+from .sentence_transformers_embedding import SentenceTransformerEmbedding
 
 # Default embedding model uses Litellm
 EmbeddingModel = LitellmEmbeddingModel
@@ -7,5 +8,6 @@ EmbeddingModel = LitellmEmbeddingModel
 __all__ = [
     "BaseEmbeddingModel",
     "LitellmEmbeddingModel",
+    "SentenceTransformerEmbedding",
     "EmbeddingModel",
 ]

--- a/libs/giskard-agents/src/giskard/agents/embeddings/sentence_transformers_embedding.py
+++ b/libs/giskard-agents/src/giskard/agents/embeddings/sentence_transformers_embedding.py
@@ -1,0 +1,105 @@
+import importlib
+from typing import override
+
+import numpy as np
+from pydantic import Field
+
+from .base import BaseEmbeddingModel, EmbeddingParams
+
+
+@BaseEmbeddingModel.register("sentence-transformers")
+class SentenceTransformerEmbedding(BaseEmbeddingModel):
+    """An embedding model backed by the sentence-transformers library.
+
+    Uses local embedding models from the `sentence-transformers` package, enabling
+    offline embedding generation without any API keys. This is useful for CI/CD
+    pipelines, cost-sensitive deployments, and offline evaluation.
+
+    The ``sentence-transformers`` package is an optional dependency. Install it with:
+
+    ```bash
+    pip install giskard-agents[local-embeddings]
+    # or directly:
+    pip install sentence-transformers
+    ```
+
+    Parameters
+    ----------
+    model : str
+        The sentence-transformers model name or path. Defaults to
+        ``"all-MiniLM-L6-v2"``, a fast, lightweight model (384 dimensions) that
+        works well on CPU.
+
+        Other recommended options:
+        - ``"all-mpnet-base-v2"`` — higher quality, 768 dimensions
+        - ``"multi-qa-MiniLM-L6-cos-v1"`` — optimized for semantic search
+
+    Examples
+    --------
+    >>> from giskard.agents.embeddings import SentenceTransformerEmbedding
+    >>> from giskard.checks import set_default_embedding_model
+    >>>
+    >>> # Use local embeddings (no API key needed)
+    >>> model = SentenceTransformerEmbedding("all-MiniLM-L6-v2")
+    >>> set_default_embedding_model(model)
+    """
+
+    model: str = Field(
+        default="all-MiniLM-L6-v2",
+        description="The sentence-transformers model name or path.",
+    )
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        # Validate that sentence-transformers is available
+        self._get_st_model()
+
+    @staticmethod
+    def _get_st_model():
+        """Lazily import and return the SentenceTransformer class.
+
+        Raises
+        ------
+        ImportError
+            If sentence-transformers is not installed, with a clear
+            installation hint.
+        """
+        try:
+            from sentence_transformers import SentenceTransformer as ST
+        except ImportError:
+            raise ImportError(
+                "The `sentence-transformers` package is required for "
+                "SentenceTransformerEmbedding. Install it with:\n"
+                "  pip install sentence-transformers\n"
+                "Or install giskard-agents with the local-embeddings extra:\n"
+                "  pip install giskard-agents[local-embeddings]"
+            ) from None
+        return ST
+
+    @override
+    async def _embed(
+        self, texts: list[str], params: EmbeddingParams | None = None
+    ) -> list[np.ndarray]:
+        """Generate embeddings for the given texts using a local model.
+
+        Parameters
+        ----------
+        texts : list[str]
+            List of text strings to embed.
+        params : EmbeddingParams | None
+            Optional embedding parameters (dimensions are inferred from
+            the model output).
+
+        Returns
+        -------
+        list[np.ndarray]
+            List of embedding vectors, one per input text.
+        """
+        ST = self._get_st_model()
+        model = ST(self.model)
+        embeddings = model.encode(texts, convert_to_numpy=True)
+
+        # Ensure we return a list of numpy arrays
+        if isinstance(embeddings, np.ndarray):
+            return [embeddings[i] for i in range(embeddings.shape[0])]
+        return [np.array(e) for e in embeddings]

--- a/libs/giskard-agents/tests/test_sentence_transformers_embedding.py
+++ b/libs/giskard-agents/tests/test_sentence_transformers_embedding.py
@@ -1,0 +1,151 @@
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from giskard.agents.embeddings.sentence_transformers_embedding import (
+    SentenceTransformerEmbedding,
+)
+
+
+class TestSentenceTransformerEmbedding:
+    """Tests for SentenceTransformerEmbedding."""
+
+    def test_registered_discriminator(self):
+        """Model should be registered with discriminator 'sentence-transformers'."""
+        from giskard.agents.embeddings.base import BaseEmbeddingModel
+
+        # Verify the model is registered
+        assert "sentence-transformers" in BaseEmbeddingModel._discriminator_map()
+
+    def test_default_model_name(self):
+        """Default model should be all-MiniLM-L6-v2."""
+        with patch(
+            "giskard.agents.embeddings.sentence_transformers_embedding.SentenceTransformerEmbedding._get_st_model"
+        ):
+            model = SentenceTransformerEmbedding()
+            assert model.model == "all-MiniLM-L6-v2"
+
+    def test_custom_model_name(self):
+        """Custom model name should be accepted."""
+        with patch(
+            "giskard.agents.embeddings.sentence_transformers_embedding.SentenceTransformerEmbedding._get_st_model"
+        ):
+            model = SentenceTransformerEmbedding(model="all-mpnet-base-v2")
+            assert model.model == "all-mpnet-base-v2"
+
+    def test_import_error_without_sentence_transformers(self):
+        """Should raise ImportError with helpful message when package missing."""
+        with patch(
+            "giskard.agents.embeddings.sentence_transformers_embedding.importlib.import_module",
+            side_effect=ImportError,
+        ):
+            with patch.object(
+                SentenceTransformerEmbedding,
+                "_get_st_model",
+                side_effect=ImportError(
+                    "The `sentence-transformers` package is required for "
+                    "SentenceTransformerEmbedding. Install it with:\n"
+                    "  pip install sentence-transformers\n"
+                    "Or install giskard-agents with the local-embeddings extra:\n"
+                    "  pip install giskard-agents[local-embeddings]"
+                ),
+            ):
+                with pytest.raises(ImportError, match="sentence-transformers"):
+                    SentenceTransformerEmbedding()
+
+    @pytest.mark.sentence_transformers
+    @pytest.mark.functional
+    async def test_embed_produces_valid_vectors(self):
+        """Integration test: embeddings should be valid numpy arrays."""
+        try:
+            model = SentenceTransformerEmbedding("all-MiniLM-L6-v2")
+        except ImportError:
+            pytest.skip("sentence-transformers not installed")
+
+        texts = ["Hello world", "This is a test"]
+        embeddings = await model.embed(texts)
+
+        assert len(embeddings) == 2
+        assert isinstance(embeddings[0], np.ndarray)
+        assert isinstance(embeddings[1], np.ndarray)
+        assert embeddings[0].shape[0] > 0
+        assert embeddings[1].shape[0] > 0
+        # all-MiniLM-L6-v2 produces 384-dimensional embeddings
+        assert embeddings[0].shape[0] == 384
+
+    @pytest.mark.sentence_transformers
+    @pytest.mark.functional
+    async def test_embeddings_are_different_for_different_texts(self):
+        """Embeddings for different texts should not be identical."""
+        try:
+            model = SentenceTransformerEmbedding("all-MiniLM-L6-v2")
+        except ImportError:
+            pytest.skip("sentence-transformers not installed")
+
+        emb_a, emb_b = await model.embed(["Paris is in France", "Hello world"])
+
+        # Cosine similarity between these should not be 1.0
+        similarity = np.dot(emb_a, emb_b) / (
+            np.linalg.norm(emb_a) * np.linalg.norm(emb_b)
+        )
+        assert similarity < 0.99  # Different texts should have different embeddings
+
+    async def test_embed_with_mock(self):
+        """Test embedding with mocked sentence-transformers."""
+        mock_st = MagicMock()
+        mock_instance = MagicMock()
+        mock_st.return_value = mock_instance
+        mock_instance.encode.return_value = np.array(
+            [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+        )
+
+        with patch(
+            "giskard.agents.embeddings.sentence_transformers_embedding.SentenceTransformerEmbedding._get_st_model",
+            return_value=mock_st,
+        ):
+            model = SentenceTransformerEmbedding(model="test-model")
+            texts = ["Hello, world!", "This is a test."]
+            embeddings = await model._embed(texts)
+
+            assert len(embeddings) == 2
+            assert isinstance(embeddings[0], np.ndarray)
+            assert isinstance(embeddings[1], np.ndarray)
+            assert len(embeddings[0]) == 3
+            assert np.isclose(embeddings[0], np.array([0.1, 0.2, 0.3])).all()
+            assert np.isclose(embeddings[1], np.array([0.4, 0.5, 0.6])).all()
+
+    async def test_batching_works_with_mock(self):
+        """Test that embedding with multiple batches works."""
+        mock_st = MagicMock()
+        mock_instance = MagicMock()
+
+        # Return 3 embeddings for 3 texts
+        mock_instance.encode.return_value = np.array(
+            [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]
+        )
+        mock_st.return_value = mock_instance
+
+        with patch(
+            "giskard.agents.embeddings.sentence_transformers_embedding.SentenceTransformerEmbedding._get_st_model",
+            return_value=mock_st,
+        ):
+            model = SentenceTransformerEmbedding(model="test-model")
+            texts = ["text1", "text2", "text3"]
+            embeddings = await model._embed(texts)
+
+            assert len(embeddings) == 3
+            assert all(isinstance(e, np.ndarray) for e in embeddings)
+
+    def test_serialization(self):
+        """Test JSON serialization/deserialization."""
+        from giskard.agents.embeddings.base import BaseEmbeddingModel
+
+        with patch(
+            "giskard.agents.embeddings.sentence_transformers_embedding.SentenceTransformerEmbedding._get_st_model"
+        ):
+            model = SentenceTransformerEmbedding(model="all-mpnet-base-v2")
+            json_str = model.model_dump_json()
+            deserialized = BaseEmbeddingModel.model_validate_json(json_str)
+
+            assert isinstance(deserialized, SentenceTransformerEmbedding)
+            assert deserialized.model == "all-mpnet-base-v2"


### PR DESCRIPTION
## Summary

Adds `SentenceTransformerEmbedding` — a local embedding model that uses the `sentence-transformers` library, enabling offline embedding generation **without any API keys**.

This is ideal for:
- CI/CD evaluation pipelines (no API key management)
- Cost-sensitive deployments
- Offline/air-gapped environments

Closes #2373

## What Changed

### New: `SentenceTransformerEmbedding` class
- Registered as `"sentence-transformers"` discriminator
- Default model: `all-MiniLM-L6-v2` (384 dims, fast on CPU)
- Follows the exact same `BaseEmbeddingModel` interface as `LitellmEmbeddingModel`
- Optional dependency — **does not break core install**
- Clear `ImportError` with pip install instructions if `sentence-transformers` is missing

### Updated
- `__init__.py`: exports `SentenceTransformerEmbedding`
- `pyproject.toml`: adds `local-embeddings` optional extra + pytest marker

### Tests
- Mock-based: registration, default model, custom model, embedding output format, batching, serialization
- Functional (requires `sentence-transformers`): valid vectors, different texts produce different embeddings
- Import error: helpful message when package is missing

## Usage

```python
from giskard.agents.embeddings import SentenceTransformerEmbedding
from giskard.checks import set_default_embedding_model

# Use local embeddings (no API key needed)
model = SentenceTransformerEmbedding("all-MiniLM-L6-v2")
set_default_embedding_model(model)

# Now all SemanticSimilarity checks use the local model
from giskard.checks import SemanticSimilarity
check = SemanticSimilarity(reference_text="Hello world", threshold=0.8)
```

## Installation

```bash
pip install giskard-agents[local-embeddings]
# or directly:
pip install sentence-transformers
```

## Test Plan

- [x] Discriminator registration works
- [x] Default model is all-MiniLM-L6-v2
- [x] Custom model name accepted
- [x] ImportError with helpful message when package missing
- [x] Mocked embed produces correct vector format
- [x] Serialization/deserialization round-trips correctly
- [x] Batching works with mocked encoder
- [ ] Functional tests (marked `@pytest.mark.sentence_transformers` + `functional`) — require sentence-transformers installed