### PR TITLE
chore: add optional deps to `giskard-scan`

### DIFF
--- a/libs/giskard-scan/pyproject.toml
+++ b/libs/giskard-scan/pyproject.toml
@@ -12,6 +12,13 @@ dependencies = [
     "numpy>=2.4.1,<3",
 ]
 
+[project.optional-dependencies]
+openai = ["giskard-agents[openai]"]
+google = ["giskard-agents[google]"]
+anthropic = ["giskard-agents[anthropic]"]
+litellm = ["giskard-agents[litellm]"]
+all = ["giskard-agents[all]"]
+
 [build-system]
 requires = ["hatchling>=1.25.0"]
 build-backend = "hatchling.build"

--- a/uv.lock
+++ b/uv.lock
@@ -1023,12 +1023,35 @@ dependencies = [
     { name = "numpy" },
 ]
 
+[package.optional-dependencies]
+all = [
+    { name = "giskard-agents", extra = ["all"] },
+]
+anthropic = [
+    { name = "giskard-agents", extra = ["anthropic"] },
+]
+google = [
+    { name = "giskard-agents", extra = ["google"] },
+]
+litellm = [
+    { name = "giskard-agents", extra = ["litellm"] },
+]
+openai = [
+    { name = "giskard-agents", extra = ["openai"] },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "giskard-agents", editable = "libs/giskard-agents" },
+    { name = "giskard-agents", extras = ["all"], marker = "extra == 'all'", editable = "libs/giskard-agents" },
+    { name = "giskard-agents", extras = ["anthropic"], marker = "extra == 'anthropic'", editable = "libs/giskard-agents" },
+    { name = "giskard-agents", extras = ["google"], marker = "extra == 'google'", editable = "libs/giskard-agents" },
+    { name = "giskard-agents", extras = ["litellm"], marker = "extra == 'litellm'", editable = "libs/giskard-agents" },
+    { name = "giskard-agents", extras = ["openai"], marker = "extra == 'openai'", editable = "libs/giskard-agents" },
     { name = "giskard-checks", editable = "libs/giskard-checks" },
     { name = "numpy", specifier = ">=2.4.1,<3" },
 ]
+provides-extras = ["openai", "google", "anthropic", "litellm", "all"]
 
 [[package]]
 name = "google-auth"


### PR DESCRIPTION
## Description

This PR makes it possible to install `giskard-scan` along with  `giskard-agents[provider]`.

Example:

```
pip install "giskard-scan[openai]"
```
```
pip install "giskard-scan[litellm]"
```
```
pip install "giskard-scan[all]"
```

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix