### PR TITLE
fix(checks): validate suite max concurrency

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
@@ -206,8 +206,13 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
         target = target if not isinstance(target, NotProvided) else self.target
         has_target = not isinstance(target, NotProvided)
 
-        if parallel and max_concurrency is not None and max_concurrency < 1:
-            raise ValueError("max_concurrency must be greater than 0")
+        if max_concurrency is not None:
+            if isinstance(max_concurrency, bool) or not isinstance(
+                max_concurrency, int
+            ):
+                raise TypeError("max_concurrency must be None or a positive integer")
+            if max_concurrency < 1:
+                raise ValueError("max_concurrency must be greater than 0")
 
         with telemetry_run_context():
             telemetry_tag("giskard_component", "suite")

--- a/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
@@ -207,8 +207,8 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
         has_target = not isinstance(target, NotProvided)
 
         if max_concurrency is not None:
-            if isinstance(max_concurrency, bool) or not isinstance(
-                max_concurrency, int
+            if not isinstance(max_concurrency, int) or isinstance(
+                max_concurrency, bool
             ):
                 raise TypeError("max_concurrency must be None or a positive integer")
             if max_concurrency < 1:

--- a/libs/giskard-checks/tests/core/test_suite.py
+++ b/libs/giskard-checks/tests/core/test_suite.py
@@ -289,13 +289,46 @@ async def test_suite_parallel_respects_max_concurrency():
     assert peak_runs == 2
 
 
+@pytest.mark.parametrize("max_concurrency", [0, -1])
 @pytest.mark.asyncio
-async def test_suite_parallel_rejects_invalid_max_concurrency():
+async def test_suite_parallel_rejects_non_positive_max_concurrency(max_concurrency):
     suite = Suite(name="invalid_parallel_limit_suite", target=lambda inputs: inputs)
     suite.append(Scenario("a").interact("a"))
 
     with pytest.raises(ValueError, match="max_concurrency must be greater than 0"):
-        await suite.run(parallel=True, max_concurrency=0)
+        await suite.run(parallel=True, max_concurrency=max_concurrency)
+
+
+@pytest.mark.parametrize("max_concurrency", [True, False, 1.5, "2"])
+@pytest.mark.asyncio
+async def test_suite_parallel_rejects_non_integer_max_concurrency(max_concurrency):
+    suite = Suite(name="invalid_parallel_limit_suite", target=lambda inputs: inputs)
+    suite.append(Scenario("a").interact("a"))
+
+    with pytest.raises(
+        TypeError, match="max_concurrency must be None or a positive integer"
+    ):
+        await suite.run(parallel=True, max_concurrency=max_concurrency)
+
+
+@pytest.mark.parametrize(
+    ("max_concurrency", "error_type", "message"),
+    [
+        (0, ValueError, "max_concurrency must be greater than 0"),
+        (True, TypeError, "max_concurrency must be None or a positive integer"),
+        (1.5, TypeError, "max_concurrency must be None or a positive integer"),
+        ("2", TypeError, "max_concurrency must be None or a positive integer"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_suite_rejects_invalid_max_concurrency_without_parallel(
+    max_concurrency, error_type, message
+):
+    suite = Suite(name="invalid_sequential_limit_suite", target=lambda inputs: inputs)
+    suite.append(Scenario("a").interact("a"))
+
+    with pytest.raises(error_type, match=message):
+        await suite.run(parallel=False, max_concurrency=max_concurrency)
 
 
 def test_progress_counter_appears_only_on_the_overall_row():

--- a/libs/giskard-checks/tests/core/test_suite.py
+++ b/libs/giskard-checks/tests/core/test_suite.py
@@ -289,46 +289,31 @@ async def test_suite_parallel_respects_max_concurrency():
     assert peak_runs == 2
 
 
-@pytest.mark.parametrize("max_concurrency", [0, -1])
-@pytest.mark.asyncio
-async def test_suite_parallel_rejects_non_positive_max_concurrency(max_concurrency):
-    suite = Suite(name="invalid_parallel_limit_suite", target=lambda inputs: inputs)
+@pytest.fixture
+def simple_suite():
+    suite = Suite(name="invalid_limit_suite", target=lambda inputs: inputs)
     suite.append(Scenario("a").interact("a"))
-
-    with pytest.raises(ValueError, match="max_concurrency must be greater than 0"):
-        await suite.run(parallel=True, max_concurrency=max_concurrency)
+    return suite
 
 
-@pytest.mark.parametrize("max_concurrency", [True, False, 1.5, "2"])
-@pytest.mark.asyncio
-async def test_suite_parallel_rejects_non_integer_max_concurrency(max_concurrency):
-    suite = Suite(name="invalid_parallel_limit_suite", target=lambda inputs: inputs)
-    suite.append(Scenario("a").interact("a"))
-
-    with pytest.raises(
-        TypeError, match="max_concurrency must be None or a positive integer"
-    ):
-        await suite.run(parallel=True, max_concurrency=max_concurrency)
-
-
+@pytest.mark.parametrize("parallel", [True, False])
 @pytest.mark.parametrize(
     ("max_concurrency", "error_type", "message"),
     [
         (0, ValueError, "max_concurrency must be greater than 0"),
+        (-1, ValueError, "max_concurrency must be greater than 0"),
         (True, TypeError, "max_concurrency must be None or a positive integer"),
+        (False, TypeError, "max_concurrency must be None or a positive integer"),
         (1.5, TypeError, "max_concurrency must be None or a positive integer"),
         ("2", TypeError, "max_concurrency must be None or a positive integer"),
     ],
 )
 @pytest.mark.asyncio
-async def test_suite_rejects_invalid_max_concurrency_without_parallel(
-    max_concurrency, error_type, message
+async def test_suite_rejects_invalid_max_concurrency(
+    simple_suite, parallel, max_concurrency, error_type, message
 ):
-    suite = Suite(name="invalid_sequential_limit_suite", target=lambda inputs: inputs)
-    suite.append(Scenario("a").interact("a"))
-
     with pytest.raises(error_type, match=message):
-        await suite.run(parallel=False, max_concurrency=max_concurrency)
+        await simple_suite.run(parallel=parallel, max_concurrency=max_concurrency)
 
 
 def test_progress_counter_appears_only_on_the_overall_row():


### PR DESCRIPTION
## Description

Validate `Suite.run(max_concurrency=...)` before execution starts. This keeps `None` and positive integers valid, rejects bool/non-int values with a clear `TypeError`, and keeps non-positive integers on the existing `ValueError` path.

The validation now applies even when `parallel=False`, so invalid configuration is not silently ignored.

## Related Issue

Fixes #2499

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality change)
- [ ] 🔐 Security fix

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [ ] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been modified)

## Verification

- `AGENT_NAME="kiku-jw" REASON="Giskard-AI/giskard-oss#2499 max_concurrency validation" make setup-for-agents`
- `GISKARD_TELEMETRY_DISABLED=true uv run pytest libs/giskard-checks/tests/core/test_suite.py -k max_concurrency -q`
- `GISKARD_TELEMETRY_DISABLED=true uv run pytest libs/giskard-checks/tests/core/test_suite.py -q`
- `GISKARD_TELEMETRY_DISABLED=true make test-unit PACKAGE=giskard-checks`
- `GISKARD_TELEMETRY_DISABLED=true make format`
- `UV_TOOL_DIR=/tmp/uv-tools-giskard-oss-2499 UV_CACHE_DIR=/tmp/uv-cache-giskard-oss-2499 GISKARD_TELEMETRY_DISABLED=true make check`