### PR TITLE
chore(claude): auto-format hook + /check verification-gate skill

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,18 @@
     "superpowers@claude-plugins-official": true
   },
   "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "read -r json; fp=$(printf '%s' \"$json\" | jq -r '.tool_input.file_path'); case \"$fp\" in */libs/*.py) uv run ruff format \"$fp\" && uv run ruff check --fix \"$fp\";; esac 2>/dev/null || true",
+            "statusMessage": "Running ruff format + check..."
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "startup",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "read -r json; fp=$(printf '%s' \"$json\" | jq -r '.tool_input.file_path'); case \"$fp\" in */libs/*.py) uv run ruff format \"$fp\" && uv run ruff check --fix \"$fp\";; esac 2>/dev/null || true",
+            "command": "{ read -r json; fp=$(printf '%s' \"$json\" | jq -r '.tool_input.file_path' 2>/dev/null); case \"$fp\" in libs/*.py|*/libs/*.py) uv run ruff format \"$fp\" && uv run ruff check --fix \"$fp\";; esac; } 2>/dev/null || true",
             "statusMessage": "Running ruff format + check..."
           }
         ]

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: check
+description: Run the giskard-oss verification gate (format, check, unit tests) for a package
+disable-model-invocation: true
+---
+
+# check
+
+Run the giskard-oss verification gate that `AGENTS.md` mandates before any task is "done":
+
+```
+make format && make check && make test-unit PACKAGE=<affected-lib>
+```
+
+## Usage
+
+`/check <package>` — run the full gate scoped to one lib's unit tests.
+
+`/check` — run the gate; unit tests cover all libs (slower).
+
+`<package>` is a directory under `libs/`: `giskard-agents`, `giskard-checks`, `giskard-core`, `giskard-llm`, `giskard-scan`.
+
+## What to run
+
+With a package:
+
+```bash
+make format && make check && make test-unit PACKAGE=<package>
+```
+
+Without a package:
+
+```bash
+make format && make check && make test-unit
+```
+
+`format` and `check` are repo-wide and take no `PACKAGE`. Only `test-unit` is scoped.
+
+## Notes
+
+- Run the three steps as one `&&` chain so a failure stops the gate early.
+- Report failures with the command's output — do not claim the gate passed unless every step exited 0.
+- `make format` mutates files (ruff format + check --fix); show the resulting diff if anything changed.


### PR DESCRIPTION
## What

Two Claude Code workflow additions, no changes to library code:

1. **PostToolUse hook** (`.claude/settings.json`) — runs `ruff format` then `ruff check --fix` on any `libs/**/*.py` file after an Edit/Write, mirroring `make format`. Keeps Claude's edits pre-commit clean. Non-lib paths, non-Python files, and ruff failures are skipped without blocking the edit.

2. **`/check` skill** (`.claude/skills/check/SKILL.md`) — user-only command wrapping the `AGENTS.md` verification gate: `make format && make check && make test-unit PACKAGE=<lib>`. `/check <package>` scopes unit tests to one lib; `/check` runs all.

## Verification

- Hook fire-tested: edited a `libs/` file with a formatting violation, confirmed ruff rewrote it.
- `/check` commands dry-run validated against the Makefile; full gate run green (format clean, all checks passed, all unit suites passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)