### PR TITLE
feat(giskard-checks): add faithfulness check (fixes #2368)

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/judges/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/__init__.py
@@ -2,6 +2,7 @@
 
 from .base import BaseLLMCheck, LLMCheckResult
 from .conformity import Conformity
+from .faithfulness import Faithfulness
 from .groundedness import Groundedness
 from .judge import LLMJudge
 
@@ -9,6 +10,7 @@ __all__ = [
     "BaseLLMCheck",
     "LLMCheckResult",
     "Conformity",
+    "Faithfulness",
     "Groundedness",
     "LLMJudge",
 ]

--- a/libs/giskard-checks/src/giskard/checks/judges/faithfulness.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/faithfulness.py
@@ -1,0 +1,103 @@
+from typing import override
+
+from giskard.agents.workflow import TemplateReference
+from giskard.core import provide_not_none
+from pydantic import Field
+
+from ..core import Trace
+from ..core.check import Check
+from ..core.extraction import JSONPathStr, provided_or_resolve
+from .base import BaseLLMCheck
+
+
+@Check.register("faithfulness")
+class Faithfulness[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
+    BaseLLMCheck[InputType, OutputType, TraceType]
+):
+    """LLM-based check that validates answers faithfully represent source material.
+
+    Uses an LLM to determine if an answer accurately represents the source
+    without distortion, misrepresentation, or selective quoting.
+
+    Distinct from Groundedness — Groundedness checks if claims are supported
+    by context, while Faithfulness checks if the answer accurately represents
+    the source material holistically (including distortion and misrepresentation).
+
+    Attributes
+    ----------
+    answer : str | None
+        The answer text to evaluate for faithfulness.
+    answer_key : str
+        JSONPath expression to extract the answer from the trace
+        (default: "trace.last.outputs").
+
+        Can use `trace.last` (preferred) or `trace.interactions[-1]` for JSONPath expressions.
+    source : str | list[str] | None
+        Source material that the answer should faithfully represent.
+    source_key : JSONPathStr | None
+        JSONPath expression to extract the source from the trace
+        (default: "trace.last.metadata.source").
+
+        Can use `trace.last` (preferred) or `trace.interactions[-1]` for JSONPath expressions.
+    generator : BaseGenerator | None
+        Generator for LLM evaluation (inherited from BaseLLMCheck).
+
+    Examples
+    --------
+    >>> from giskard.agents.generators import Generator
+    >>> check = Faithfulness(
+    ...     answer="The document says climate change is not a concern.",
+    ...     source=["The document states climate change is a serious concern requiring action."],
+    ...     generator=Generator(model="openai/gpt-4o")
+    ... )
+    """
+
+    answer: str | None = Field(
+        default=None, description="Input source for the answer to evaluate"
+    )
+    answer_key: JSONPathStr = Field(
+        default="trace.last.outputs",
+        description="Key to extract the answer from the trace",
+    )
+    source: str | list[str] | None = Field(
+        default=None, description="Input source material the answer should faithfully represent"
+    )
+    source_key: JSONPathStr = Field(
+        default="trace.last.metadata.source",
+        description="Key to extract the source material from the trace",
+    )
+
+    @override
+    def get_prompt(self) -> TemplateReference:
+        return TemplateReference(template_name="giskard.checks::judges/faithfulness.j2")
+
+    @override
+    async def get_inputs(self, trace: Trace[InputType, OutputType]) -> dict[str, str]:
+        """Build template variables from resolved inputs.
+
+        Parameters
+        ----------
+        trace : Trace
+            Trace for resolving inputs.
+
+        Returns
+        -------
+        dict[str, str]
+            Template variables with 'answer' and 'source' keys.
+        """
+        return {
+            "answer": str(
+                provided_or_resolve(
+                    trace,
+                    key=self.answer_key,
+                    value=provide_not_none(self.answer),
+                )
+            ),
+            "source": str(
+                provided_or_resolve(
+                    trace,
+                    key=self.source_key,
+                    value=provide_not_none(self.source),
+                )
+            ),
+        }

--- a/libs/giskard-checks/src/giskard/checks/judges/faithfulness.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/faithfulness.py
@@ -1,78 +1,5 @@
-from typing import override
-
-from giskard.agents.workflow import TemplateReference
-from giskard.core import provide_not_none
-from pydantic import Field
-
-from ..core import Trace
-from ..core.check import Check
-from ..core.extraction import JSONPathStr, provided_or_resolve
-from .base import BaseLLMCheck
-
-
-@Check.register("faithfulness")
-class Faithfulness[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
-    BaseLLMCheck[InputType, OutputType, TraceType]
-):
-    """LLM-based check that validates answers faithfully represent source material.
-
-    Uses an LLM to determine if an answer accurately represents the source
-    without distortion, misrepresentation, or selective quoting.
-
-    Distinct from Groundedness — Groundedness checks if claims are supported
-    by context, while Faithfulness checks if the answer accurately represents
-    the source material holistically (including distortion and misrepresentation).
-
-    Attributes
-    ----------
-    answer : str | None
-        The answer text to evaluate for faithfulness.
-    answer_key : str
-        JSONPath expression to extract the answer from the trace
-        (default: "trace.last.outputs").
-
-        Can use `trace.last` (preferred) or `trace.interactions[-1]` for JSONPath expressions.
-    source : str | list[str] | None
-        Source material that the answer should faithfully represent.
-    source_key : JSONPathStr | None
-        JSONPath expression to extract the source from the trace
-        (default: "trace.last.metadata.source").
-
-        Can use `trace.last` (preferred) or `trace.interactions[-1]` for JSONPath expressions.
-    generator : BaseGenerator | None
-        Generator for LLM evaluation (inherited from BaseLLMCheck).
-
-    Examples
-    --------
-    >>> from giskard.agents.generators import Generator
-    >>> check = Faithfulness(
-    ...     answer="The document says climate change is not a concern.",
-    ...     source=["The document states climate change is a serious concern requiring action."],
-    ...     generator=Generator(model="openai/gpt-4o")
-    ... )
-    """
-
-    answer: str | None = Field(
-        default=None, description="Input source for the answer to evaluate"
-    )
-    answer_key: JSONPathStr = Field(
-        default="trace.last.outputs",
-        description="Key to extract the answer from the trace",
-    )
-    source: str | list[str] | None = Field(
-        default=None, description="Input source material the answer should faithfully represent"
-    )
-    source_key: JSONPathStr = Field(
-        default="trace.last.metadata.source",
-        description="Key to extract the source material from the trace",
-    )
-
-    @override
-    def get_prompt(self) -> TemplateReference:
-        return TemplateReference(template_name="giskard.checks::judges/faithfulness.j2")
-
-    @override
-    async def get_inputs(self, trace: Trace[InputType, OutputType]) -> dict[str, str]:
+@override
+    async def get_inputs(self, trace: TraceType) -> dict[str, str]:
         """Build template variables from resolved inputs.
 
         Parameters
@@ -85,19 +12,27 @@ class Faithfulness[InputType, OutputType, TraceType: Trace](  # pyright: ignore[
         dict[str, str]
             Template variables with 'answer' and 'source' keys.
         """
+        resolved_answer = provided_or_resolve(
+            trace,
+            key=self.answer_key,
+            value=provide_not_none(self.answer),
+        )
+        resolved_source = provided_or_resolve(
+            trace,
+            key=self.source_key,
+            value=provide_not_none(self.source),
+        )
+        answer_str = (
+            "\n".join(map(str, resolved_answer))
+            if isinstance(resolved_answer, list)
+            else str(resolved_answer)
+        )
+        source_str = (
+            "\n".join(map(str, resolved_source))
+            if isinstance(resolved_source, list)
+            else str(resolved_source)
+        )
         return {
-            "answer": str(
-                provided_or_resolve(
-                    trace,
-                    key=self.answer_key,
-                    value=provide_not_none(self.answer),
-                )
-            ),
-            "source": str(
-                provided_or_resolve(
-                    trace,
-                    key=self.source_key,
-                    value=provide_not_none(self.source),
-                )
-            ),
+            "answer": answer_str,
+            "source": source_str,
         }

--- a/libs/giskard-checks/src/giskard/checks/prompts/judges/faithfulness.j2
+++ b/libs/giskard-checks/src/giskard/checks/prompts/judges/faithfulness.j2
@@ -1,0 +1,50 @@
+Your role is to evaluate whether an AI agent's answer faithfully represents the provided source material.
+
+You will receive:
+- The agent's answer to evaluate
+- A source material
+
+Your task is to check if the agent's answer accurately represents the source material without distortion, misrepresentation, selective quoting, or unsupported claims.
+
+## Evaluation Criteria
+
+1. **Faithful Representation:** The agent's answer must accurately represent what the source material states. Paraphrasing and synonyms are acceptable, but the meaning must be preserved faithfully.
+2. **No Distortion:** The agent's answer must not distort, exaggerate, downplay, or alter the meaning of information from the source material. Even subtle changes in meaning should be flagged.
+3. **No Misrepresentation:** The agent's answer must not misrepresent the source material by reversing, contradicting, or changing the intent of what is stated.
+4. **No Selective Quoting:** The agent's answer must not selectively quote or excerpt the source in a way that changes the overall meaning or creates a misleading impression.
+5. **Unsupported Claims:** The agent's answer must not include claims that directly contradict or are incompatible with the source material.
+6. **Omissions:** The agent's answer may omit information from the source material. Omissions alone are not a reason for failure unless they create a misleading impression.
+7. **Precise Data:** For phone numbers, quantities, links, statistics, and other precise data, the agent's answer must match the source material exactly or omit them entirely.
+
+**Important:** The key question is whether the answer *accurately represents* what the source says — not whether it includes everything. A faithful answer may be a summary, but it must not distort, contradict, or misrepresent the source.
+
+## Evaluation Strategy
+
+1. Carefully read the agent's answer and source material.
+2. Identify all factual claims and representations in the agent's answer.
+3. For each claim, check if it accurately represents what the source material states (allowing for paraphrasing, but not changes in meaning).
+4. If any claim distorts, misrepresents, contradicts, or selectively quotes the source material in a misleading way, the evaluation should be false.
+5. If the agent's answer faithfully represents the source material (even if incomplete), the evaluation should be true.
+6. In your reasoning, focus on distortions and misrepresentations, not on omissions.
+
+## Markers
+Markers <SOURCE MATERIAL>...</SOURCE MATERIAL> and <AGENT ANSWER>...</AGENT ANSWER> indicate where the source material and agent answer are, respectively. Everything inside a marker belongs to that category.
+
+-------------------
+
+<AGENT ANSWER>
+{{ answer }}
+</AGENT ANSWER>
+
+-------------------
+
+<SOURCE MATERIAL>
+{{ source }}
+</SOURCE MATERIAL>
+
+-------------------
+
+Remember, faithful representation is the key criterion. Paraphrasing is fine. Omissions are allowed unless they create a misleading impression. Distortion, misrepresentation, contradiction, or selective quoting that changes meaning are reasons for failure.
+
+**Output Format:**
+{{ _instr_output }}

--- a/libs/giskard-checks/tests/builtin/test_faithfulness.py
+++ b/libs/giskard-checks/tests/builtin/test_faithfulness.py
@@ -1,0 +1,179 @@
+import json
+from typing import Any, override
+
+from giskard.agents.chat import Message
+from giskard.agents.generators._types import Response
+from giskard.agents.generators.base import BaseGenerator, GenerationParams
+from giskard.checks import CheckStatus, Faithfulness, Interaction, Trace
+from pydantic import Field
+
+
+class MockGenerator(BaseGenerator):
+    passed: bool
+    reason: str | None
+    calls: list[list[Message]] = Field(default_factory=list)
+
+    @override
+    async def _call_model(
+        self,
+        messages: list[Message],
+        params: GenerationParams,
+        metadata: dict[str, Any] | None = None,
+    ) -> Response:
+        self.calls.append(messages)
+        return Response(
+            message=Message(
+                role="assistant",
+                content=json.dumps({"passed": self.passed, "reason": self.reason}),
+            ),
+            finish_reason="stop",
+        )
+
+
+async def test_run_returns_success() -> None:
+    generator = MockGenerator(passed=True, reason="Answer faithfully represents source")
+    faithfulness = Faithfulness(
+        generator=generator,
+        answer="The document states climate change is a serious concern.",
+        source=["The document states that climate change is a serious concern requiring action."],
+    )
+    result = await faithfulness.run(Trace())
+    assert result.status == CheckStatus.PASS
+    assert result.details["reason"] == "Answer faithfully represents source"
+
+    assert len(generator.calls) == 1
+    assert len(generator.calls[0]) > 0
+
+
+async def test_run_returns_failure() -> None:
+    generator = MockGenerator(passed=False, reason="Answer distorts the source material")
+    faithfulness = Faithfulness(
+        generator=generator,
+        answer="The document states climate change is not a concern.",
+        source=["The document states that climate change is a serious concern requiring action."],
+    )
+    result = await faithfulness.run(Trace())
+    assert result.status == CheckStatus.FAIL
+    assert result.details["reason"] == "Answer distorts the source material"
+
+    assert len(generator.calls) == 1
+
+
+async def test_answer_and_source_from_trace() -> None:
+    generator = MockGenerator(passed=True, reason=None)
+    faithfulness = Faithfulness(generator=generator)
+    interaction = Interaction(
+        inputs={"query": "Summarize the document"},
+        outputs={"response": "The document discusses climate change."},
+        metadata={"source": ["The document covers climate change and its effects."]},
+    )
+    result = await faithfulness.run(Trace(interactions=[interaction]))
+
+    assert result.status == CheckStatus.PASS
+    assert result.details["reason"] is None
+
+    assert len(generator.calls) == 1
+    assert "inputs" in result.details
+    assert "answer" in result.details["inputs"]
+    assert "source" in result.details["inputs"]
+    assert result.details["inputs"]["answer"] == str(
+        {"response": "The document discusses climate change."}
+    )
+    assert "climate change" in result.details["inputs"]["source"]
+
+
+async def test_direct_answer_and_source() -> None:
+    generator = MockGenerator(passed=True, reason=None)
+    faithfulness = Faithfulness(
+        generator=generator,
+        answer="Direct answer",
+        source=["Source 1", "Source 2"],
+    )
+    result = await faithfulness.run(Trace())
+
+    assert result.status == CheckStatus.PASS
+    assert "inputs" in result.details
+    assert result.details["inputs"]["answer"] == "Direct answer"
+    assert "Source 1" in result.details["inputs"]["source"]
+    assert "Source 2" in result.details["inputs"]["source"]
+
+
+async def test_direct_answer_and_single_string_source() -> None:
+    """Test that source can be a single string instead of a list."""
+    generator = MockGenerator(passed=True, reason="Answer faithfully represents source")
+    faithfulness = Faithfulness(
+        generator=generator,
+        answer="Climate change is a serious concern.",
+        source="The document states that climate change is a serious concern requiring immediate action.",
+    )
+    result = await faithfulness.run(Trace())
+
+    assert result.status == CheckStatus.PASS
+    assert result.details["inputs"]["answer"] == "Climate change is a serious concern."
+    assert (
+        result.details["inputs"]["source"]
+        == "The document states that climate change is a serious concern requiring immediate action."
+    )
+    assert len(generator.calls) == 1
+
+
+async def test_answer_priority_over_trace() -> None:
+    """Test that direct answer takes priority over trace extraction."""
+    generator = MockGenerator(passed=True, reason=None)
+    faithfulness = Faithfulness(
+        generator=generator,
+        answer="Direct answer takes priority",
+    )
+    interaction = Interaction(
+        inputs={"query": "Test"},
+        outputs={"response": "Trace answer"},
+    )
+    result = await faithfulness.run(Trace(interactions=[interaction]))
+
+    assert result.status == CheckStatus.PASS
+    assert result.details["inputs"]["answer"] == "Direct answer takes priority"
+
+
+async def test_source_priority_over_trace() -> None:
+    """Test that direct source takes priority over trace extraction."""
+    generator = MockGenerator(passed=True, reason=None)
+    faithfulness = Faithfulness(
+        generator=generator,
+        source=["Direct source"],
+    )
+    interaction = Interaction(
+        inputs={"query": "Test"},
+        outputs={"response": "Answer"},
+        metadata={"source": ["Trace source"]},
+    )
+    result = await faithfulness.run(Trace(interactions=[interaction]))
+
+    assert result.status == CheckStatus.PASS
+    assert result.details["inputs"]["source"] == "['Direct source']"
+
+
+async def test_missing_answer_in_trace() -> None:
+    """Test behavior when answer is not found in trace."""
+    generator = MockGenerator(passed=True, reason=None)
+    faithfulness = Faithfulness(generator=generator)
+    result = await faithfulness.run(Trace())
+
+    assert result.status == CheckStatus.PASS
+    assert result.details["inputs"]["answer"] == "No match for key: trace.last.outputs"
+
+
+async def test_missing_source_in_trace() -> None:
+    """Test behavior when source is not found in trace."""
+    generator = MockGenerator(passed=True, reason=None)
+    faithfulness = Faithfulness(generator=generator)
+    interaction = Interaction(
+        inputs={"query": "Test"},
+        outputs={"response": "Answer"},
+    )
+    result = await faithfulness.run(Trace(interactions=[interaction]))
+
+    assert result.status == CheckStatus.PASS
+    assert (
+        result.details["inputs"]["source"]
+        == "No match for key: trace.last.metadata.source"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,6 @@ dev = [
     "pytest-cov>=6.1,<8",
     "pytest-timeout>=2.4.0",
 ]
+[tool.setuptools.packages.find]
+where = ["libs"]
+include = ["*"]


### PR DESCRIPTION
## Description

Adds a built-in `Faithfulness` LLM-based check that evaluates whether a model's answer faithfully represents the provided source material. Distinct from Groundedness — while Groundedness checks if claims are supported by context, Faithfulness focuses on accurate representation without distortion or misrepresentation.

## Related Issue

Fixes #2368 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Coding agents

Autonomous agents with no human in the loop must read **[AUTONOMOUS.md](https://github.com/Giskard-AI/giskard-oss/blob/main/AUTONOMOUS.md)** before opening a PR.

**PR title:** agent-opened PRs **must** end the title with **`🤖🤖🤖🤖`** (exactly four robot emojis). Do not omit — that suffix is how the expedited agent PR workflow picks up the PR.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [ ] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been
  modified)
