### PR TITLE
fix(checks): require comparison expected value

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/builtin/comparison.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/comparison.py
@@ -35,9 +35,9 @@ class ComparisonCheck[InputType, OutputType, TraceType: Trace, ExpectedType](  #
     key: JSONPathStr = Field(
         ..., description="The key to extract the actual value from the trace"
     )
-    expected_value: ExpectedType | None = Field(
-        default=None,
-        description="The expected value to compare against. If None, the expected value is extracted from the trace using the expected_value_key.",
+    expected_value: ExpectedType | None | NotProvided = Field(
+        default=NOT_PROVIDED,
+        description="The expected value to compare against. If omitted, the expected value is extracted from the trace using the expected_value_key.",
     )
     expected_value_key: JSONPathStr | NotProvided = Field(
         default=NOT_PROVIDED,

--- a/libs/giskard-checks/tests/builtin/test_comparison.py
+++ b/libs/giskard-checks/tests/builtin/test_comparison.py
@@ -6,8 +6,10 @@ Tests cover different types (numbers, strings) and various comparison scenarios:
 - TypeError handling (missing methods and incompatible types)
 """
 
+import pytest
 from giskard.checks import (
     CheckStatus,
+    Equals,
     GreaterEquals,
     GreaterThan,
     Interaction,
@@ -17,6 +19,37 @@ from giskard.checks import (
     Trace,
 )
 from giskard.checks.core.extraction import NoMatch
+
+
+class TestComparisonValidation:
+    """Test shared comparison-check configuration validation."""
+
+    @pytest.mark.parametrize(
+        "check_cls",
+        [Equals, GreaterThan, LesserThan, GreaterEquals, LesserThanEquals, NotEquals],
+    )
+    def test_expected_value_or_key_is_required(self, check_cls):
+        with pytest.raises(
+            ValueError,
+            match="Either 'expected_value' or 'expected_value_key' must be provided",
+        ):
+            check_cls(key="trace.interactions[-1].outputs")
+
+    def test_explicit_none_expected_value_is_valid(self):
+        check = Equals(
+            expected_value=None,
+            key="trace.interactions[-1].outputs",
+        )
+
+        assert check.expected_value is None
+
+    def test_expected_value_key_is_valid_without_expected_value(self):
+        check = Equals(
+            expected_value_key="trace.interactions[0].inputs",
+            key="trace.interactions[-1].outputs",
+        )
+
+        assert check.expected_value_key == "trace.interactions[0].inputs"
 
 
 class TestLesserThan:


### PR DESCRIPTION
  Closes #2545 

  ## Summary
  - distinguish omitted `expected_value` from explicit `expected_value=None`
  - reject comparison checks when both `expected_value` and `expected_value_key` are omitted
  - keep explicit `expected_value=None` valid
  - keep `expected_value_key=...` valid without `expected_value`
  - add shared validation coverage for comparison checks

  ## Testing
  - `.venv\Scripts\python.exe -m pytest -q libs/giskard-checks/tests/builtin/test_comparison.py libs/giskard-checks/
  tests/builtin/test_equals.py`
  - `uv run --no-sync ruff check libs/giskard-checks/src/giskard/checks/builtin/comparison.py libs/giskard-checks/tests/
  builtin/test_comparison.py`

  Verification: 103 passed, Ruff passed.
