### PR TITLE
fix(checks): `NOT_PROVIDED` serialization roundtrip set `{}`

### DIFF
--- a/.cursor/skills/giskard-checks-new-check/SKILL.md
+++ b/.cursor/skills/giskard-checks-new-check/SKILL.md
@@ -24,7 +24,7 @@ For one-off or experimental logic, users can use `from_fn` / `FnCheck` without a
 
 ### Naming and typing (required)
 
-Any `Check` field named `key` or whose name ends with `_key` is a JSONPath into the trace. It **must** be annotated with `JSONPathStr`, or `JSONPathStr | None`, or `JSONPathStr | NotProvided` (from `..core.extraction` and `giskard.core`). Otherwise `tests/core/test_jsonpath_enforcement.py` fails.
+Any `Check` field named `key` or whose name ends with `_key` is a JSONPath into the trace. It **must** be annotated with `JSONPathStr`, or `JSONPathStr | None`, or `JSONPathStr | MISSING` (import `MISSING` from `pydantic.experimental.missing_sentinel`). Otherwise `tests/core/test_jsonpath_enforcement.py` fails.
 
 Inside the library, import from `..core.extraction` (module `giskard.checks.core.extraction`).
 
@@ -36,9 +36,9 @@ Inside the library, import from `..core.extraction` (module `giskard.checks.core
 ### Reading values
 
 - **`resolve(trace, key)`** — Use when the value always comes from the trace (e.g. comparison `key`).
-- **`provided_or_resolve(trace, key=..., value=...)`** — Use when the user may pass an inline value **or** fall back to a path (e.g. `answer` + `answer_key`). If `value` is provided (`provide_not_none` helps for optional fields), that wins; otherwise the path is evaluated.
+- **`provided_or_resolve(trace, key=..., value=...)`** — Use when the user may pass an inline value **or** fall back to a path (e.g. `answer` + `answer_key`). If `value is not MISSING`, that wins; otherwise the path is evaluated.
 
-Optional key fields that are only sometimes used: type as `JSONPathStr | None` or `JSONPathStr | NotProvided`, pass through `provide_not_none` when calling `provided_or_resolve`, and validate combinations with a `@model_validator` if only one of (inline, `*_key`) may be set (see `StringMatching` / `ComparisonCheck`).
+Optional inline-or-path fields: type as `T | MISSING = MISSING` (and `JSONPathStr | MISSING = MISSING` for optional `*_key` fields). Pass fields directly to `provided_or_resolve`; validate combinations with a `@model_validator` if only one of (inline, `*_key`) may be set (see `StringMatching` / `ComparisonCheck`). Do not use `None` to mean "extract from trace"—omit the field so it stays `MISSING`. Explicit `None` is only valid when comparing against or supplying `None` as a real value (e.g. `Equals(expected_value=None)`).
 
 ### Failures and types
 

--- a/.cursor/skills/giskard-checks-new-check/reference.md
+++ b/.cursor/skills/giskard-checks-new-check/reference.md
@@ -3,9 +3,9 @@
 ## JSONPath enforcement and helpers
 
 - **Source**: `libs/giskard-checks/src/giskard/checks/core/extraction.py` — `JSONPathStr`, `resolve`, `provided_or_resolve`, `NoMatch`.
-- **Enforcement**: `libs/giskard-checks/tests/core/test_jsonpath_enforcement.py` — field names `key` or `*_key` must carry the `JSONPathStr` marker (including inside unions with `None` or `NotProvided`).
-- **`NotProvided` pattern** (`ComparisonCheck`): `expected_value_key: JSONPathStr | NotProvided` with `default=NOT_PROVIDED`; in `run`, use `provided_or_resolve(trace, key=provide_not_none(self.expected_value_key), value=self.expected_value)` so a literal `expected_value` skips the path.
-- **`None` optional path** (`StringMatching.keyword_key`): `JSONPathStr | None` with a validator that requires exactly one of inline value or key—do not use a bare `str` annotation for any `*_key` field.
+- **Enforcement**: `libs/giskard-checks/tests/core/test_jsonpath_enforcement.py` — field names `key` or `*_key` must carry the `JSONPathStr` marker (including inside unions with `None` or `MISSING`).
+- **`MISSING` inline-or-path** (`ComparisonCheck`): `expected_value: ExpectedType | MISSING = MISSING` and `expected_value_key: JSONPathStr | MISSING = MISSING`; validate with `is MISSING` checks; in `run`, call `provided_or_resolve(trace, key=self.expected_value_key, value=self.expected_value)` so an inline `expected_value` (including explicit `None`) skips the path.
+- **`MISSING` optional path** (`StringMatching.keyword_key`): `JSONPathStr | MISSING = MISSING` with a validator that requires exactly one of inline value or key—do not use a bare `str` annotation for any `*_key` field.
 - **Multi-match**: `resolve` returns a list when the expression yields multiple matches or the parsed path is list-like (`Slice`, `Union`, etc.); single-match paths return one value or `NoMatch`.
 
 ## Non-LLM `Check`

--- a/libs/giskard-checks/src/giskard/checks/builtin/comparison.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/comparison.py
@@ -1,8 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Any, Self, override
 
-from giskard.core import NOT_PROVIDED, NotProvided, provide_not_none
 from pydantic import Field, model_validator
+from pydantic.experimental.missing_sentinel import MISSING
 
 from ..core import Trace
 from ..core.check import Check
@@ -35,13 +35,13 @@ class ComparisonCheck[InputType, OutputType, TraceType: Trace, ExpectedType](  #
     key: JSONPathStr = Field(
         ..., description="The key to extract the actual value from the trace"
     )
-    expected_value: ExpectedType | NotProvided = Field(
-        default=NOT_PROVIDED,
+    expected_value: ExpectedType | MISSING = Field(
+        default=MISSING,
         description="The expected value to compare against. If omitted, the expected value is extracted from the trace using expected_value_key. Explicit None is valid and compares against None.",
     )
-    expected_value_key: JSONPathStr | NotProvided = Field(
-        default=NOT_PROVIDED,
-        description="The key to extract the expected value from the trace. If None, the expected value is used as is. If provided, the expected value is extracted from the trace using the expected_value_key.",
+    expected_value_key: JSONPathStr | MISSING = Field(
+        default=MISSING,
+        description="The key to extract the expected value from the trace. If omitted, use expected_value directly. If provided, the expected value is extracted from the trace using this key.",
     )
     normalization_form: NormalizationForm | None = Field(
         default="NFKC",
@@ -68,9 +68,7 @@ class ComparisonCheck[InputType, OutputType, TraceType: Trace, ExpectedType](  #
     @model_validator(mode="after")
     def validate_expected_value_or_expected_value_key(self) -> Self:
         """Validate that exactly one of expected_value or expected_value_key is provided."""
-        if isinstance(self.expected_value, NotProvided) and isinstance(
-            self.expected_value_key, NotProvided
-        ):
+        if self.expected_value is MISSING and self.expected_value_key is MISSING:
             raise ValueError(
                 "Either 'expected_value' or 'expected_value_key' must be provided"
             )
@@ -82,7 +80,7 @@ class ComparisonCheck[InputType, OutputType, TraceType: Trace, ExpectedType](  #
         actual_value = resolve(trace, self.key)
         expected_value = provided_or_resolve(
             trace,
-            key=provide_not_none(self.expected_value_key),
+            key=self.expected_value_key,
             value=self.expected_value,
         )
 

--- a/libs/giskard-checks/src/giskard/checks/builtin/comparison.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/comparison.py
@@ -68,9 +68,9 @@ class ComparisonCheck[InputType, OutputType, TraceType: Trace, ExpectedType](  #
     @model_validator(mode="after")
     def validate_expected_value_or_expected_value_key(self) -> Self:
         """Validate that exactly one of expected_value or expected_value_key is provided."""
-        if self.expected_value is MISSING and self.expected_value_key is MISSING:
+        if (self.expected_value is MISSING) == (self.expected_value_key is MISSING):
             raise ValueError(
-                "Either 'expected_value' or 'expected_value_key' must be provided"
+                "Exactly one of 'expected_value' or 'expected_value_key' must be provided"
             )
         return self
 

--- a/libs/giskard-checks/src/giskard/checks/builtin/semantic_similarity.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/semantic_similarity.py
@@ -1,8 +1,8 @@
 from typing import override
 
 import numpy as np
-from giskard.core import provide_not_none
 from pydantic import Field
+from pydantic.experimental.missing_sentinel import MISSING
 
 from ..core import Trace
 from ..core.check import Check
@@ -58,9 +58,9 @@ class SemanticSimilarity[InputType, OutputType, TraceType: Trace](  # pyright: i
     threshold : float
         The minimum cosine similarity score required for the check to pass
         (default: 0.95).
-    reference_text : str | None
-        The reference text to compare the output against. If None, the reference
-        text will be extracted from the trace using `reference_text_key`.
+    reference_text : str | MISSING
+        The reference text to compare the output against. If omitted, extracted
+        from the trace using ``reference_text_key``.
     reference_text_key : str
         JSONPath expression to extract the reference text from the trace
         (default: "trace.last.metadata.reference_text").
@@ -87,8 +87,8 @@ class SemanticSimilarity[InputType, OutputType, TraceType: Trace](  # pyright: i
     threshold: float = Field(
         default=0.95, description="The threshold for the semantic similarity"
     )
-    reference_text: str | None = Field(
-        default=None, description="The reference text to compare the output with"
+    reference_text: str | MISSING = Field(
+        default=MISSING, description="The reference text to compare the output with"
     )
     reference_text_key: JSONPathStr = Field(
         default="trace.last.metadata.reference_text",
@@ -117,8 +117,8 @@ class SemanticSimilarity[InputType, OutputType, TraceType: Trace](  # pyright: i
         """
         reference_text = provided_or_resolve(
             trace,
-            key=provide_not_none(self.reference_text_key),
-            value=provide_not_none(self.reference_text),
+            key=self.reference_text_key,
+            value=self.reference_text,
         )
         if isinstance(reference_text, NoMatch):
             return CheckResult.failure(

--- a/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
@@ -9,8 +9,8 @@ from abc import ABC, abstractmethod
 from typing import Any, Self, override
 
 import regex
-from giskard.core import provide_not_none
 from pydantic import Field, model_validator
+from pydantic.experimental.missing_sentinel import MISSING
 
 from ..core import Trace
 from ..core.check import Check
@@ -32,16 +32,16 @@ class TextBasedCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignor
 
     Attributes
     ----------
-    text : str | None
-        The text string to search within. If None, will be extracted from
-        trace using `text_key`.
+    text : str | MISSING
+        The text string to search within. If omitted, extracted from
+        trace using ``text_key``.
     text_key : JSONPathStr
         JSONPath expression to extract the text from the trace. Defaults to
         "trace.last.outputs" which extracts the last interaction's outputs.
     """
 
-    text: str | None = Field(
-        default=None,
+    text: str | MISSING = Field(
+        default=MISSING,
         description="The text string to search within.",
     )
     text_key: JSONPathStr = Field(
@@ -52,8 +52,8 @@ class TextBasedCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignor
     def _extract_and_validate(
         self,
         trace: TraceType,
-        target_value: str | None,
-        target_key: JSONPathStr | None,
+        target_value: str | MISSING,
+        target_key: JSONPathStr | MISSING,
         target_name: str,
     ) -> tuple[str, str, dict[str, Any]] | tuple[None, None, CheckResult]:
         """Extract and validate text and target from trace or direct values.
@@ -62,9 +62,9 @@ class TextBasedCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignor
         ----------
         trace : TraceType
             The trace to extract values from.
-        target_value : str | None
+        target_value : str | MISSING
             Direct target value (keyword/pattern).
-        target_key : JSONPathStr | None
+        target_key : JSONPathStr | MISSING
             JSONPath key to extract target from trace.
         target_name : str
             Name of the target parameter (for error messages).
@@ -75,13 +75,11 @@ class TextBasedCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignor
             Either (text, target, details) on success, or (None, None, error_result) on failure.
         """
         # Extract text and target
-        text = provided_or_resolve(
-            trace, key=self.text_key, value=provide_not_none(self.text)
-        )
+        text = provided_or_resolve(trace, key=self.text_key, value=self.text)
         target = provided_or_resolve(
             trace,
-            key=provide_not_none(target_key),
-            value=provide_not_none(target_value),
+            key=target_key,
+            value=target_value,
         )
 
         details = {"text": text, target_name: target}
@@ -156,18 +154,18 @@ class StringMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignor
 
     Attributes
     ----------
-    text : str | None
-        The text string to search within. If None, will be extracted from
-        trace using `text_key`.
+    text : str | MISSING
+        The text string to search within. If omitted, extracted from
+        trace using ``text_key``.
     text_key : JSONPathStr
         JSONPath expression to extract the text from the trace. Defaults to
         "trace.last.outputs" which extracts the last interaction's outputs.
-    keyword : str | None
-        The keyword to search for within the text. If None, must provide
-        `keyword_key` to extract from trace.
-    keyword_key : JSONPathStr | None
+    keyword : str | MISSING
+        The keyword to search for within the text. If omitted, must provide
+        ``keyword_key`` to extract from trace.
+    keyword_key : JSONPathStr | MISSING
         JSONPath expression to extract the keyword from the trace. Either
-        `keyword` or `keyword_key` must be provided.
+        ``keyword`` or ``keyword_key`` must be provided.
     normalization_form : NormalizationForm | None
         Unicode normalization form to apply before matching. Options:
         - "NFC": Canonical Composition
@@ -204,12 +202,12 @@ class StringMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignor
         )
     """
 
-    keyword: str | None = Field(
-        default=None,
+    keyword: str | MISSING = Field(
+        default=MISSING,
         description="The keyword to search for within the text. Either this or keyword_key must be provided.",
     )
-    keyword_key: JSONPathStr | None = Field(
-        default=None,
+    keyword_key: JSONPathStr | MISSING = Field(
+        default=MISSING,
         description="JSONPath expression to extract the keyword from the trace (e.g., 'trace.last.inputs.expected'). Either this or keyword must be provided.",
     )
     normalization_form: NormalizationForm | None = Field(
@@ -235,7 +233,7 @@ class StringMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignor
         ValueError
             If neither or both keyword and keyword_key are provided.
         """
-        if (self.keyword is None) == (self.keyword_key is None):
+        if (self.keyword is MISSING) == (self.keyword_key is MISSING):
             raise ValueError(
                 "Exactly one of 'keyword' or 'keyword_key' must be provided, not both or neither."
             )
@@ -335,15 +333,15 @@ class RegexMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignore
 
     Attributes
     ----------
-    text : str | None
-        The text string to search within. If None, will be extracted from
-        trace using `text_key`.
+    text : str | MISSING
+        The text string to search within. If omitted, extracted from
+        trace using ``text_key``.
     text_key : JSONPathStr
         JSONPath expression to extract the text from the trace. Defaults to
         "trace.last.outputs" which extracts the last interaction's outputs.
-    pattern : str | None
-        The regex pattern to search for. Either this or pattern_key must be provided.
-    pattern_key : JSONPathStr | None
+    pattern : str | MISSING
+        The regex pattern to search for. Either this or ``pattern_key`` must be provided.
+    pattern_key : JSONPathStr | MISSING
         JSONPath expression to extract pattern from trace.
     match_timeout_seconds : float
         Upper bound on how long matching may take before the check raises an error.
@@ -394,12 +392,12 @@ class RegexMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignore
         )
     """
 
-    pattern: str | None = Field(
-        default=None,
+    pattern: str | MISSING = Field(
+        default=MISSING,
         description="The regex pattern to search for within the text.",
     )
-    pattern_key: JSONPathStr | None = Field(
-        default=None,
+    pattern_key: JSONPathStr | MISSING = Field(
+        default=MISSING,
         description="JSONPath expression to extract the pattern from the trace.",
     )
     match_timeout_seconds: float = Field(
@@ -422,7 +420,7 @@ class RegexMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignore
         ValueError
             If neither or both pattern and pattern_key are provided.
         """
-        if (self.pattern is None) == (self.pattern_key is None):
+        if (self.pattern is MISSING) == (self.pattern_key is MISSING):
             raise ValueError(
                 "Exactly one of 'pattern' or 'pattern_key' must be provided, not both or neither."
             )

--- a/libs/giskard-checks/src/giskard/checks/core/extraction.py
+++ b/libs/giskard-checks/src/giskard/checks/core/extraction.py
@@ -88,7 +88,7 @@ def resolve[TraceType: Trace](trace: TraceType, key: str) -> Any:  # pyright: ig
     return matches[0].value if matches else NoMatch(key=key)
 
 
-def provided_or_resolve[T, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
+def provided_or_resolve[TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
     trace: TraceType,
     key: str | MISSING = MISSING,
     value: Any = MISSING,

--- a/libs/giskard-checks/src/giskard/checks/core/extraction.py
+++ b/libs/giskard-checks/src/giskard/checks/core/extraction.py
@@ -1,6 +1,5 @@
 from typing import Annotated, Any, override
 
-from giskard.core import NOT_PROVIDED, NotProvided
 from jsonpath_ng import (
     Child,
     DatumInContext,
@@ -15,6 +14,7 @@ from jsonpath_ng import (
 )
 from jsonpath_ng.exceptions import JsonPathLexerError, JsonPathParserError
 from pydantic import AfterValidator, BaseModel, Field
+from pydantic.experimental.missing_sentinel import MISSING
 
 from .interaction import Trace
 
@@ -88,12 +88,12 @@ def resolve[TraceType: Trace](trace: TraceType, key: str) -> Any:  # pyright: ig
     return matches[0].value if matches else NoMatch(key=key)
 
 
-def provided_or_resolve[TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
+def provided_or_resolve[T, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
     trace: TraceType,
-    key: str | NotProvided = NOT_PROVIDED,
-    value: Any = NOT_PROVIDED,
+    key: str | MISSING = MISSING,
+    value: Any = MISSING,
 ) -> Any:
-    if isinstance(key, NotProvided) or not isinstance(value, NotProvided):
+    if key is MISSING or value is not MISSING:
         return value
 
     return resolve(trace, key)

--- a/libs/giskard-checks/src/giskard/checks/core/interaction/interact.py
+++ b/libs/giskard-checks/src/giskard/checks/core/interaction/interact.py
@@ -2,8 +2,8 @@ from collections.abc import AsyncGenerator
 from typing import Any, cast, override
 
 from giskard.checks.utils.injectable import ValueGenerator, ValueProvider
-from giskard.core.utils import NOT_PROVIDED, NotProvided
 from pydantic import Field, PrivateAttr, model_validator
+from pydantic.experimental.missing_sentinel import MISSING
 
 from ...utils.inference import _infer_input_type
 from ..input_generator import InputGenerator
@@ -79,10 +79,11 @@ class Interact[InputType, OutputType, TraceType: Trace](  # pyright: ignore[repo
         Input specification. Can be a static value, callable, or generator.
         Callables can take no arguments or the current `Trace` as an argument.
         Generators yield multiple inputs and receive updated traces via `asend()`.
-    outputs : OutputType | Callable[..., OutputType | Awaitable[OutputType | Interaction]]
-        Output specification. Can be a static value or callable.
-        Callables receive the current `InputType` and optionally the current `Trace`.
-        Can return an `Interaction` object directly to override default metadata.
+    outputs : Target | MISSING
+        Output specification, or ``MISSING`` (default) to bind the scenario or
+        ``run()`` target at execution time. Can also be a static value or callable.
+        Callables receive the current ``InputType`` and optionally the current ``Trace``.
+        Can return an ``Interaction`` object directly to override default metadata.
     metadata : dict[str, Any]
         Default metadata to attach to interactions. Can be overridden if `outputs`
         returns an `Interaction` object directly.
@@ -132,8 +133,8 @@ class Interact[InputType, OutputType, TraceType: Trace](  # pyright: ignore[repo
         | GeneratorType[[], InputType, None]
         | GeneratorType[[TraceType], InputType, TraceType]
     ) = Field(..., description="The inputs of the interaction.")
-    outputs: Target[InputType, OutputType, TraceType] | NotProvided = Field(
-        default=NOT_PROVIDED, description="The outputs of the interaction."
+    outputs: Target[InputType, OutputType, TraceType] | MISSING = Field(
+        default=MISSING, description="The outputs of the interaction."
     )
     metadata: dict[str, Any] = Field(
         default_factory=dict, description="The metadata of the interaction."
@@ -155,7 +156,7 @@ class Interact[InputType, OutputType, TraceType: Trace](  # pyright: ignore[repo
 
     def _validate_outputs(self) -> None:
         try:
-            if not isinstance(self.outputs, NotProvided):
+            if self.outputs is not MISSING:
                 self._output_injectable = ValueProvider(
                     self.outputs, {"inputs", "trace"}
                 )
@@ -175,7 +176,7 @@ class Interact[InputType, OutputType, TraceType: Trace](  # pyright: ignore[repo
 
     def set_outputs(
         self,
-        outputs: Target[InputType, OutputType, TraceType] | NotProvided,
+        outputs: Target[InputType, OutputType, TraceType] | MISSING,
     ) -> "Interact[InputType, OutputType, TraceType]":
         """Update the outputs of the interact and recompute the injection mappings. Returns self for chaining."""
         self.outputs = outputs
@@ -195,7 +196,7 @@ class Interact[InputType, OutputType, TraceType: Trace](  # pyright: ignore[repo
         try:
             inputs = await anext(generator)
             while True:
-                if isinstance(self.outputs, NotProvided):
+                if self.outputs is MISSING:
                     raise ValueError(
                         "Interaction outputs are not provided and no target was bound."
                     )

--- a/libs/giskard-checks/src/giskard/checks/core/scenario.py
+++ b/libs/giskard-checks/src/giskard/checks/core/scenario.py
@@ -1,7 +1,7 @@
 from typing import Any, Self
 
-from giskard.core.utils import NOT_PROVIDED, NotProvided
 from pydantic import BaseModel, Field
+from pydantic.experimental.missing_sentinel import MISSING
 
 from .check import Check
 from .input_generator import InputGenerator
@@ -75,8 +75,8 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
     annotations : dict[str, Any]
         Key-value pairs merged into the trace at run start.
         Can be accessed as `trace.annotations` during scenario execution.
-    target : Target[InputType, OutputType, TraceType] | NotProvided
-        Default SUT for interactions whose outputs are ``NOT_PROVIDED`` when no
+    target : Target[InputType, OutputType, TraceType] | MISSING
+        Default SUT for interactions whose outputs are ``MISSING`` when no
         per-call ``target`` is passed to ``run`` (see ``with_target``).
     multiple_runs : int
         Default upper bound on how many times to execute the full scenario (each
@@ -104,9 +104,9 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
         default_factory=dict,
         description="Scenario-level annotations that will be injected in the trace.",
     )
-    target: Target[InputType, OutputType, TraceType] | NotProvided = Field(
-        default=NOT_PROVIDED,
-        description="Scenario-level target SUT that will be used to replace NOT_PROVIDED outputs.",
+    target: Target[InputType, OutputType, TraceType] | MISSING = Field(
+        default=MISSING,
+        description="Scenario-level target SUT that will be used to replace MISSING outputs.",
     )
     multiple_runs: int = Field(
         default=1,
@@ -161,7 +161,7 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
             | GeneratorType[[], InputType, None]
             | GeneratorType[[TraceType], InputType, TraceType]
         ),
-        outputs: Target[InputType, OutputType, TraceType] | NotProvided = NOT_PROVIDED,
+        outputs: Target[InputType, OutputType, TraceType] | MISSING = MISSING,
         metadata: dict[str, object] | None = None,
     ) -> Self:
         """Add an interaction to the scenario.
@@ -176,9 +176,9 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
         inputs : InputType | InputGenerator | Generator | Callable
             Input specification: static value, ``InputGenerator``, generator, or
             callable producing inputs (same options as ``Interact``).
-        outputs : OutputType | Callable | NotProvided, optional
-            Output specification, or ``NOT_PROVIDED`` to use the scenario-level
-            or ``run()``-level target. Defaults to ``NOT_PROVIDED``.
+        outputs : Target | MISSING, optional
+            Output specification, or ``MISSING`` to use the scenario-level
+            or ``run()``-level target. Defaults to ``MISSING``.
         metadata : dict[str, object] | None
             Optional metadata to attach to the interaction.
 
@@ -271,7 +271,7 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
         self,
         target: Target[InputType, OutputType, TraceType],
     ) -> Self:
-        """Set the default SUT for interactions with ``NOT_PROVIDED`` outputs.
+        """Set the default SUT for interactions with ``MISSING`` outputs.
 
         Parameters
         ----------
@@ -304,7 +304,7 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
 
     async def run(
         self,
-        target: Target[InputType, OutputType, TraceType] | NotProvided = NOT_PROVIDED,
+        target: Target[InputType, OutputType, TraceType] | MISSING = MISSING,
         return_exception: bool = False,
         multiple_runs: int | None = None,
     ) -> ScenarioResult[TraceType]:
@@ -320,22 +320,15 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
 
         Parameters
         ----------
-        target : Target | NotProvided
-            Optional target override used to replace `NOT_PROVIDED` interaction outputs.
-        return_exception : bool
-            If True, return results even when exceptions occur instead of raising.
-        multiple_runs : int | None
-            Optional cap on full scenario executions. When provided, it overrides
-            the scenario-level `multiple_runs` value.
-
-        Parameters
-        ----------
-        target : Target[InputType, OutputType, TraceType] | NotProvided, optional
-            SUT used to replace ``NOT_PROVIDED`` outputs on ``Interact`` specs.
-            Defaults to ``NOT_PROVIDED``; overrides the scenario's ``target`` when set.
+        target : Target | MISSING, optional
+            SUT used to replace ``MISSING`` outputs on ``Interact`` specs.
+            Defaults to ``MISSING``; overrides the scenario's ``target`` when set.
         return_exception : bool, default False
             If True, exceptions raised by checks become ``CheckResult.error``
             entries instead of propagating.
+        multiple_runs : int | None, optional
+            Optional cap on full scenario executions. When provided, it overrides
+            the scenario-level ``multiple_runs`` value.
 
         Returns
         -------

--- a/libs/giskard-checks/src/giskard/checks/judges/answer_relevance.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/answer_relevance.py
@@ -1,8 +1,8 @@
 from typing import Any, override
 
 from giskard.agents.workflow import TemplateReference
-from giskard.core import provide_not_none
 from pydantic import Field
+from pydantic.experimental.missing_sentinel import MISSING
 
 from ..core import Trace
 from ..core.check import Check
@@ -27,21 +27,23 @@ class AnswerRelevance[InputType, OutputType, TraceType: Trace](  # pyright: igno
 
     Attributes
     ----------
-    question : str | None
+    question : str | MISSING
         The question to evaluate relevance against. When provided, takes priority
-        over ``question_key``.
+        over ``question_key``. If omitted, extracted from the trace using ``question_key``.
     question_key : JSONPathStr
         JSONPath expression to extract the question from the trace
         (default: ``"trace.last.inputs"``).
-    answer : str | None
+    answer : str | MISSING
         The answer to evaluate. When provided, takes priority over ``answer_key``.
+        If omitted, extracted from the trace using ``answer_key``.
     answer_key : JSONPathStr
         JSONPath expression to extract the answer from the trace
         (default: ``"trace.last.outputs"``).
-    context : str | None
+    context : str | MISSING
         Optional domain context that describes the chatbot's purpose or scope
         (e.g., ``"This is a chatbot that answers questions about programming languages"``).
-        Not extracted from the trace—must be supplied directly when needed.
+        Not extracted from the trace—supply directly when needed. Defaults to an
+        empty string when omitted.
 
     Examples
     --------
@@ -54,24 +56,24 @@ class AnswerRelevance[InputType, OutputType, TraceType: Trace](  # pyright: igno
     ... )
     """
 
-    question: str | None = Field(
-        default=None,
+    question: str | MISSING = Field(
+        default=MISSING,
         description="The question to evaluate relevance against. Takes priority over question_key.",
     )
     question_key: JSONPathStr = Field(
         default="trace.last.inputs",
         description="JSONPath to extract the question from the trace.",
     )
-    answer: str | None = Field(
-        default=None,
+    answer: str | MISSING = Field(
+        default=MISSING,
         description="The answer to evaluate. Takes priority over answer_key.",
     )
     answer_key: JSONPathStr = Field(
         default="trace.last.outputs",
         description="JSONPath to extract the answer from the trace.",
     )
-    context: str | None = Field(
-        default=None,
+    context: str | MISSING = Field(
+        default=MISSING,
         description=(
             "Optional domain context describing the chatbot's purpose or scope. "
             "Not extracted from the trace—supply directly when needed."
@@ -102,17 +104,17 @@ class AnswerRelevance[InputType, OutputType, TraceType: Trace](  # pyright: igno
         question = provided_or_resolve(
             trace,
             key=self.question_key,
-            value=provide_not_none(self.question),
+            value=self.question,
         )
         answer = provided_or_resolve(
             trace,
             key=self.answer_key,
-            value=provide_not_none(self.answer),
+            value=self.answer,
         )
 
         return {
             "question": question,
             "answer": answer,
             "history": trace,
-            "context": self.context or "",
+            "context": self.context if self.context is not MISSING else "",
         }

--- a/libs/giskard-checks/src/giskard/checks/judges/groundedness.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/groundedness.py
@@ -1,8 +1,8 @@
 from typing import override
 
 from giskard.agents.workflow import TemplateReference
-from giskard.core import provide_not_none
 from pydantic import Field
+from pydantic.experimental.missing_sentinel import MISSING
 
 from ..core import Trace
 from ..core.check import Check
@@ -21,15 +21,17 @@ class Groundedness[InputType, OutputType, TraceType: Trace](  # pyright: ignore[
 
     Attributes
     ----------
-    answer : str | None
-        The answer text to evaluate for groundedness.
+    answer : str | MISSING
+        The answer text to evaluate for groundedness. If omitted, extracted from
+        the trace using ``answer_key``.
     answer_key : str
         JSONPath expression to extract the answer from the trace
         (default: "trace.last.outputs").
 
         Can use `trace.last` (preferred) or `trace.interactions[-1]` for JSONPath expressions.
-    context : list[str] | None
-        List of context documents that should support the answer.
+    context : str | list[str] | MISSING
+        Context documents that should support the answer. If omitted, extracted
+        from the trace using ``context_key``.
     context_key : str
         JSONPath expression to extract the context from the trace
         (default: "trace.last.metadata.context").
@@ -48,15 +50,15 @@ class Groundedness[InputType, OutputType, TraceType: Trace](  # pyright: ignore[
     ... )
     """
 
-    answer: str | None = Field(
-        default=None, description="Input source for the answer to evaluate"
+    answer: str | MISSING = Field(
+        default=MISSING, description="Input source for the answer to evaluate"
     )
     answer_key: JSONPathStr = Field(
         default="trace.last.outputs",
         description="Key to extract the answer from the trace",
     )
-    context: str | list[str] | None = Field(
-        default=None, description="Input source for the reference context"
+    context: str | list[str] | MISSING = Field(
+        default=MISSING, description="Input source for the reference context"
     )
     context_key: JSONPathStr = Field(
         default="trace.last.metadata.context",
@@ -86,14 +88,14 @@ class Groundedness[InputType, OutputType, TraceType: Trace](  # pyright: ignore[
                 provided_or_resolve(
                     trace,
                     key=self.answer_key,
-                    value=provide_not_none(self.answer),
+                    value=self.answer,
                 )
             ),
             "context": str(
                 provided_or_resolve(
                     trace,
                     key=self.context_key,
-                    value=provide_not_none(self.context),
+                    value=self.context,
                 )
             ),
         }

--- a/libs/giskard-checks/src/giskard/checks/judges/toxicity.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/toxicity.py
@@ -1,8 +1,8 @@
 from typing import Any, Literal, override
 
 from giskard.agents.workflow import TemplateReference
-from giskard.core import provide_not_none
 from pydantic import Field
+from pydantic.experimental.missing_sentinel import MISSING
 
 from ..core import Trace
 from ..core.check import Check
@@ -40,8 +40,8 @@ class Toxicity[InputType, OutputType, TraceType: Trace](  # pyright: ignore[repo
 
     Attributes
     ----------
-    output : str | None
-        The text to evaluate for toxicity. If None, extracted from the trace
+    output : str | MISSING
+        The text to evaluate for toxicity. If omitted, extracted from the trace
         using ``output_key``.
     output_key : JSONPathStr
         JSONPath expression to extract the output from the trace
@@ -78,9 +78,9 @@ class Toxicity[InputType, OutputType, TraceType: Trace](  # pyright: ignore[repo
     ... )
     """
 
-    output: str | None = Field(
-        default=None,
-        description="The text to evaluate for toxicity. If None, extracted from the trace using output_key.",
+    output: str | MISSING = Field(
+        default=MISSING,
+        description="The text to evaluate for toxicity. If omitted, extracted from the trace using output_key.",
     )
     output_key: JSONPathStr = Field(
         default="trace.last.outputs",
@@ -122,7 +122,7 @@ class Toxicity[InputType, OutputType, TraceType: Trace](  # pyright: ignore[repo
                 provided_or_resolve(
                     trace,
                     key=self.output_key,
-                    value=provide_not_none(self.output),
+                    value=self.output,
                 )
             ),
             "categories": self.categories,

--- a/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
@@ -9,12 +9,11 @@ import time
 from typing import Any, cast
 
 from giskard.core import (
-    NOT_PROVIDED,
-    NotProvided,
     scoped_telemetry,
     telemetry_capture,
     telemetry_tag,
 )
+from pydantic.experimental.missing_sentinel import MISSING
 
 from .._telemetry_props import scenario_shape_properties
 from ..core import Trace
@@ -38,26 +37,24 @@ def _validate_multiple_runs(value: int | None) -> int | None:
 
 def _build_steps[InputType, OutputType, TraceType: Trace[Any, Any]](
     scenario: Scenario[InputType, OutputType, TraceType],
-    target: Target[InputType, OutputType, TraceType] | NotProvided,
+    target: Target[InputType, OutputType, TraceType] | MISSING,
 ) -> list[Step[InputType, OutputType, TraceType]]:
     """Build steps with target bound to Interact outputs where needed.
 
     If no target is provided, returns the scenario's steps as-is. Otherwise,
-    returns new Step objects with interacts that have NOT_PROVIDED outputs
+    returns new Step objects with interacts that have MISSING outputs
     replaced by the given target.
     """
-    target = target if not isinstance(target, NotProvided) else scenario.target
+    target = target if target is not MISSING else scenario.target
 
-    if isinstance(target, NotProvided):
+    if target is MISSING:
         return scenario.steps
 
     steps = []
     for step in scenario.steps:
         interacts = []
         for interact in step.interacts:
-            if isinstance(interact, Interact) and isinstance(
-                interact.outputs, NotProvided
-            ):
+            if isinstance(interact, Interact) and interact.outputs is MISSING:
                 interact = interact.model_copy().set_outputs(target)
             interacts.append(interact)
 
@@ -68,13 +65,11 @@ def _build_steps[InputType, OutputType, TraceType: Trace[Any, Any]](
 
 def _resolve_trace_type[InputType, OutputType, TraceType: Trace[Any, Any]](
     scenario: Scenario[InputType, OutputType, TraceType],
-    run_target: Target[InputType, OutputType, TraceType] | NotProvided,
+    run_target: Target[InputType, OutputType, TraceType] | MISSING,
 ) -> type[TraceType]:
     if scenario.trace_type is not None:
         return scenario.trace_type
-    effective_target = (
-        run_target if not isinstance(run_target, NotProvided) else scenario.target
-    )
+    effective_target = run_target if run_target is not MISSING else scenario.target
     inferred = _infer_trace_type(effective_target)
     return cast(type[TraceType], inferred if inferred is not None else Trace)
 
@@ -114,7 +109,7 @@ class ScenarioRunner:
     async def _run_once[InputType, OutputType, TraceType: Trace[Any, Any]](
         self,
         scenario: Scenario[InputType, OutputType, TraceType],
-        target: Target[InputType, OutputType, TraceType] | NotProvided = NOT_PROVIDED,
+        target: Target[InputType, OutputType, TraceType] | MISSING = MISSING,
         return_exception: bool = False,
     ) -> ScenarioResult[TraceType]:
         start_time = time.perf_counter()
@@ -126,7 +121,7 @@ class ScenarioRunner:
 
         steps = _build_steps(scenario, target)
         steps_results: list[TestCaseResult] = []
-        has_target = target is not NOT_PROVIDED
+        has_target = target is not MISSING
         shape_props = scenario_shape_properties(
             scenario,
             has_target=has_target,
@@ -189,7 +184,7 @@ class ScenarioRunner:
     async def run[InputType, OutputType, TraceType: Trace[Any, Any]](
         self,
         scenario: Scenario[InputType, OutputType, TraceType],
-        target: Target[InputType, OutputType, TraceType] | NotProvided = NOT_PROVIDED,
+        target: Target[InputType, OutputType, TraceType] | MISSING = MISSING,
         return_exception: bool = False,
         multiple_runs: int | None = None,
     ) -> ScenarioResult[TraceType]:
@@ -204,8 +199,8 @@ class ScenarioRunner:
         ----------
         scenario : Scenario
             The scenario to execute.
-        target : Target | NotProvided
-            Optional target override used to replace `NOT_PROVIDED` interaction outputs.
+        target : Target | MISSING, optional
+            Optional target override used to replace ``MISSING`` interaction outputs.
         return_exception : bool
             If True, return results even when exceptions occur instead of raising.
         multiple_runs : int | None

--- a/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
@@ -5,8 +5,8 @@ from contextlib import contextmanager, nullcontext
 from typing import Any, Generic, Self, TypeVar
 
 from giskard.core import telemetry_capture, telemetry_run_context, telemetry_tag
-from giskard.core.utils import NOT_PROVIDED, NotProvided
 from pydantic import BaseModel, Field
+from pydantic.experimental.missing_sentinel import MISSING
 from rich.console import RenderableType
 from rich.progress import (
     BarColumn,
@@ -111,7 +111,7 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
         Suite identifier.
     scenarios : list[Scenario]
         List of scenarios to execute.
-    target : Any | NotProvided
+    target : Target | MISSING
         Optional suite-level target SUT.
 
     Examples
@@ -134,8 +134,8 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
     scenarios: list[Scenario[InputType, OutputType, Trace[Any, Any]]] = Field(
         default_factory=list, description="Scenarios in the suite"
     )
-    target: Target[InputType, OutputType, Trace[Any, Any]] | NotProvided = Field(
-        default=NOT_PROVIDED,
+    target: Target[InputType, OutputType, Trace[Any, Any]] | MISSING = Field(
+        default=MISSING,
         description="Suite-level target SUT that will override any scenario-level target.",
     )
 
@@ -160,9 +160,7 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
 
     async def run(
         self,
-        target: Target[InputType, OutputType, Trace[Any, Any]] | NotProvided = (
-            NOT_PROVIDED
-        ),
+        target: Target[InputType, OutputType, Trace[Any, Any]] | MISSING = (MISSING),
         return_exception: bool = False,
         parallel: bool = False,
         max_concurrency: int | None = None,
@@ -172,7 +170,7 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
 
         Parameters
         ----------
-        target : Any | NotProvided
+        target : Target | MISSING, optional
             Override target for all scenarios in the suite. If provided, this
             overrides both the suite-level target and any scenario-level targets.
         return_exception : bool
@@ -203,8 +201,8 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
         result_v2 = await suite.run(target=my_sut_v2)
         ```
         """
-        target = target if not isinstance(target, NotProvided) else self.target
-        has_target = not isinstance(target, NotProvided)
+        target = target if target is not MISSING else self.target
+        has_target = target is not MISSING
 
         if max_concurrency is not None:
             if not isinstance(max_concurrency, int) or isinstance(

--- a/libs/giskard-checks/tests/builtin/test_comparison.py
+++ b/libs/giskard-checks/tests/builtin/test_comparison.py
@@ -928,3 +928,12 @@ class TestComparisonSentinelDefault:
             expected_value_key="trace.last.metadata.expected",
         )
         assert check.expected_value_key == "trace.last.metadata.expected"
+
+    def test_cannot_provide_both_expected_value_and_expected_value_key(self):
+        """Providing both expected_value and expected_value_key must raise ValueError."""
+        with pytest.raises(ValueError, match="Exactly one"):
+            Equals(
+                key="trace.last.outputs",
+                expected_value=42,
+                expected_value_key="trace.last.metadata.expected",
+            )

--- a/libs/giskard-checks/tests/core/test_jsonpath_enforcement.py
+++ b/libs/giskard-checks/tests/core/test_jsonpath_enforcement.py
@@ -28,7 +28,7 @@ def _annotation_has_marker(annotation) -> bool:
     This handles complex type annotations like:
     - Annotated[str, AfterValidator(...), _JSONPathStrMarker()]
     - JSONPathStr | None
-    - JSONPathStr | NotProvided
+    - JSONPathStr | MISSING
     """
     if get_origin(annotation) is Annotated:
         return any(isinstance(m, _JSONPathStrMarker) for m in get_args(annotation)[1:])
@@ -43,7 +43,7 @@ def _has_jsonpath_marker(field_info) -> bool:
 
     Pydantic v2 stores Annotated metadata in two places depending on the type:
     - Simple `JSONPathStr`: marker is in field_info.metadata
-    - Union `JSONPathStr | None` / `JSONPathStr | NotProvided`: marker is
+    - Union `JSONPathStr | None` / `JSONPathStr | MISSING`: marker is
       inside field_info.annotation (the Annotated[str, ...] is preserved within
       the Union at the annotation level)
     """
@@ -74,6 +74,6 @@ def test_all_jsonpath_fields_use_jsonpath_str():
     assert not violations, (
         "The following JSONPath fields do not use JSONPathStr.\n"
         "All fields named 'key' or ending in '_key' must be annotated as JSONPathStr "
-        "(or JSONPathStr | None / JSONPathStr | NotProvided):\n"
+        "(or JSONPathStr | None / JSONPathStr | MISSING):\n"
         + "\n".join(f"  - {v}" for v in violations)
     )

--- a/libs/giskard-checks/tests/core/test_missing_serialization.py
+++ b/libs/giskard-checks/tests/core/test_missing_serialization.py
@@ -1,0 +1,89 @@
+"""Tests that MISSING fields omit from JSON and round-trip as MISSING."""
+
+import json
+
+import pytest
+from giskard.checks.builtin.comparison import Equals
+from giskard.checks.builtin.text_matching import RegexMatching, StringMatching
+from giskard.checks.core.interaction.interact import Interact
+from giskard.checks.core.scenario import Scenario
+from giskard.checks.judges.groundedness import Groundedness
+from giskard.checks.judges.toxicity import Toxicity
+from giskard.checks.scenarios.runner import _build_steps
+from giskard.checks.scenarios.suite import Suite
+from pydantic.experimental.missing_sentinel import MISSING
+
+
+def _assert_missing_json_roundtrip(model, field: str) -> None:
+    """Assert a MISSING field is absent from JSON and restored after round-trip."""
+    assert getattr(model, field) is MISSING
+
+    payload = json.loads(model.model_dump_json())
+    assert field not in payload, (
+        f"{field!r} must be omitted from JSON, got {payload.get(field)!r}"
+    )
+
+    restored = type(model).model_validate_json(model.model_dump_json())
+    assert getattr(restored, field) is MISSING
+
+
+@pytest.mark.parametrize(
+    ("model", "field"),
+    [
+        pytest.param(Interact(inputs="hi"), "outputs", id="interact-outputs"),
+        pytest.param(
+            Equals(
+                key="trace.last.outputs",
+                expected_value_key="trace.last.metadata.expected",
+            ),
+            "expected_value",
+            id="equals-expected-value",
+        ),
+        pytest.param(
+            StringMatching(text="hello", keyword_key="trace.last.inputs.keyword"),
+            "keyword",
+            id="string-matching-keyword",
+        ),
+        pytest.param(
+            RegexMatching(text="hello", pattern_key="trace.last.inputs.pattern"),
+            "pattern",
+            id="regex-matching-pattern",
+        ),
+        pytest.param(Scenario("scenario"), "target", id="scenario-target"),
+        pytest.param(Suite(name="suite"), "target", id="suite-target"),
+        pytest.param(Toxicity(), "output", id="toxicity-output"),
+        pytest.param(Groundedness(), "answer", id="groundedness-answer"),
+    ],
+)
+def test_missing_field_json_roundtrip(model, field):
+    _assert_missing_json_roundtrip(model, field)
+
+
+def test_scenario_nested_interact_outputs_missing_json_roundtrip():
+    scenario = Scenario("nested").interact("hello")
+    interact = scenario.steps[0].interacts[0]
+    assert isinstance(interact, Interact)
+    assert interact.outputs is MISSING
+
+    payload = json.loads(scenario.model_dump_json())
+    nested_outputs = payload["steps"][0]["interacts"][0]
+    assert "outputs" not in nested_outputs
+    assert nested_outputs.get("outputs") is None
+
+    restored = Scenario.model_validate_json(scenario.model_dump_json())
+    restored_interact = restored.steps[0].interacts[0]
+    assert isinstance(restored_interact, Interact)
+    assert restored_interact.outputs is MISSING
+
+
+def test_missing_outputs_still_binds_target_after_json_roundtrip():
+    async def target(inputs: str, trace) -> str:
+        return f"echo: {inputs}"
+
+    scenario = Scenario("bind-target").interact("hello")
+    restored = Scenario.model_validate_json(scenario.model_dump_json())
+
+    steps = _build_steps(restored, target)
+    interact = steps[0].interacts[0]
+    assert isinstance(interact, Interact)
+    assert interact.outputs is target

--- a/libs/giskard-checks/tests/core/test_trace_type_inference.py
+++ b/libs/giskard-checks/tests/core/test_trace_type_inference.py
@@ -3,7 +3,7 @@ from giskard.checks.core.interaction.trace import Trace
 from giskard.checks.core.scenario import Scenario
 from giskard.checks.scenarios.runner import _resolve_trace_type
 from giskard.checks.utils.inference import _infer_trace_type
-from giskard.core.utils import NOT_PROVIDED
+from pydantic.experimental.missing_sentinel import MISSING
 
 
 class MyTrace(Trace[str, str], frozen=True):
@@ -94,7 +94,7 @@ def test_resolve_trace_type_falls_back_to_scenario_target():
 
     scenario = Scenario("s", target=scenario_target)
 
-    assert _resolve_trace_type(scenario, NOT_PROVIDED) is MyTrace
+    assert _resolve_trace_type(scenario, MISSING) is MyTrace
 
 
 def test_resolve_trace_type_run_target_wins_over_scenario_target():
@@ -120,7 +120,7 @@ def test_resolve_trace_type_defaults_to_base_trace():
 
 def test_resolve_trace_type_defaults_to_base_trace_when_no_target():
     scenario = Scenario("s")
-    assert _resolve_trace_type(scenario, NOT_PROVIDED) is Trace
+    assert _resolve_trace_type(scenario, MISSING) is Trace
 
 
 # --- Runner integration tests ---

--- a/libs/giskard-core/src/giskard/core/__init__.py
+++ b/libs/giskard-core/src/giskard/core/__init__.py
@@ -23,10 +23,7 @@ from .telemetry import (
 )
 from .utils import (
     GISKARD_LIBS_VERSIONS,
-    NOT_PROVIDED,
-    NotProvided,
     get_lib_version,
-    provide_not_none,
 )
 
 LEGACY_GISKARD_PACKAGE_NAME = "giskard"
@@ -54,9 +51,6 @@ __all__ = [
     # Error handling
     "Error",
     # Utilities
-    "NotProvided",
-    "NOT_PROVIDED",
-    "provide_not_none",
     "GISKARD_LIBS_VERSIONS",
     # Limiter
     "MinIntervalRateLimiter",

--- a/libs/giskard-core/src/giskard/core/utils.py
+++ b/libs/giskard-core/src/giskard/core/utils.py
@@ -2,9 +2,6 @@
 
 from collections.abc import Iterable
 from importlib.metadata import PackageNotFoundError, version
-from typing import Literal
-
-from pydantic import BaseModel
 
 GISKARD_LIBS = frozenset(
     [
@@ -15,19 +12,6 @@ GISKARD_LIBS = frozenset(
         "giskard-llm",
     ]
 )
-
-
-class NotProvided(BaseModel):
-    """Sentinel class to indicate that a value was not provided."""
-
-    __type__: Literal["not_provided"] = "not_provided"
-
-
-NOT_PROVIDED = NotProvided()
-
-
-def provide_not_none[T](value: T | None) -> T | NotProvided:
-    return value if value is not None else NOT_PROVIDED
 
 
 def get_lib_version(lib: str, default: str = "unknown") -> str:


### PR DESCRIPTION
Use `pydantic.experimental.missing_sentinel.MISSING` for optional inline-or-path fields so omitted values serialize cleanly and explicit `None` stays meaningful for comparison checks.
