### PR TITLE
Fix/check kind console label

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/core/result.py
+++ b/libs/giskard-checks/src/giskard/checks/core/result.py
@@ -222,12 +222,22 @@ class CheckResult(BaseResult, frozen=True):
         """Return True if `status` is `SKIP`."""
         return self.status == CheckStatus.SKIP
 
+    @property
+    def check_label(self) -> str:
+        details = self.details if isinstance(self.details, Mapping) else {}
+        return str(
+            details.get("check_name")
+            or details.get("check_kind")
+            or details.get("name")
+            or "Unnamed check"
+        )
+
     def __rich_console__(
         self, console: Console, options: ConsoleOptions
     ) -> RenderResult:
         status = STATUS_MAPPING[self.status]
 
-        name = self.details.get("check_name", "[dim italic]Unnamed check[/dim italic]")
+        name = self.check_label
 
         if self.status == CheckStatus.FAIL or self.status == CheckStatus.ERROR:
             details = (

--- a/libs/giskard-checks/src/giskard/checks/core/result.py
+++ b/libs/giskard-checks/src/giskard/checks/core/result.py
@@ -238,6 +238,8 @@ class CheckResult(BaseResult, frozen=True):
         status = STATUS_MAPPING[self.status]
 
         name = self.check_label
+        if name == "Unnamed check":
+            name = "[dim italic]Unnamed check[/dim italic]"
 
         if self.status == CheckStatus.FAIL or self.status == CheckStatus.ERROR:
             details = (

--- a/libs/giskard-checks/src/giskard/checks/export/junit.py
+++ b/libs/giskard-checks/src/giskard/checks/export/junit.py
@@ -23,14 +23,8 @@ def _to_json(value: Any) -> str:
 
 
 def _check_label(result: CheckResult, fallback: str) -> str:
-    if isinstance(result.details, dict):
-        return str(
-            result.details.get("check_name")
-            or result.details.get("check_kind")
-            or result.details.get("name")
-            or fallback
-        )
-    return fallback
+    label = result.check_label
+    return label if label != "Unnamed check" else fallback
 
 
 def _iter_checks(scenario: ScenarioResult[Any]):

--- a/libs/giskard-checks/tests/core/test_suite.py
+++ b/libs/giskard-checks/tests/core/test_suite.py
@@ -3,9 +3,10 @@ import time
 from contextlib import nullcontext
 
 import pytest
-from giskard.checks import Equals, Scenario, Suite
+from giskard.checks import CheckResult, Equals, Scenario, Suite
 from giskard.checks.core.result import ScenarioStatus
 from giskard.checks.scenarios.suite import _OverallOnly, _SuiteProgress
+from rich.console import Console
 from rich.progress import MofNCompleteColumn, Progress
 from rich.text import Text
 
@@ -28,6 +29,20 @@ def sut3():
 @pytest.fixture
 def identity_sut():
     return lambda inputs: inputs
+
+
+def test_check_result_console_falls_back_to_check_kind():
+    result = CheckResult.failure(
+        message="boom",
+        details={"check_kind": "MyCheck"},
+    )
+    console = Console(record=True, width=120)
+
+    console.print(result)
+
+    output = console.export_text()
+    assert "MyCheck" in output
+    assert "Unnamed check" not in output
 
 
 @pytest.mark.asyncio

--- a/libs/giskard-checks/tests/core/test_suite.py
+++ b/libs/giskard-checks/tests/core/test_suite.py
@@ -201,7 +201,6 @@ async def test_suite_parallel_preserves_result_order():
 @pytest.mark.asyncio
 async def test_suite_parallel_runs_concurrently():
     sleep_s = 0.06
-    n = 3
 
     async def delayed_identity(inputs):
         await asyncio.sleep(sleep_s)
@@ -212,12 +211,15 @@ async def test_suite_parallel_runs_concurrently():
     suite.append(Scenario("b").interact("b"))
     suite.append(Scenario("c").interact("c"))
 
-    start = time.perf_counter()
-    await suite.run(parallel=True)
-    parallel_duration = time.perf_counter() - start
+    serial_start = time.perf_counter()
+    await suite.run(verbose=False)
+    serial_duration = time.perf_counter() - serial_start
 
-    # Must complete faster than running all scenarios serially
-    assert parallel_duration < sleep_s * n
+    parallel_start = time.perf_counter()
+    await suite.run(parallel=True, verbose=False)
+    parallel_duration = time.perf_counter() - parallel_start
+
+    assert parallel_duration < serial_duration
 
 
 @pytest.mark.asyncio

--- a/libs/giskard-checks/tests/export/test_junit.py
+++ b/libs/giskard-checks/tests/export/test_junit.py
@@ -7,6 +7,7 @@ from giskard.checks import (
     Metric,
     ScenarioResult,
     SuiteResult,
+    TestCaseResult,
     Trace,
 )
 from giskard.checks.export.junit import to_junit_xml
@@ -168,6 +169,39 @@ def test_to_junit_xml_maps_failure_error_and_skip() -> None:
     skipped = testcases["scenario_skip"].find("skipped")
     assert skipped is not None
     assert "no retrieved context" in (skipped.text or "")
+
+
+def test_to_junit_xml_falls_back_to_check_kind_for_labels() -> None:
+    suite_result = SuiteResult(
+        results=[
+            ScenarioResult(
+                scenario_name="scenario_kind_only",
+                steps=[
+                    TestCaseResult(
+                        results=[
+                            CheckResult(
+                                status=CheckStatus.FAIL,
+                                message="kind-only failure",
+                                details={"check_kind": "MyCheck"},
+                            )
+                        ],
+                        duration_ms=10,
+                    )
+                ],
+                duration_ms=10,
+                final_trace=Trace(),
+            )
+        ],
+        duration_ms=10,
+    )
+
+    root = ET.fromstring(to_junit_xml(suite_result))
+    testcase = root.find("testcase")
+    assert testcase is not None
+    failure = testcase.find("failure")
+    assert failure is not None
+    assert failure.attrib["type"] == "MyCheck"
+    assert "MyCheck" in (failure.text or "")
 
 
 def test_to_junit_xml_writes_file(tmp_path: Path) -> None:


### PR DESCRIPTION
 Closes #2532

  ## Summary
  - add a shared `check_label` fallback on `CheckResult`
  - use `check_name -> check_kind -> name -> Unnamed check` for console rendering
  - reuse the same label logic in JUnit export
  - add regressions for `check_kind`-only failures in console output and JUnit output
  - stabilize the suite parallel timing test so it compares parallel vs serial execution directly

  ## Testing
  - `ruff check libs/giskard-checks/src/giskard/checks/core/result.py libs/giskard-checks/src/giskard/checks/export/
  junit.py libs/giskard-checks/tests/core/test_suite.py libs/giskard-checks/tests/export/test_junit.py`
  - `pytest -q libs/giskard-checks/tests/core/test_suite.py libs/giskard-checks/tests/export/test_junit.py`