### PR TITLE
feat(scan): Add automatic recommendation from failure categories

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/core/result.py
+++ b/libs/giskard-checks/src/giskard/checks/core/result.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field
 from rich.console import Console, ConsoleOptions, RenderResult
+from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.rule import Rule
 from rich.table import Table
@@ -549,6 +550,8 @@ class SuiteResult(BaseResult, frozen=True):
     suite : Suite | None
         The Suite that produced this result. Excluded from serialization
         (``None`` after a serialize/deserialize round-trip).
+    recommendation : str | None
+        Optional Markdown-friendly guidance attached by scan or suite producers.
     passed_count : int
         Number of scenarios that passed.
     failed_count : int
@@ -567,6 +570,10 @@ class SuiteResult(BaseResult, frozen=True):
     duration_ms: int = Field(..., description="Total execution time in milliseconds")
     suite: "Suite[Any, Any] | None" = Field(
         default=None, exclude=True, description="The Suite that produced this result"
+    )
+    recommendation: str | None = Field(
+        default=None,
+        description="Optional Markdown-friendly recommendation for this suite result",
     )
 
     @computed_field
@@ -682,64 +689,80 @@ class SuiteResult(BaseResult, frozen=True):
     def __rich_console__(
         self, console: Console, options: ConsoleOptions
     ) -> RenderResult:
-        yield Rule("Suite Results", style="bold blue")
-
-        # Dots view
-        yield "".join(
-            f"[{STATUS_MAPPING[r.status]['color']}]{STATUS_MAPPING[r.status]['symbol']}[/{STATUS_MAPPING[r.status]['color']}]"
-            for r in self.results
+        yield from _suite_rich_console(
+            self, console, options, include_recommendation=True
         )
-        yield ""
 
-        failures_and_errors = self.failures_and_errors
 
-        if failures_and_errors:
-            max_reported_failures = _max_reported_failures_from_env()
-            reported_failures = failures_and_errors[:max_reported_failures]
-            n_hidden = len(failures_and_errors) - len(reported_failures)
+def _suite_rich_console(
+    result: SuiteResult,
+    console: Console,
+    options: ConsoleOptions,
+    *,
+    include_recommendation: bool,
+) -> RenderResult:
+    yield Rule("Suite Results", style="bold blue")
 
-            # Details
-            yield Rule("FAILURES", characters="=", style="grey")
-            for f in reported_failures:
-                yield Panel(
-                    f,
-                    title=f.scenario_name,
-                    border_style=f"{STATUS_MAPPING[f.status]['color']} bold",
-                )
-            if n_hidden > 0:
-                yield f"  ... and {n_hidden} more"
+    # Dots view
+    yield "".join(
+        f"[{STATUS_MAPPING[r.status]['color']}]{STATUS_MAPPING[r.status]['symbol']}[/{STATUS_MAPPING[r.status]['color']}]"
+        for r in result.results
+    )
+    yield ""
 
-            # Summary
-            yield Rule("SUMMARY", characters="=", style="grey")
-            for f in reported_failures:
-                status = STATUS_MAPPING[f.status]
-                yield f"[{status['color']} bold]{f.scenario_name}[/{status['color']} bold]\t[{status['color']}]{f.status.value.upper()}[/{status['color']}]"
-                for tc in f.failures_and_errors:
-                    for c in tc.failures_and_errors:
-                        yield from (
-                            f"\t{line}" for line in c.__rich_console__(console, options)
-                        )
-            if n_hidden > 0:
-                yield f"  ... and {n_hidden} more"
+    failures_and_errors = result.failures_and_errors
 
-        yield Rule(style="bold blue")
+    if failures_and_errors:
+        max_reported_failures = _max_reported_failures_from_env()
+        reported_failures = failures_and_errors[:max_reported_failures]
+        n_hidden = len(failures_and_errors) - len(reported_failures)
 
-        # Summary metrics
-        count_parts = [
-            f"[{STATUS_MAPPING['total']['color']} bold]{len(self.results)} total[/{STATUS_MAPPING['total']['color']} bold]"
-        ]
-        count_parts.extend(
-            format_status_count_parts(
-                {
-                    "error": self.errored_count,
-                    "fail": self.failed_count,
-                    "skip": self.skipped_count,
-                    "pass": self.passed_count,
-                }
+        # Details
+        yield Rule("FAILURES", characters="=", style="grey")
+        for f in reported_failures:
+            yield Panel(
+                f,
+                title=f.scenario_name,
+                border_style=f"{STATUS_MAPPING[f.status]['color']} bold",
             )
+        if n_hidden > 0:
+            yield f"  ... and {n_hidden} more"
+
+        # Summary
+        yield Rule("SUMMARY", characters="=", style="grey")
+        for f in reported_failures:
+            status = STATUS_MAPPING[f.status]
+            yield f"[{status['color']} bold]{f.scenario_name}[/{status['color']} bold]\t[{status['color']}]{f.status.value.upper()}[/{status['color']}]"
+            for tc in f.failures_and_errors:
+                for c in tc.failures_and_errors:
+                    yield from (
+                        f"\t{line}" for line in c.__rich_console__(console, options)
+                    )
+        if n_hidden > 0:
+            yield f"  ... and {n_hidden} more"
+
+    yield Rule(style="bold blue")
+
+    # Summary metrics
+    count_parts = [
+        f"[{STATUS_MAPPING['total']['color']} bold]{len(result.results)} total[/{STATUS_MAPPING['total']['color']} bold]"
+    ]
+    count_parts.extend(
+        format_status_count_parts(
+            {
+                "error": result.errored_count,
+                "fail": result.failed_count,
+                "skip": result.skipped_count,
+                "pass": result.passed_count,
+            }
         )
-        summary = ", ".join(count_parts)
-        yield f"Summary: {summary} | Pass Rate: [default bold]{self.pass_rate:.1%}[/default bold] | Total Duration: {self.duration_ms}ms"
+    )
+    summary = ", ".join(count_parts)
+    yield f"Summary: {summary} | Pass Rate: [default bold]{result.pass_rate:.1%}[/default bold] | Total Duration: {result.duration_ms}ms"
+
+    recommendation = result.recommendation
+    if include_recommendation and recommendation and recommendation.strip():
+        yield _recommendation_panel(recommendation)
 
 
 def _parse_tag(tag: str) -> tuple[str, str]:
@@ -798,7 +821,9 @@ class GroupedSuiteResult(BaseResult, frozen=True):
     def __rich_console__(
         self, console: Console, options: ConsoleOptions
     ) -> RenderResult:
-        yield from self.suite_result.__rich_console__(console, options)
+        yield from _suite_rich_console(
+            self.suite_result, console, options, include_recommendation=False
+        )
 
         table = Table(title=f"Results by {self.key}")
         table.add_column(self.key, style="bold")
@@ -819,3 +844,14 @@ class GroupedSuiteResult(BaseResult, frozen=True):
             table.add_row(display_name, rate)
 
         yield table
+        recommendation = self.suite_result.recommendation
+        if recommendation and recommendation.strip():
+            yield _recommendation_panel(recommendation)
+
+
+def _recommendation_panel(recommendation: str) -> Panel:
+    return Panel(
+        Markdown(recommendation),
+        title="Recommendation",
+        border_style="blue",
+    )

--- a/libs/giskard-checks/src/giskard/checks/core/result.py
+++ b/libs/giskard-checks/src/giskard/checks/core/result.py
@@ -689,17 +689,14 @@ class SuiteResult(BaseResult, frozen=True):
     def __rich_console__(
         self, console: Console, options: ConsoleOptions
     ) -> RenderResult:
-        yield from _suite_rich_console(
-            self, console, options, include_recommendation=True
-        )
+        yield from _suite_report_renderables(self, console, options)
+        yield from _recommendation_renderables(self.recommendation)
 
 
-def _suite_rich_console(
+def _suite_report_renderables(
     result: SuiteResult,
     console: Console,
     options: ConsoleOptions,
-    *,
-    include_recommendation: bool,
 ) -> RenderResult:
     yield Rule("Suite Results", style="bold blue")
 
@@ -760,10 +757,6 @@ def _suite_rich_console(
     summary = ", ".join(count_parts)
     yield f"Summary: {summary} | Pass Rate: [default bold]{result.pass_rate:.1%}[/default bold] | Total Duration: {result.duration_ms}ms"
 
-    recommendation = result.recommendation
-    if include_recommendation and recommendation and recommendation.strip():
-        yield _recommendation_panel(recommendation)
-
 
 def _parse_tag(tag: str) -> tuple[str, str]:
     key, _, value = tag.partition(":")
@@ -821,9 +814,7 @@ class GroupedSuiteResult(BaseResult, frozen=True):
     def __rich_console__(
         self, console: Console, options: ConsoleOptions
     ) -> RenderResult:
-        yield from _suite_rich_console(
-            self.suite_result, console, options, include_recommendation=False
-        )
+        yield from _suite_report_renderables(self.suite_result, console, options)
 
         table = Table(title=f"Results by {self.key}")
         table.add_column(self.key, style="bold")
@@ -844,9 +835,12 @@ class GroupedSuiteResult(BaseResult, frozen=True):
             table.add_row(display_name, rate)
 
         yield table
-        recommendation = self.suite_result.recommendation
-        if recommendation and recommendation.strip():
-            yield _recommendation_panel(recommendation)
+        yield from _recommendation_renderables(self.suite_result.recommendation)
+
+
+def _recommendation_renderables(recommendation: str | None) -> RenderResult:
+    if recommendation and recommendation.strip():
+        yield _recommendation_panel(recommendation)
 
 
 def _recommendation_panel(recommendation: str) -> Panel:

--- a/libs/giskard-checks/tests/builtin/test_contradiction.py
+++ b/libs/giskard-checks/tests/builtin/test_contradiction.py
@@ -77,6 +77,22 @@ async def test_single_string_context_is_passed_to_judge() -> None:
     assert result.details["inputs"]["context"] == "The Eiffel Tower is in Paris."
 
 
+async def test_prompt_tolerates_refusals_without_conflicting_factual_claims() -> None:
+    generator = MockGenerator(passed=True, reason="Refusal is not a contradiction")
+    contradiction = Contradiction(
+        generator=generator,
+        answer="I can't help with harmful requests.",
+        context=["ZephyrBank accounts are available to eligible applicants."],
+    )
+
+    result = await contradiction.run(Trace())
+
+    assert result.status == CheckStatus.PASS
+    prompt = generator.calls[0][0].transcript
+    assert "incorrectly frames the request as harmful" in prompt
+    assert "does not also make a factual claim that conflicts" in prompt
+
+
 async def test_answer_and_context_from_trace() -> None:
     generator = MockGenerator(passed=True, reason=None)
     contradiction = Contradiction(generator=generator)

--- a/libs/giskard-checks/tests/builtin/test_contradiction.py
+++ b/libs/giskard-checks/tests/builtin/test_contradiction.py
@@ -93,6 +93,22 @@ async def test_prompt_tolerates_refusals_without_conflicting_factual_claims() ->
     assert "does not also make a factual claim that conflicts" in prompt
 
 
+async def test_prompt_tolerates_refusals_without_conflicting_factual_claims() -> None:
+    generator = MockGenerator(passed=True, reason="Refusal is not a contradiction")
+    contradiction = Contradiction(
+        generator=generator,
+        answer="I can't help with harmful requests.",
+        context=["ZephyrBank accounts are available to eligible applicants."],
+    )
+
+    result = await contradiction.run(Trace())
+
+    assert result.status == CheckStatus.PASS
+    prompt = generator.calls[0][0].transcript
+    assert "incorrectly frames the request as harmful" in prompt
+    assert "does not also make a factual claim that conflicts" in prompt
+
+
 async def test_answer_and_context_from_trace() -> None:
     generator = MockGenerator(passed=True, reason=None)
     contradiction = Contradiction(generator=generator)

--- a/libs/giskard-checks/tests/builtin/test_contradiction.py
+++ b/libs/giskard-checks/tests/builtin/test_contradiction.py
@@ -93,22 +93,6 @@ async def test_prompt_tolerates_refusals_without_conflicting_factual_claims() ->
     assert "does not also make a factual claim that conflicts" in prompt
 
 
-async def test_prompt_tolerates_refusals_without_conflicting_factual_claims() -> None:
-    generator = MockGenerator(passed=True, reason="Refusal is not a contradiction")
-    contradiction = Contradiction(
-        generator=generator,
-        answer="I can't help with harmful requests.",
-        context=["ZephyrBank accounts are available to eligible applicants."],
-    )
-
-    result = await contradiction.run(Trace())
-
-    assert result.status == CheckStatus.PASS
-    prompt = generator.calls[0][0].transcript
-    assert "incorrectly frames the request as harmful" in prompt
-    assert "does not also make a factual claim that conflicts" in prompt
-
-
 async def test_answer_and_context_from_trace() -> None:
     generator = MockGenerator(passed=True, reason=None)
     contradiction = Contradiction(generator=generator)

--- a/libs/giskard-checks/tests/core/test_result_recommendation.py
+++ b/libs/giskard-checks/tests/core/test_result_recommendation.py
@@ -1,0 +1,34 @@
+from giskard.checks.core.result import SuiteResult
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+
+def test_suite_result_renders_recommendation_after_group_table():
+    result = SuiteResult(
+        results=[],
+        duration_ms=0,
+        recommendation="- Improve LLM answers for conciseness failures.",
+    )
+    console = Console(width=100)
+
+    suite_renderables = list(result.__rich_console__(console, console.options))
+    grouped_renderables = list(
+        result.group_by("component").__rich_console__(console, console.options)
+    )
+
+    assert any(
+        isinstance(renderable, Panel) and renderable.title == "Recommendation"
+        for renderable in suite_renderables
+    )
+    group_table_index = next(
+        index
+        for index, renderable in enumerate(grouped_renderables)
+        if isinstance(renderable, Table) and renderable.title == "Results by component"
+    )
+    recommendation_index = next(
+        index
+        for index, renderable in enumerate(grouped_renderables)
+        if isinstance(renderable, Panel) and renderable.title == "Recommendation"
+    )
+    assert group_table_index < recommendation_index

--- a/libs/giskard-scan/src/giskard/scan/__init__.py
+++ b/libs/giskard-scan/src/giskard/scan/__init__.py
@@ -24,7 +24,6 @@ from .quality import quality_scan, quality_suite_generator_registry
 from .registry import SuiteGeneratorRegistry
 from .types import ScanOptions
 from .utils.knowledge_base import Document, KnowledgeBase
-from .utils.recommendation import QualityScanResult
 from .vulnerability import vulnerability_scan, vulnerability_suite_generator_registry
 
 add_prompts_path(str(Path(__file__).parent / "prompts"), "giskard.scan")
@@ -50,7 +49,6 @@ __all__ = [
     "KnowledgeBase",
     "ScanOptions",
     "SuiteGeneratorRegistry",
-    "QualityScanResult",
     "quality_suite_generator_registry",
     "quality_scan",
     "vulnerability_suite_generator_registry",

--- a/libs/giskard-scan/src/giskard/scan/__init__.py
+++ b/libs/giskard-scan/src/giskard/scan/__init__.py
@@ -24,6 +24,7 @@ from .quality import quality_scan, quality_suite_generator_registry
 from .registry import SuiteGeneratorRegistry
 from .types import ScanOptions
 from .utils.knowledge_base import Document, KnowledgeBase
+from .utils.recommendation import QualityScanResult
 from .vulnerability import vulnerability_scan, vulnerability_suite_generator_registry
 
 add_prompts_path(str(Path(__file__).parent / "prompts"), "giskard.scan")
@@ -49,6 +50,7 @@ __all__ = [
     "KnowledgeBase",
     "ScanOptions",
     "SuiteGeneratorRegistry",
+    "QualityScanResult",
     "quality_suite_generator_registry",
     "quality_scan",
     "vulnerability_suite_generator_registry",

--- a/libs/giskard-scan/src/giskard/scan/generators/knowledge_base/out_of_scope.py
+++ b/libs/giskard-scan/src/giskard/scan/generators/knowledge_base/out_of_scope.py
@@ -107,7 +107,9 @@ class OutOfScopeScenarioGenerator(KnowledgeBaseScenarioGenerator, WithGeneratorM
                 language,
                 self._document_contents(context_documents),
             )
-            if not candidate.topic.strip() or self._has_direct_text_match(candidate.topic, knowledge_base_documents):
+            if not candidate.topic.strip() or self._has_direct_text_match(
+                candidate.topic, knowledge_base_documents
+            ):
                 continue
 
             validation_documents = await knowledge_base.closest_documents_to_text(

--- a/libs/giskard-scan/src/giskard/scan/generators/knowledge_base/out_of_scope.py
+++ b/libs/giskard-scan/src/giskard/scan/generators/knowledge_base/out_of_scope.py
@@ -107,7 +107,7 @@ class OutOfScopeScenarioGenerator(KnowledgeBaseScenarioGenerator, WithGeneratorM
                 language,
                 self._document_contents(context_documents),
             )
-            if self._has_direct_text_match(candidate.topic, knowledge_base_documents):
+            if not candidate.topic.strip() or self._has_direct_text_match(candidate.topic, knowledge_base_documents):
                 continue
 
             validation_documents = await knowledge_base.closest_documents_to_text(

--- a/libs/giskard-scan/src/giskard/scan/prompts/generate_suite/quality_recommendation.j2
+++ b/libs/giskard-scan/src/giskard/scan/prompts/generate_suite/quality_recommendation.j2
@@ -21,11 +21,7 @@ Write one concise recommendation for the development team to improve the quality
 When writing the recommendation, explicitly connect the failed quality categories to the component they evaluate. For example, if `split-questions` fails under `history`, recommend improving conversation-state handling; if `fabricated-hallucination` fails under `retrieval` and `llm`, recommend better out-of-scope detection and grounded refusal behavior. Do not refer at the question categories directly, i.e. do not say split-questions passed, say instead the agent handled well the split question scenarios or pattern.
 
 Make sure the recommendation is actionable and not just a generic advice.
-
-Return JSON in exactly this format:
-{
-    "recommendation": "Markdown text with 1-3 short bullets."
-}
+Return only Markdown text with 1-3 short bullets.
 
 ### RESULTS BY COMPONENT
 {% for result in component_results %}

--- a/libs/giskard-scan/src/giskard/scan/prompts/generate_suite/quality_recommendation.j2
+++ b/libs/giskard-scan/src/giskard/scan/prompts/generate_suite/quality_recommendation.j2
@@ -1,0 +1,40 @@
+{% message user %}
+You are helping improve an AI agent after a quality scan.
+
+The scan results are grouped in two ways:
+- Components identify which part of the agent stack is likely affected.
+- Quality categories identify which type of question or behavior failed.
+
+### Component guide
+- `llm`: the answer generation layer. Failures usually indicate that the model is not staying faithful to the available context, is overconfident, or is fabricating facts.
+- `retrieval`: the context selection layer. Failures usually indicate that the agent is not retrieving the right documents, is missing relevant context, or is not recognizing that a topic is outside the knowledge base.
+- `history`: the conversation memory layer. Failures usually indicate that the agent is losing, mixing, or misusing information across turns.
+
+### Quality category guide
+- `direct-hallucination`: direct factual questions grounded in the knowledge base. These mostly stress the `llm` component because the answer should stay faithful to the retrieved/reference context.
+- `sycophancy-hallucinations`: leading or user-biased questions that encourage agreement with a false claim. These mostly stress the `llm` component because the answer should correct the user instead of agreeing, retrieval should not be perturbed by user bias.
+- `split-questions`: multi-turn questions where the user splits one request across several turns. These mostly stress the `history` component because the agent must combine prior turns correctly.
+- `multi-topic-questions`: questions that ask about several knowledge-base topics in one conversation. These stress both `retrieval` and `history` because the agent must retrieve the right context for each topic while preserving the conversation state.
+- `fabricated-hallucination`: questions about topics absent from the knowledge base. These stress both `retrieval` and `llm` because the system should detect missing support and avoid inventing an answer.
+
+Write one concise recommendation for the development team to improve the quality of the agent. Focus on the worst failing components and quality categories. Be specific about what to improve, but do not invent implementation details that are not supported by the scan summary.
+When writing the recommendation, explicitly connect the failed quality categories to the component they evaluate. For example, if `split-questions` fails under `history`, recommend improving conversation-state handling; if `fabricated-hallucination` fails under `retrieval` and `llm`, recommend better out-of-scope detection and grounded refusal behavior. Do not refer at the question categories directly, i.e. do not say split-questions passed, say instead the agent handled well the split question scenarios or pattern.
+
+Make sure the recommendation is actionable and not just a generic advice.
+
+Return JSON in exactly this format:
+{
+    "recommendation": "Markdown text with 1-3 short bullets."
+}
+
+### RESULTS BY COMPONENT
+{% for result in component_results %}
+- {{ result.name }}: {{ result.passed }}/{{ result.non_skipped }} passed{% if result.failed %}, {{ result.failed }} failed{% endif %}{% if result.errored %}, {{ result.errored }} errored{% endif %}{% if result.skipped %}, {{ result.skipped }} skipped{% endif %}
+{% endfor %}
+
+### RESULTS BY QUALITY CATEGORY
+{% for result in quality_results %}
+- {{ result.name }}: {{ result.passed }}/{{ result.non_skipped }} passed{% if result.failed %}, {{ result.failed }} failed{% endif %}{% if result.errored %}, {{ result.errored }} errored{% endif %}{% if result.skipped %}, {{ result.skipped }} skipped{% endif %}
+{% endfor %}
+
+{% endmessage %}

--- a/libs/giskard-scan/src/giskard/scan/quality.py
+++ b/libs/giskard-scan/src/giskard/scan/quality.py
@@ -16,6 +16,7 @@ from .generators.knowledge_base import (
 )
 from .registry import SuiteGeneratorRegistry
 from .utils.knowledge_base import KnowledgeBase, normalize_knowledge_base
+from .utils.recommendation import QualityScanResult, generate_quality_recommendation
 
 QUALITY_GENERATOR_TYPES: tuple[type[KnowledgeBaseScenarioGenerator], ...] = (
     HallucinationScenarioGenerator,
@@ -37,15 +38,16 @@ async def quality_scan[InputType, OutputType, TraceType: Trace](  # pyright: ign
     knowledge_base: KnowledgeBase | list[str] | None = None,
     max_scenarios: int | None = None,
     seed: int = 42,
-    group_by: str | None = "quality",
+    group_by: str | None = "component",
     parallel: bool = True,
     max_concurrency: int | None = None,
     target_mode: TargetMode = "multiturn",
-) -> SuiteResult:
+) -> QualityScanResult:
     """Generate and run the standard quality scan suite.
 
     Builds a suite from the quality scenario generator registry, runs it
-    against the target, prints the grouped report, and returns the suite result.
+    against the target, prints the grouped report with a recommendation, and
+    returns the suite result.
 
     Args:
         target: Agent or provider target to evaluate.
@@ -67,7 +69,7 @@ async def quality_scan[InputType, OutputType, TraceType: Trace](  # pyright: ign
             Defaults to ``"multiturn"``.
 
     Returns:
-        The completed suite result for the quality scan.
+        The completed suite result with a generated quality recommendation.
     """
     knowledge_base = normalize_knowledge_base(
         _warn_if_missing_knowledge_base(knowledge_base)
@@ -83,13 +85,20 @@ async def quality_scan[InputType, OutputType, TraceType: Trace](  # pyright: ign
         knowledge_base=knowledge_base,
     )
 
-    result = await suite.run(
+    result: SuiteResult = await suite.run(
         target,
         parallel=parallel,
         max_concurrency=max_concurrency,
     )
-    result.print_report(group_by=group_by)
-    return result
+    recommendation = await generate_quality_recommendation(result)
+    quality_result = QualityScanResult(
+        results=result.results,
+        duration_ms=result.duration_ms,
+        suite=result.suite,
+        recommendation=recommendation,
+    )
+    quality_result.print_report(group_by=group_by)
+    return quality_result
 
 
 def _warn_if_missing_knowledge_base(

--- a/libs/giskard-scan/src/giskard/scan/quality.py
+++ b/libs/giskard-scan/src/giskard/scan/quality.py
@@ -90,7 +90,11 @@ async def quality_scan[InputType, OutputType, TraceType: Trace](  # pyright: ign
         parallel=parallel,
         max_concurrency=max_concurrency,
     )
-    recommendation = await generate_quality_recommendation(result)
+    try:
+        recommendation = await generate_quality_recommendation(result)
+    except Exception:
+        logger.exception("Quality recommendation generation failed")
+        recommendation = "Quality recommendation generation failed"
     quality_result = QualityScanResult(
         results=result.results,
         duration_ms=result.duration_ms,

--- a/libs/giskard-scan/src/giskard/scan/quality.py
+++ b/libs/giskard-scan/src/giskard/scan/quality.py
@@ -97,7 +97,7 @@ async def quality_scan[InputType, OutputType, TraceType: Trace](  # pyright: ign
         recommendation = await generate_quality_recommendation(result)
     except Exception:
         logger.exception("Quality recommendation generation failed")
-        recommendation = "Quality recommendation generation failed"
+        recommendation = ""
     quality_result = result.model_copy(update={"recommendation": recommendation})
     quality_result.print_report(group_by=group_by)
     return quality_result

--- a/libs/giskard-scan/src/giskard/scan/quality.py
+++ b/libs/giskard-scan/src/giskard/scan/quality.py
@@ -1,5 +1,6 @@
 """Quality scan entry points for giskard.scan."""
 
+import logging
 import warnings
 
 from giskard.checks import SuiteResult, Target, Trace
@@ -16,7 +17,9 @@ from .generators.knowledge_base import (
 )
 from .registry import SuiteGeneratorRegistry
 from .utils.knowledge_base import KnowledgeBase, normalize_knowledge_base
-from .utils.recommendation import QualityScanResult, generate_quality_recommendation
+from .utils.recommendation import generate_quality_recommendation
+
+logger = logging.getLogger(__name__)
 
 QUALITY_GENERATOR_TYPES: tuple[type[KnowledgeBaseScenarioGenerator], ...] = (
     HallucinationScenarioGenerator,
@@ -42,7 +45,7 @@ async def quality_scan[InputType, OutputType, TraceType: Trace](  # pyright: ign
     parallel: bool = True,
     max_concurrency: int | None = None,
     target_mode: TargetMode = "multiturn",
-) -> QualityScanResult:
+) -> SuiteResult:
     """Generate and run the standard quality scan suite.
 
     Builds a suite from the quality scenario generator registry, runs it
@@ -95,12 +98,7 @@ async def quality_scan[InputType, OutputType, TraceType: Trace](  # pyright: ign
     except Exception:
         logger.exception("Quality recommendation generation failed")
         recommendation = "Quality recommendation generation failed"
-    quality_result = QualityScanResult(
-        results=result.results,
-        duration_ms=result.duration_ms,
-        suite=result.suite,
-        recommendation=recommendation,
-    )
+    quality_result = result.model_copy(update={"recommendation": recommendation})
     quality_result.print_report(group_by=group_by)
     return quality_result
 

--- a/libs/giskard-scan/src/giskard/scan/utils/recommendation.py
+++ b/libs/giskard-scan/src/giskard/scan/utils/recommendation.py
@@ -1,73 +1,9 @@
 """Recommendation helpers for scan results."""
 
-from typing import override
-
 from giskard.checks import SuiteResult
-from giskard.checks.core.result import GroupedSuiteResult, GroupStats
 from giskard.checks.settings import get_default_generator
-from pydantic import BaseModel, Field
-from rich.console import Console, ConsoleOptions, RenderResult
-from rich.markdown import Markdown
-from rich.panel import Panel
-from rich.table import Table
-
-
-class QualityRecommendationGeneration(BaseModel):
-    """Structured output returned by the quality recommendation prompt."""
-
-    recommendation: str = Field(
-        default="",
-        description="Concise recommendation text for improving quality scan failures.",
-    )
-
 
 type QualitySummaryRow = dict[str, str | int | float | None]
-
-
-class QualityScanResult(SuiteResult, frozen=True):
-    """Suite result enriched with a quality improvement recommendation.
-
-    Attributes:
-        recommendation: Markdown-friendly recommendation generated from the
-            quality scan's component and quality-category failure profile.
-    """
-
-    recommendation: str = Field(default="")
-
-    @override
-    def group_by(self, key: str) -> "QualityGroupedSuiteResult":
-        grouped = super().group_by(key)
-        return QualityGroupedSuiteResult(
-            suite_result=self,
-            key=grouped.key,
-            groups=grouped.groups,
-        )
-
-    @override
-    def __rich_console__(
-        self, console: Console, options: ConsoleOptions
-    ) -> RenderResult:
-        yield from SuiteResult.__rich_console__(self, console, options)
-        recommendation = self.recommendation
-        if recommendation.strip():
-            yield _recommendation_panel(recommendation)
-
-
-class QualityGroupedSuiteResult(GroupedSuiteResult, frozen=True):
-    """Grouped quality scan result that appends the recommendation last."""
-
-    suite_result: QualityScanResult
-    groups: dict[str | None, GroupStats]
-
-    @override
-    def __rich_console__(
-        self, console: Console, options: ConsoleOptions
-    ) -> RenderResult:
-        yield from SuiteResult.__rich_console__(self.suite_result, console, options)
-        yield _group_table(self.key, self.groups)
-        recommendation = self.suite_result.recommendation
-        if recommendation.strip():
-            yield _recommendation_panel(recommendation)
 
 
 async def generate_quality_recommendation(result: SuiteResult) -> str:
@@ -86,44 +22,13 @@ async def generate_quality_recommendation(result: SuiteResult) -> str:
     response = (
         await get_default_generator()
         .template("giskard.scan::generate_suite/quality_recommendation.j2")
-        .with_output(QualityRecommendationGeneration)
         .with_inputs(
             component_results=_group_summary(result, "component"),
             quality_results=_group_summary(result, "quality"),
         )
         .run()
     )
-    return response.output.recommendation.strip()
-
-
-def _recommendation_panel(recommendation: str) -> Panel:
-    return Panel(
-        Markdown(recommendation),
-        title="Quality Recommendation",
-        border_style="blue",
-    )
-
-
-def _group_table(key: str, groups: dict[str | None, GroupStats]) -> Table:
-    table = Table(title=f"Results by {key}")
-    table.add_column(key, style="bold")
-    table.add_column("Pass Rate", justify="right")
-
-    for group_value, stats in groups.items():
-        if group_value is None:
-            display_name = "(untagged)"
-        elif group_value == "":
-            display_name = "true"
-        else:
-            display_name = group_value
-        rate = (
-            f"{stats.passed} / {stats.non_skipped}"
-            if stats.pass_rate is not None
-            else "—"
-        )
-        table.add_row(display_name, rate)
-
-    return table
+    return (response.last.text or "").strip()
 
 
 def _group_summary(result: SuiteResult, key: str) -> list[QualitySummaryRow]:

--- a/libs/giskard-scan/src/giskard/scan/utils/recommendation.py
+++ b/libs/giskard-scan/src/giskard/scan/utils/recommendation.py
@@ -1,7 +1,6 @@
 """Recommendation helpers for scan results."""
 
-from giskard.checks import SuiteResult
-from giskard.checks.settings import get_default_generator
+from giskard.checks import SuiteResult, get_default_generator
 
 type QualitySummaryRow = dict[str, str | int | float | None]
 

--- a/libs/giskard-scan/src/giskard/scan/utils/recommendation.py
+++ b/libs/giskard-scan/src/giskard/scan/utils/recommendation.py
@@ -1,0 +1,150 @@
+"""Recommendation helpers for scan results."""
+
+from typing import override
+
+from giskard.checks import SuiteResult
+from giskard.checks.core.result import GroupedSuiteResult, GroupStats
+from giskard.checks.settings import get_default_generator
+from pydantic import BaseModel, Field
+from rich.console import Console, ConsoleOptions, RenderResult
+from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.table import Table
+
+
+class QualityRecommendationGeneration(BaseModel):
+    """Structured output returned by the quality recommendation prompt."""
+
+    recommendation: str = Field(
+        default="",
+        description="Concise recommendation text for improving quality scan failures.",
+    )
+
+
+type QualitySummaryRow = dict[str, str | int | float | None]
+
+
+class QualityScanResult(SuiteResult, frozen=True):
+    """Suite result enriched with a quality improvement recommendation.
+
+    Attributes:
+        recommendation: Markdown-friendly recommendation generated from the
+            quality scan's component and quality-category failure profile.
+    """
+
+    recommendation: str = Field(default="")
+
+    @override
+    def group_by(self, key: str) -> "QualityGroupedSuiteResult":
+        grouped = super().group_by(key)
+        return QualityGroupedSuiteResult(
+            suite_result=self,
+            key=grouped.key,
+            groups=grouped.groups,
+        )
+
+    @override
+    def __rich_console__(
+        self, console: Console, options: ConsoleOptions
+    ) -> RenderResult:
+        yield from SuiteResult.__rich_console__(self, console, options)
+        recommendation = self.recommendation
+        if recommendation.strip():
+            yield _recommendation_panel(recommendation)
+
+
+class QualityGroupedSuiteResult(GroupedSuiteResult, frozen=True):
+    """Grouped quality scan result that appends the recommendation last."""
+
+    suite_result: QualityScanResult
+    groups: dict[str | None, GroupStats]
+
+    @override
+    def __rich_console__(
+        self, console: Console, options: ConsoleOptions
+    ) -> RenderResult:
+        yield from SuiteResult.__rich_console__(self.suite_result, console, options)
+        yield _group_table(self.key, self.groups)
+        recommendation = self.suite_result.recommendation
+        if recommendation.strip():
+            yield _recommendation_panel(recommendation)
+
+
+async def generate_quality_recommendation(result: SuiteResult) -> str:
+    """Generate a recommendation for the failed quality scan scenarios.
+
+    Args:
+        result: Completed suite result from a quality scan.
+
+    Returns:
+        Recommendation text, or an empty string when the scan has no failures
+        or errors to explain.
+    """
+    if not result.failures_and_errors:
+        return ""
+
+    response = (
+        await get_default_generator()
+        .template("giskard.scan::generate_suite/quality_recommendation.j2")
+        .with_output(QualityRecommendationGeneration)
+        .with_inputs(
+            component_results=_group_summary(result, "component"),
+            quality_results=_group_summary(result, "quality"),
+        )
+        .run()
+    )
+    return response.output.recommendation.strip()
+
+
+def _recommendation_panel(recommendation: str) -> Panel:
+    return Panel(
+        Markdown(recommendation),
+        title="Quality Recommendation",
+        border_style="blue",
+    )
+
+
+def _group_table(key: str, groups: dict[str | None, GroupStats]) -> Table:
+    table = Table(title=f"Results by {key}")
+    table.add_column(key, style="bold")
+    table.add_column("Pass Rate", justify="right")
+
+    for group_value, stats in groups.items():
+        if group_value is None:
+            display_name = "(untagged)"
+        elif group_value == "":
+            display_name = "true"
+        else:
+            display_name = group_value
+        rate = (
+            f"{stats.passed} / {stats.non_skipped}"
+            if stats.pass_rate is not None
+            else "—"
+        )
+        table.add_row(display_name, rate)
+
+    return table
+
+
+def _group_summary(result: SuiteResult, key: str) -> list[QualitySummaryRow]:
+    return [
+        {
+            "name": _display_group_name(group_name),
+            "passed": stats.passed,
+            "failed": stats.failed,
+            "errored": stats.errored,
+            "skipped": stats.skipped,
+            "non_skipped": stats.non_skipped,
+            "total": stats.total,
+            "pass_rate": stats.pass_rate,
+        }
+        for group_name, stats in result.group_by(key).groups.items()
+    ]
+
+
+def _display_group_name(group_name: str | None) -> str:
+    if group_name is None:
+        return "(untagged)"
+    if group_name == "":
+        return "true"
+    return group_name

--- a/libs/giskard-scan/tests/test_quality.py
+++ b/libs/giskard-scan/tests/test_quality.py
@@ -1,4 +1,3 @@
-import json
 from collections.abc import Sequence
 from typing import Any, override
 
@@ -21,9 +20,7 @@ from giskard.scan.generators.knowledge_base import (
 )
 from giskard.scan.quality import quality_scan, quality_suite_generator_registry
 from giskard.scan.utils.knowledge_base import KnowledgeBase
-from giskard.scan.utils.recommendation import QualityScanResult
 from pydantic import Field
-from rich.console import Console
 
 
 class _DeterministicQualityGenerator(ScenarioGenerator):
@@ -48,7 +45,7 @@ class _DeterministicQualityGenerator(ScenarioGenerator):
 
 
 class _MockRecommendationGenerator(BaseGenerator):
-    responses: list[dict[str, Any]]
+    responses: list[str]
     index: int = 0
     calls: list[Sequence[ChatMessage]] = Field(default_factory=list)
 
@@ -61,7 +58,7 @@ class _MockRecommendationGenerator(BaseGenerator):
     ) -> CompletionResponse:
         _ = params, metadata
         self.calls.append(messages)
-        message = AssistantMessage(content=json.dumps(self.responses[self.index]))
+        message = AssistantMessage(content=self.responses[self.index])
         self.index += 1
         return CompletionResponse(
             choices=[Choice(message=message, finish_reason="stop", index=0)]
@@ -76,7 +73,7 @@ async def test_quality_scan_runs_registry_scenarios_and_returns_suite_result(
 ):
     quality_suite_generator_registry.register(_DeterministicQualityGenerator())
     recommendation_generator = _MockRecommendationGenerator(
-        responses=[{"recommendation": "- Improve retrieval grounding."}]
+        responses=["- Improve retrieval grounding."]
     )
     monkeypatch.setattr(settings, "_default_generator", recommendation_generator)
     printed_reports: list[tuple[SuiteResult, str | None]] = []
@@ -104,7 +101,7 @@ async def test_quality_scan_runs_registry_scenarios_and_returns_suite_result(
         group_by="quality",
     )
 
-    assert isinstance(result, QualityScanResult)
+    assert type(result) is SuiteResult
     assert result.recommendation == "- Improve retrieval grounding."
     assert result.passed_count == 1
     assert result.failed_count == 1
@@ -333,7 +330,7 @@ async def test_quality_scan_does_not_generate_recommendation_without_failures(
 ):
     quality_suite_generator_registry.register(_DeterministicQualityGenerator())
     recommendation_generator = _MockRecommendationGenerator(
-        responses=[{"recommendation": "This should not be used."}]
+        responses=["This should not be used."]
     )
     monkeypatch.setattr(settings, "_default_generator", recommendation_generator)
     monkeypatch.setattr(SuiteResult, "print_report", lambda self, **_: None)
@@ -351,20 +348,3 @@ async def test_quality_scan_does_not_generate_recommendation_without_failures(
 
     assert result.recommendation == ""
     assert recommendation_generator.calls == []
-
-
-def test_quality_scan_result_renders_recommendation_after_group_table():
-    result = QualityScanResult(
-        results=[],
-        duration_ms=0,
-        recommendation="- Improve LLM answers for conciseness failures.",
-    )
-    console = Console(record=True, width=100)
-
-    console.print(result.group_by("component"))
-
-    output = console.export_text()
-    assert "Results by component" in output
-    assert "Quality Recommendation" in output
-    assert output.index("Results by component") < output.index("Quality Recommendation")
-    assert "Improve LLM answers for conciseness failures." in output

--- a/libs/giskard-scan/tests/test_quality.py
+++ b/libs/giskard-scan/tests/test_quality.py
@@ -1,11 +1,16 @@
-from typing import Any
+import json
+from collections.abc import Sequence
+from typing import Any, override
 
+import giskard.checks.settings as settings
 import giskard.scan.quality as quality_module
 import numpy as np
 import pytest
+from giskard.agents.generators.base import BaseGenerator, GenerationParams
 from giskard.checks import Equals, Scenario, Trace
 from giskard.checks.core.result import SuiteResult
 from giskard.checks.scenarios.suite import Suite
+from giskard.llm.types import AssistantMessage, ChatMessage, Choice, CompletionResponse
 from giskard.scan.generators.base import ScenarioContext, ScenarioGenerator
 from giskard.scan.generators.knowledge_base import (
     HallucinationScenarioGenerator,
@@ -16,6 +21,9 @@ from giskard.scan.generators.knowledge_base import (
 )
 from giskard.scan.quality import quality_scan, quality_suite_generator_registry
 from giskard.scan.utils.knowledge_base import KnowledgeBase
+from giskard.scan.utils.recommendation import QualityScanResult
+from pydantic import Field
+from rich.console import Console
 
 
 class _DeterministicQualityGenerator(ScenarioGenerator):
@@ -30,13 +38,34 @@ class _DeterministicQualityGenerator(ScenarioGenerator):
             Scenario("passes")
             .interact("accurate")
             .check(Equals(expected_value="accurate", key="trace.last.outputs"))
-            .with_tags(["quality-dimension:accuracy"]),
+            .with_tags(["quality:accuracy", "component:retrieval"]),
             Scenario("fails")
             .interact("concise")
             .check(Equals(expected_value="verbose", key="trace.last.outputs"))
-            .with_tags(["quality-dimension:conciseness"]),
+            .with_tags(["quality:conciseness", "component:llm"]),
         ]
         return scenarios if max_scenarios is None else scenarios[:max_scenarios]
+
+
+class _MockRecommendationGenerator(BaseGenerator):
+    responses: list[dict[str, Any]]
+    index: int = 0
+    calls: list[Sequence[ChatMessage]] = Field(default_factory=list)
+
+    @override
+    async def _call_model(
+        self,
+        messages: Sequence[ChatMessage],
+        params: GenerationParams,
+        metadata: dict[str, Any] | None = None,
+    ) -> CompletionResponse:
+        _ = params, metadata
+        self.calls.append(messages)
+        message = AssistantMessage(content=json.dumps(self.responses[self.index]))
+        self.index += 1
+        return CompletionResponse(
+            choices=[Choice(message=message, finish_reason="stop", index=0)]
+        )
 
 
 pytestmark = pytest.mark.usefixtures("isolated_quality_registry")
@@ -46,6 +75,10 @@ async def test_quality_scan_runs_registry_scenarios_and_returns_suite_result(
     monkeypatch: pytest.MonkeyPatch,
 ):
     quality_suite_generator_registry.register(_DeterministicQualityGenerator())
+    recommendation_generator = _MockRecommendationGenerator(
+        responses=[{"recommendation": "- Improve retrieval grounding."}]
+    )
+    monkeypatch.setattr(settings, "_default_generator", recommendation_generator)
     printed_reports: list[tuple[SuiteResult, str | None]] = []
 
     def print_report_spy(
@@ -68,31 +101,42 @@ async def test_quality_scan_runs_registry_scenarios_and_returns_suite_result(
         knowledge_base=["reference document"],
         max_scenarios=2,
         seed=123,
-        group_by="quality-dimension",
+        group_by="quality",
     )
 
+    assert isinstance(result, QualityScanResult)
+    assert result.recommendation == "- Improve retrieval grounding."
     assert result.passed_count == 1
     assert result.failed_count == 1
     assert result.errored_count == 0
     assert result.skipped_count == 0
     assert result.pass_rate == 0.5
-    assert printed_reports == [(result, "quality-dimension")]
+    assert printed_reports == [(result, "quality")]
     assert {scenario.scenario_name for scenario in result.results} == {
         "passes",
         "fails",
     }
     assert {tuple(scenario.tags) for scenario in result.results} == {
-        ("quality-dimension:accuracy",),
-        ("quality-dimension:conciseness",),
+        ("quality:accuracy", "component:retrieval"),
+        ("quality:conciseness", "component:llm"),
     }
 
-    grouped = result.group_by("quality-dimension")
+    grouped = result.group_by("quality")
     assert grouped.groups["accuracy"].passed == 1
     assert grouped.groups["accuracy"].failed == 0
     assert grouped.groups["accuracy"].pass_rate == 1.0
     assert grouped.groups["conciseness"].passed == 0
     assert grouped.groups["conciseness"].failed == 1
     assert grouped.groups["conciseness"].pass_rate == 0.0
+    rendered_prompt = "\n".join(
+        str(message.content) for message in recommendation_generator.calls[0]
+    )
+    assert "RESULTS BY COMPONENT" in rendered_prompt
+    assert "llm: 0/1 passed, 1 failed" in rendered_prompt
+    assert "RESULTS BY QUALITY CATEGORY" in rendered_prompt
+    assert "conciseness: 0/1 passed, 1 failed" in rendered_prompt
+    assert "FAILING SCENARIOS" not in rendered_prompt
+    assert "Failure messages" not in rendered_prompt
 
 
 async def test_quality_scan_forwards_parallel_and_max_concurrency(
@@ -170,7 +214,8 @@ async def test_quality_scan_uses_empty_registry_by_default(
         )
 
     assert result.results == []
-    assert printed_reports == ["quality"]
+    assert result.recommendation == ""
+    assert printed_reports == ["component"]
 
 
 async def test_quality_scan_warns_and_skips_empty_raw_knowledge_base(
@@ -184,19 +229,15 @@ async def test_quality_scan_warns_and_skips_empty_raw_knowledge_base(
     captured_generators: list[ScenarioGenerator] = []
     captured_knowledge_bases: list[object] = []
 
-    class _FakeResult:
-        def print_report(self, group_by: str | None = None) -> None:
-            _ = group_by
-
     class _FakeSuite:
         async def run(
             self,
             target: object,
             parallel: bool = True,
             max_concurrency: int | None = None,
-        ) -> _FakeResult:
+        ) -> SuiteResult:
             _ = target, parallel, max_concurrency
-            return _FakeResult()
+            return SuiteResult(results=[], duration_ms=0)
 
     async def generate_suite_spy(**kwargs: Any) -> _FakeSuite:
         captured_generators.extend(kwargs["generators"])
@@ -239,19 +280,15 @@ async def test_quality_scan_configures_knowledge_base_generator(
     captured_knowledge_bases: list[object] = []
     printed_reports: list[str | None] = []
 
-    class _FakeResult:
-        def print_report(self, group_by: str | None = None) -> None:
-            printed_reports.append(group_by)
-
     class _FakeSuite:
         async def run(
             self,
             target: object,
             parallel: bool = True,
             max_concurrency: int | None = None,
-        ) -> _FakeResult:
+        ) -> SuiteResult:
             _ = target, parallel, max_concurrency
-            return _FakeResult()
+            return SuiteResult(results=[], duration_ms=0)
 
     async def generate_suite_spy(**kwargs: Any) -> _FakeSuite:
         captured_generators.extend(kwargs["generators"])
@@ -259,6 +296,11 @@ async def test_quality_scan_configures_knowledge_base_generator(
         return _FakeSuite()
 
     monkeypatch.setattr(quality_module, "generate_suite", generate_suite_spy)
+    monkeypatch.setattr(
+        SuiteResult,
+        "print_report",
+        lambda self, group_by=None: printed_reports.append(group_by),
+    )
 
     async def target(inputs: str) -> str:
         return inputs
@@ -270,7 +312,7 @@ async def test_quality_scan_configures_knowledge_base_generator(
         knowledge_base=["alpha"],
     )
 
-    assert printed_reports == ["quality"]
+    assert printed_reports == ["component"]
     assert len(captured_generators) == 5
     assert len(captured_knowledge_bases) == 1
     assert isinstance(captured_knowledge_bases[0], KnowledgeBase)
@@ -284,3 +326,45 @@ async def test_quality_scan_configures_knowledge_base_generator(
         MultiTopicScenarioGenerator,
         OutOfScopeScenarioGenerator,
     }
+
+
+async def test_quality_scan_does_not_generate_recommendation_without_failures(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    quality_suite_generator_registry.register(_DeterministicQualityGenerator())
+    recommendation_generator = _MockRecommendationGenerator(
+        responses=[{"recommendation": "This should not be used."}]
+    )
+    monkeypatch.setattr(settings, "_default_generator", recommendation_generator)
+    monkeypatch.setattr(SuiteResult, "print_report", lambda self, **_: None)
+
+    async def target(inputs: str) -> str:
+        return inputs
+
+    result = await quality_scan(
+        target=target,
+        description="Support agent",
+        languages=["en"],
+        knowledge_base=["reference document"],
+        max_scenarios=1,
+    )
+
+    assert result.recommendation == ""
+    assert recommendation_generator.calls == []
+
+
+def test_quality_scan_result_renders_recommendation_after_group_table():
+    result = QualityScanResult(
+        results=[],
+        duration_ms=0,
+        recommendation="- Improve LLM answers for conciseness failures.",
+    )
+    console = Console(record=True, width=100)
+
+    console.print(result.group_by("component"))
+
+    output = console.export_text()
+    assert "Results by component" in output
+    assert "Quality Recommendation" in output
+    assert output.index("Results by component") < output.index("Quality Recommendation")
+    assert "Improve LLM answers for conciseness failures." in output

--- a/libs/giskard-scan/tests/test_quality.py
+++ b/libs/giskard-scan/tests/test_quality.py
@@ -348,3 +348,31 @@ async def test_quality_scan_does_not_generate_recommendation_without_failures(
 
     assert result.recommendation == ""
     assert recommendation_generator.calls == []
+
+
+async def test_quality_scan_hides_recommendation_when_generation_fails(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    quality_suite_generator_registry.register(_DeterministicQualityGenerator())
+    monkeypatch.setattr(SuiteResult, "print_report", lambda self, **_: None)
+
+    async def fail_recommendation(_: SuiteResult) -> str:
+        raise RuntimeError("generator unavailable")
+
+    monkeypatch.setattr(
+        quality_module, "generate_quality_recommendation", fail_recommendation
+    )
+
+    async def target(inputs: str) -> str:
+        return inputs
+
+    result = await quality_scan(
+        target=target,
+        description="Support agent",
+        languages=["en"],
+        knowledge_base=["reference document"],
+        max_scenarios=2,
+    )
+
+    assert result.failed_count == 1
+    assert result.recommendation == ""


### PR DESCRIPTION
## Description

Adds QualityScanResult with an automatically generated recommendation, rendered with the quality scan report and based on component and quality-category aggregates.

<img width="1407" height="252" alt="Screenshot 2026-06-26 at 10 42 49" src="https://github.com/user-attachments/assets/1d7b761f-f6b6-446e-8690-6afd4a59923e" />


## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Coding agents

Autonomous agents with no human in the loop must read **[AUTONOMOUS.md](https://github.com/Giskard-AI/giskard-oss/blob/main/AUTONOMOUS.md)** before opening a PR.

**PR title:** agent-opened PRs **must** end the title with **`🤖🤖🤖🤖`** (exactly four robot emojis). Do not omit — that suffix is how the expedited agent PR workflow picks up the PR.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [ ] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been
  modified)
