### PR TITLE
Add contains any/all text checks

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/__init__.py
@@ -9,6 +9,8 @@ from . import builtin, judges
 from .builtin import (
     AllOf,
     AnyOf,
+    ContainsAll,
+    ContainsAny,
     Equals,
     FnCheck,
     GreaterEquals,
@@ -116,6 +118,8 @@ __all__ = [
     "SemanticSimilarity",
     "Toxicity",
     "StringMatching",
+    "ContainsAny",
+    "ContainsAll",
     "RegexMatching",
     # Exceptions
     "InputGenerationException",

--- a/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
@@ -27,7 +27,7 @@ from .fn import FnCheck, from_fn
 from .json_valid import JsonValid
 from .rego_policy import RegoPolicy
 from .semantic_similarity import SemanticSimilarity
-from .text_matching import RegexMatching, StringMatching
+from .text_matching import ContainsAll, ContainsAny, RegexMatching, StringMatching
 
 __all__ = [
     "AllOf",
@@ -38,6 +38,8 @@ __all__ = [
     "JsonValid",
     "RegoPolicy",
     "StringMatching",
+    "ContainsAny",
+    "ContainsAll",
     "RegexMatching",
     "Equals",
     "NotEquals",

--- a/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
@@ -2,6 +2,8 @@
 
 This module provides checks for text matching:
 - StringMatching: Literal substring matching with normalization
+- ContainsAny: List-based substring matching requiring at least one value
+- ContainsAll: List-based substring matching requiring every value
 - RegexMatching: Regular expression pattern matching
 """
 
@@ -316,6 +318,136 @@ class StringMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignor
 
         return CheckResult.failure(
             message=f"The answer does not contain the keyword '{keyword}'",
+            details=details,
+        )
+
+
+class ListTextMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
+    TextBasedCheck[InputType, OutputType, TraceType], ABC
+):
+    """Base class for checks that compare text against a list of strings."""
+
+    values: list[str] = Field(
+        description="The string values to search for within the text.",
+    )
+    normalization_form: NormalizationForm | None = Field(
+        default="NFKC",
+        description="Unicode normalization form to apply (NFC, NFD, NFKC, NFKD). Defaults to NFKC.",
+    )
+    case_sensitive: bool = Field(
+        default=False,
+        description="If True, matching is case-sensitive. If False, all strings are lowercased before comparison.",
+    )
+
+    @model_validator(mode="after")
+    def validate_values(self) -> Self:
+        """Validate that values contains at least one string."""
+        if not self.values:
+            raise ValueError("'values' must contain at least one string.")
+
+        return self
+
+    def _format_str(self, value: str) -> str:
+        value = normalize_string(value, self.normalization_form)
+
+        if not self.case_sensitive:
+            value = value.lower()
+
+        return value
+
+    def _extract_text(
+        self, trace: TraceType
+    ) -> tuple[str, dict[str, Any]] | CheckResult:
+        text = provided_or_resolve(
+            trace, key=self.text_key, value=provide_not_none(self.text)
+        )
+        details: dict[str, Any] = {
+            "text": text,
+            "values": self.values,
+            "normalization_form": self.normalization_form,
+            "case_sensitive": self.case_sensitive,
+        }
+
+        if isinstance(text, NoMatch):
+            return CheckResult.failure(
+                message=f"No value found for text key '{self.text_key}'.",
+                details=details,
+            )
+
+        if not isinstance(text, str):
+            return CheckResult.failure(
+                message=f"Value for text is not a string, expected string but got {type(text).__name__}.",
+                details=details,
+            )
+
+        return text, details
+
+    def _match_values(self, text: str) -> tuple[list[str], list[str]]:
+        formatted_text = self._format_str(text)
+        matched = [
+            value for value in self.values if self._format_str(value) in formatted_text
+        ]
+        missing = [value for value in self.values if value not in matched]
+
+        return matched, missing
+
+
+@Check.register("contains_any")
+class ContainsAny[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
+    ListTextMatching[InputType, OutputType, TraceType]
+):
+    """Check that validates if text contains at least one string from a list."""
+
+    @override
+    async def run(self, trace: TraceType) -> CheckResult:
+        result = self._extract_text(trace)
+
+        if isinstance(result, CheckResult):
+            return result
+
+        text, details = result
+        matched, missing = self._match_values(text)
+        details["matched_values"] = matched
+        details["missing_values"] = missing
+
+        if matched:
+            return CheckResult.success(
+                message=f"The answer contains at least one expected value: '{matched[0]}'.",
+                details=details,
+            )
+
+        return CheckResult.failure(
+            message="The answer does not contain any expected values.",
+            details=details,
+        )
+
+
+@Check.register("contains_all")
+class ContainsAll[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
+    ListTextMatching[InputType, OutputType, TraceType]
+):
+    """Check that validates if text contains every string from a list."""
+
+    @override
+    async def run(self, trace: TraceType) -> CheckResult:
+        result = self._extract_text(trace)
+
+        if isinstance(result, CheckResult):
+            return result
+
+        text, details = result
+        matched, missing = self._match_values(text)
+        details["matched_values"] = matched
+        details["missing_values"] = missing
+
+        if not missing:
+            return CheckResult.success(
+                message="The answer contains all expected values.",
+                details=details,
+            )
+
+        return CheckResult.failure(
+            message=f"The answer is missing expected values: {', '.join(repr(value) for value in missing)}.",
             details=details,
         )
 

--- a/libs/giskard-checks/tests/builtin/test_string_matching.py
+++ b/libs/giskard-checks/tests/builtin/test_string_matching.py
@@ -1,7 +1,14 @@
 """Tests for the StringMatching check."""
 
 import pytest
-from giskard.checks import CheckStatus, Interaction, StringMatching, Trace
+from giskard.checks import (
+    CheckStatus,
+    ContainsAll,
+    ContainsAny,
+    Interaction,
+    StringMatching,
+    Trace,
+)
 from giskard.checks.core.extraction import NoMatch
 
 
@@ -413,3 +420,100 @@ async def test_unicode_e_acute_no_normalization_fails() -> None:
     result = await check.run(Trace())
     # Without normalization, they should not match
     assert result.status == CheckStatus.FAIL
+
+
+async def test_contains_any_passes_when_one_value_matches() -> None:
+    check = ContainsAny(
+        text="Machine learning is a subset of artificial intelligence.",
+        values=["deep learning", "artificial intelligence"],
+    )
+
+    result = await check.run(Trace())
+
+    assert result.status == CheckStatus.PASS
+    assert result.details["matched_values"] == ["artificial intelligence"]
+    assert result.details["missing_values"] == ["deep learning"]
+
+
+async def test_contains_any_fails_when_no_values_match() -> None:
+    check = ContainsAny(text="The answer discusses Python.", values=["Java", "Rust"])
+
+    result = await check.run(Trace())
+
+    assert result.status == CheckStatus.FAIL
+    assert result.details["matched_values"] == []
+    assert result.details["missing_values"] == ["Java", "Rust"]
+
+
+async def test_contains_all_passes_when_every_value_matches() -> None:
+    check = ContainsAll(
+        text="The response includes definition, example, and caveat sections.",
+        values=["definition", "example", "caveat"],
+    )
+
+    result = await check.run(Trace())
+
+    assert result.status == CheckStatus.PASS
+    assert result.details["matched_values"] == ["definition", "example", "caveat"]
+    assert result.details["missing_values"] == []
+
+
+async def test_contains_all_fails_when_one_value_is_missing() -> None:
+    check = ContainsAll(
+        text="The response includes a definition.", values=["definition", "example"]
+    )
+
+    result = await check.run(Trace())
+
+    assert result.status == CheckStatus.FAIL
+    assert result.details["matched_values"] == ["definition"]
+    assert result.details["missing_values"] == ["example"]
+
+
+async def test_contains_checks_are_case_insensitive_by_default() -> None:
+    check = ContainsAny(text="Hello World", values=["world"])
+
+    result = await check.run(Trace())
+
+    assert result.status == CheckStatus.PASS
+
+
+async def test_contains_checks_support_case_sensitive_matching() -> None:
+    check = ContainsAny(text="Hello World", values=["world"], case_sensitive=True)
+
+    result = await check.run(Trace())
+
+    assert result.status == CheckStatus.FAIL
+
+
+async def test_contains_checks_support_unicode_normalization() -> None:
+    check = ContainsAll(
+        text="Full-width Ａ and superscript ² are normalized.",
+        values=["A", "2"],
+        normalization_form="NFKC",
+    )
+
+    result = await check.run(Trace())
+
+    assert result.status == CheckStatus.PASS
+
+
+async def test_contains_checks_extract_text_with_jsonpath() -> None:
+    check = ContainsAll(
+        text_key="trace.last.outputs.answer",
+        values=["Paris", "France"],
+    )
+    interaction = Interaction(
+        inputs={"query": "Where is the Eiffel Tower?"},
+        outputs={"answer": "The Eiffel Tower is in Paris, France."},
+    )
+
+    result = await check.run(Trace(interactions=[interaction]))
+
+    assert result.status == CheckStatus.PASS
+    assert result.details["text"] == "The Eiffel Tower is in Paris, France."
+
+
+async def test_contains_checks_reject_empty_values() -> None:
+    with pytest.raises(ValueError, match="'values' must contain at least one string"):
+        ContainsAny(text="Hello", values=[])


### PR DESCRIPTION
## Summary
- add ContainsAny and ContainsAll built-in text checks
- export both checks from giskard.checks and builtin checks
- cover matching, case sensitivity, Unicode normalization, JSONPath extraction, and empty values

Fixes #2361

## Tests
- uv run pytest libs/giskard-checks/tests/builtin/test_string_matching.py
- uv run ruff check libs/giskard-checks/src/giskard/checks/builtin/text_matching.py libs/giskard-checks/src/giskard/checks/builtin/__init__.py libs/giskard-checks/src/giskard/checks/__init__.py libs/giskard-checks/tests/builtin/test_string_matching.py