### PR TITLE
feat(checks): add suite field to SuiteResult

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/core/check.py
+++ b/libs/giskard-checks/src/giskard/checks/core/check.py
@@ -1,8 +1,11 @@
+from typing import TYPE_CHECKING
 from giskard.core import Discriminated, discriminated_base
 from pydantic import Field
 
 from .interaction import Trace
-from .result import CheckResult
+
+if TYPE_CHECKING:
+    from .result import CheckResult
 
 
 @discriminated_base
@@ -18,7 +21,7 @@ class Check[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportM
     name: str | None = Field(default=None, description="Check name")
     description: str | None = Field(default=None, description="Check description")
 
-    async def run(self, trace: TraceType) -> CheckResult:
+    async def run(self, trace: TraceType) -> "CheckResult":
         """Execute the check against the provided trace.
 
         Subclasses must override this method and return a `CheckResult`. The

--- a/libs/giskard-checks/src/giskard/checks/core/check.py
+++ b/libs/giskard-checks/src/giskard/checks/core/check.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING
+
 from giskard.core import Discriminated, discriminated_base
 from pydantic import Field
 

--- a/libs/giskard-checks/src/giskard/checks/core/result.py
+++ b/libs/giskard-checks/src/giskard/checks/core/result.py
@@ -4,6 +4,9 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
+if TYPE_CHECKING:
+    from giskard.checks.scenarios.suite import Suite
+
 from pydantic import BaseModel, ConfigDict, Field, computed_field
 from rich.console import Console, ConsoleOptions, RenderResult
 from rich.panel import Panel
@@ -13,9 +16,6 @@ from rich.text import Text
 
 from .interaction import Trace
 from .protocols import RichConsoleProtocol, RichProtocol
-
-if TYPE_CHECKING:
-    from giskard.checks.scenarios.suite import Suite
 
 STATUS_MAPPING = {
     "total": {
@@ -515,8 +515,9 @@ class SuiteResult(BaseResult, frozen=True):
         Scenario results produced during the suite execution.
     duration_ms : int
         Total execution time in milliseconds.
-    suite : Suite
-        The Suite that produced this result.
+    suite : Suite | None
+        The Suite that produced this result. Excluded from serialization
+        (``None`` after a serialize/deserialize round-trip).
     passed_count : int
         Number of scenarios that passed.
     failed_count : int
@@ -533,8 +534,8 @@ class SuiteResult(BaseResult, frozen=True):
         ..., description="List of scenario results"
     )
     duration_ms: int = Field(..., description="Total execution time in milliseconds")
-    suite: "Suite[Any, Any]" = Field(
-        ..., description="The Suite that produced this result"
+    suite: "Suite[Any, Any] | None" = Field(
+        default=None, exclude=True, description="The Suite that produced this result"
     )
 
     @computed_field

--- a/libs/giskard-checks/src/giskard/checks/core/result.py
+++ b/libs/giskard-checks/src/giskard/checks/core/result.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from collections.abc import Mapping
 from enum import Enum
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field
 from rich.console import Console, ConsoleOptions, RenderResult
@@ -13,6 +13,9 @@ from rich.text import Text
 
 from .interaction import Trace
 from .protocols import RichConsoleProtocol, RichProtocol
+
+if TYPE_CHECKING:
+    from giskard.checks.scenarios.suite import Suite
 
 STATUS_MAPPING = {
     "total": {
@@ -512,6 +515,8 @@ class SuiteResult(BaseResult, frozen=True):
         Scenario results produced during the suite execution.
     duration_ms : int
         Total execution time in milliseconds.
+    suite : Suite
+        The Suite that produced this result.
     passed_count : int
         Number of scenarios that passed.
     failed_count : int
@@ -528,6 +533,9 @@ class SuiteResult(BaseResult, frozen=True):
         ..., description="List of scenario results"
     )
     duration_ms: int = Field(..., description="Total execution time in milliseconds")
+    suite: "Suite[Any, Any]" = Field(
+        ..., description="The Suite that produced this result"
+    )
 
     @computed_field
     @property

--- a/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
@@ -241,6 +241,7 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
             suite_result = SuiteResult(
                 results=results,
                 duration_ms=int((end_time - start_time) * 1000),
+                suite=self,
             )
 
             telemetry_capture(
@@ -320,3 +321,9 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
                 raise exc_group.exceptions[0]
             raise
         return [task.result() for task in tasks]
+
+
+# `SuiteResult.suite` is a forward reference to `Suite`, which is only imported
+# under `TYPE_CHECKING` in result.py to avoid a circular import. Rebuild the model
+# here, where `Suite` exists at runtime, so Pydantic can resolve the annotation.
+SuiteResult.model_rebuild()

--- a/libs/giskard-checks/tests/core/test_suite.py
+++ b/libs/giskard-checks/tests/core/test_suite.py
@@ -119,6 +119,31 @@ async def test_suite_result_aggregation():
 
 
 @pytest.mark.asyncio
+async def test_suite_result_exposes_originating_suite():
+    """The suite that produced a result is recoverable from the result."""
+    suite = Suite(name="recover_suite", target=lambda inputs: inputs)
+    suite.append(Scenario("s1").interact("a", "a"))
+
+    result = await suite.run()
+
+    # In-memory: the originating suite is recoverable from the result. Pydantic
+    # revalidates the submodel, so this is an equal copy rather than the same
+    # object, but the suite-level target callable is carried through by identity.
+    assert result.suite is not None
+    assert result.suite.name == suite.name
+    assert result.suite.target is suite.target
+
+    # Serialization: `suite` is excluded (it holds non-serializable callables),
+    # so dumping never raises and the field is absent from the output.
+    dumped = result.model_dump()
+    assert "suite" not in dumped
+    assert "suite" not in result.model_dump_json()
+
+    # Round-trip: deserializing has no suite to restore, so it comes back None.
+    assert result.__class__.model_validate_json(result.model_dump_json()).suite is None
+
+
+@pytest.mark.asyncio
 async def test_suite_callable_target():
     """Verify that suite target can be a callable."""
     scenario = Scenario("s1").interact("hello")

--- a/libs/giskard-checks/tests/core/test_suite.py
+++ b/libs/giskard-checks/tests/core/test_suite.py
@@ -474,6 +474,7 @@ def test_suite_group_by_skipped_scenario_counted_separately():
         SuiteResult,
         TestCaseResult,
     )
+    from giskard.checks.scenarios.suite import Suite
 
     empty_trace = Trace(interactions=[])
 
@@ -500,7 +501,9 @@ def test_suite_group_by_skipped_scenario_counted_separately():
         tags=["Category:Hallucination"],
     )
     suite_result = SuiteResult(
-        results=[skipped_scenario, passing_scenario], duration_ms=0
+        results=[skipped_scenario, passing_scenario],
+        duration_ms=0,
+        suite=Suite(name="test"),
     )
     grouped = suite_result.group_by("Category")
 

--- a/libs/giskard-checks/tests/export/test_junit.py
+++ b/libs/giskard-checks/tests/export/test_junit.py
@@ -10,6 +10,7 @@ from giskard.checks import (
     Trace,
 )
 from giskard.checks.export.junit import to_junit_xml
+from giskard.checks.scenarios.suite import Suite
 
 
 def _sample_suite_result() -> SuiteResult:
@@ -99,6 +100,7 @@ def _sample_suite_result() -> SuiteResult:
             ),
         ],
         duration_ms=420,
+        suite=Suite(name="test"),
     )
 
 
@@ -226,6 +228,7 @@ def test_failed_scenario_with_mixed_check_statuses_is_still_a_failure() -> None:
             )
         ],
         duration_ms=50,
+        suite=Suite(name="test"),
     )
 
     root = ET.fromstring(to_junit_xml(suite_result))


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Coding agents

Autonomous agents with no human in the loop must read **[AUTONOMOUS.md](https://github.com/Giskard-AI/giskard-oss/blob/main/AUTONOMOUS.md)** before opening a PR.

**PR title:** agent-opened PRs **must** end the title with **`🤖🤖🤖🤖`** (exactly four robot emojis). Do not omit — that suffix is how the expedited agent PR workflow picks up the PR.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [ ] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been
  modified)
