### PR TITLE
feat(checks): add pydantic-settings for default model and config

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -183,6 +183,6 @@ jobs:
       - name: Run functional tests
         env:
           GOOGLE_API_KEY: ${{ matrix.provider == 'google' && secrets.GEMINI_API_KEY || '' }}
-          TEST_MODEL: "google/gemini-3.5-flash"
-          TEST_EMBEDDING_MODEL: "google/gemini-embedding-001"
+          GISKARD_CHECKS_DEFAULT_MODEL: "google/gemini-3.5-flash"
+          GISKARD_CHECKS_DEFAULT_EMBEDDING_MODEL: "google/gemini-embedding-001"
         run: make test-functional PACKAGE=giskard-checks PROVIDER=$PROVIDER

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -69,6 +69,7 @@ Find a list of packages below
 |✔|pycparser|
 |✔|pydantic|
 |✔|pydantic-core|
+|✔|pydantic-settings|
 |✔|pygments|
 |✔|python-dotenv|
 |✔|pyyaml|
@@ -472,6 +473,13 @@ Find a list of packages below
 ### pydantic-core-2.46.4
 
 - HomePage: https://github.com/pydantic/pydantic
+- Author: Samuel Colvin
+- License: MIT
+- Compatible: True
+
+### pydantic-settings-2.14.2
+
+- HomePage:
 - Author: Samuel Colvin
 - License: MIT
 - Compatible: True

--- a/libs/giskard-checks/README.md
+++ b/libs/giskard-checks/README.md
@@ -187,6 +187,13 @@ API Overview
 
 **Settings**
 - `giskard.checks.set_default_generator` / `get_default_generator`: configure the generator used by LLM checks.
+- Environment variables (or `.env` at the project root), prefixed with `GISKARD_CHECKS_`:
+  - `GISKARD_CHECKS_DEFAULT_MODEL` — default LLM model (default: `openai/gpt-4o-mini`).
+  - `GISKARD_CHECKS_DEFAULT_EMBEDDING_MODEL` — default embedding model (default: `text-embedding-3-small`).
+  - `GISKARD_CHECKS_MAX_REPORTED_FAILURES` — cap on failures shown in suite reports.
+  - `GISKARD_CHECKS_DISABLE_RICH_PRETTY` — disable rich REPL pretty-printing.
+
+Runtime `set_default_generator()` overrides take precedence over environment settings.
 
 Testing
 -------

--- a/libs/giskard-checks/pyproject.toml
+++ b/libs/giskard-checks/pyproject.toml
@@ -8,6 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     "jsonpath-ng>=1.7.0,<2",
     "pydantic>=2.12,<3",
+    "pydantic-settings>=2.7,<3",
     "giskard-agents>=1.0.2b2",
     "jinja2>=3.1.6,<4",
     "giskard-core>=1.0.1b3,<2",

--- a/libs/giskard-checks/src/giskard/checks/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/__init__.py
@@ -1,6 +1,5 @@
 """Public package exports for giskard.checks."""
 
-import os
 from pathlib import Path
 
 from giskard.agents import add_prompts_path
@@ -65,19 +64,14 @@ from .judges import (
 )
 from .scenarios.runner import ScenarioRunner
 from .scenarios.suite import Suite
-from .settings import get_default_generator, set_default_generator
+from .settings import get_default_generator, get_settings, set_default_generator
 from .testing import WithSpy
 from .testing.runner import TestCaseRunner
 
 __version__ = get_lib_version("giskard-checks")
 
-# Install rich.pretty for better REPL output (including Pydantic models)
-# Can be disabled by setting GISKARD_CHECKS_DISABLE_RICH_PRETTY=1
-if os.getenv("GISKARD_CHECKS_DISABLE_RICH_PRETTY", "").lower() not in (
-    "1",
-    "true",
-    "yes",
-):
+# Install rich.pretty for better REPL output unless disabled in settings.
+if not get_settings().disable_rich_pretty:
     from rich.pretty import install
 
     install()

--- a/libs/giskard-checks/src/giskard/checks/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/__init__.py
@@ -1,6 +1,5 @@
 """Public package exports for giskard.checks."""
 
-import os
 from pathlib import Path
 
 from giskard.agents import add_prompts_path
@@ -65,7 +64,7 @@ from .judges import (
 )
 from .scenarios.runner import ScenarioRunner
 from .scenarios.suite import Suite
-from .settings import get_default_generator, set_default_generator
+from .settings import get_default_generator, get_settings, set_default_generator
 from .testing import WithSpy
 from .testing.runner import TestCaseRunner
 
@@ -73,11 +72,7 @@ __version__ = get_lib_version("giskard-checks")
 
 # Install rich.pretty for better REPL output (including Pydantic models)
 # Can be disabled by setting GISKARD_CHECKS_DISABLE_RICH_PRETTY=1
-if os.getenv("GISKARD_CHECKS_DISABLE_RICH_PRETTY", "").lower() not in (
-    "1",
-    "true",
-    "yes",
-):
+if not get_settings().disable_rich_pretty:
     from rich.pretty import install
 
     install()

--- a/libs/giskard-checks/src/giskard/checks/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/__init__.py
@@ -1,5 +1,6 @@
 """Public package exports for giskard.checks."""
 
+import os
 from pathlib import Path
 
 from giskard.agents import add_prompts_path
@@ -64,7 +65,7 @@ from .judges import (
 )
 from .scenarios.runner import ScenarioRunner
 from .scenarios.suite import Suite
-from .settings import get_default_generator, get_settings, set_default_generator
+from .settings import get_default_generator, set_default_generator
 from .testing import WithSpy
 from .testing.runner import TestCaseRunner
 
@@ -72,7 +73,11 @@ __version__ = get_lib_version("giskard-checks")
 
 # Install rich.pretty for better REPL output (including Pydantic models)
 # Can be disabled by setting GISKARD_CHECKS_DISABLE_RICH_PRETTY=1
-if not get_settings().disable_rich_pretty:
+if os.getenv("GISKARD_CHECKS_DISABLE_RICH_PRETTY", "").lower() not in (
+    "1",
+    "true",
+    "yes",
+):
     from rich.pretty import install
 
     install()

--- a/libs/giskard-checks/src/giskard/checks/core/result.py
+++ b/libs/giskard-checks/src/giskard/checks/core/result.py
@@ -46,7 +46,6 @@ STATUS_MAPPING = {
     },
 }
 
-MAX_REPORTED_FAILURES_ENV_VAR = "GISKARD_CHECKS_MAX_REPORTED_FAILURES"
 STATUS_SUMMARY_ORDER: tuple[tuple[str, str], ...] = (
     ("error", "errored"),
     ("fail", "failed"),
@@ -81,11 +80,6 @@ def _pluralize(count: int, word: str, plural: str | None = None) -> str:
     if plural is None:
         plural = word + "s"
     return f"{count} {plural}"
-
-
-def _max_reported_failures_from_env() -> int | None:
-    """Return failure cap from settings, or ``None`` for unlimited reporting."""
-    return get_settings().max_reported_failures
 
 
 class CheckStatus(str, Enum):
@@ -698,7 +692,7 @@ def _suite_report_renderables(
     failures_and_errors = result.failures_and_errors
 
     if failures_and_errors:
-        max_reported_failures = _max_reported_failures_from_env()
+        max_reported_failures = get_settings().max_reported_failures
         reported_failures = failures_and_errors[:max_reported_failures]
         n_hidden = len(failures_and_errors) - len(reported_failures)
 

--- a/libs/giskard-checks/src/giskard/checks/core/result.py
+++ b/libs/giskard-checks/src/giskard/checks/core/result.py
@@ -1,4 +1,3 @@
-import os
 from collections import defaultdict
 from collections.abc import Mapping
 from enum import Enum
@@ -16,6 +15,7 @@ from rich.rule import Rule
 from rich.table import Table
 from rich.text import Text
 
+from ..settings import get_settings
 from .interaction import Trace
 from .protocols import RichConsoleProtocol, RichProtocol
 
@@ -84,20 +84,8 @@ def _pluralize(count: int, word: str, plural: str | None = None) -> str:
 
 
 def _max_reported_failures_from_env() -> int | None:
-    """Return failure cap from env, or ``None`` for unlimited reporting."""
-    raw_value = os.getenv(MAX_REPORTED_FAILURES_ENV_VAR)
-    if raw_value is None:
-        return None
-
-    try:
-        value = int(raw_value)
-    except ValueError:
-        return None
-
-    if value < 0:
-        return None
-
-    return value
+    """Return failure cap from settings, or ``None`` for unlimited reporting."""
+    return get_settings().max_reported_failures
 
 
 class CheckStatus(str, Enum):

--- a/libs/giskard-checks/src/giskard/checks/settings.py
+++ b/libs/giskard-checks/src/giskard/checks/settings.py
@@ -1,15 +1,15 @@
 """Runtime and environment configuration for giskard-checks."""
 
-from giskard.agents import BaseEmbeddingModel, BaseGenerator, EmbeddingModel, Generator
+from giskard.agents import BaseGenerator, EmbeddingModel, Generator
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-# Runtime overrides (take precedence over environment settings)
+# Runtime override (takes precedence over environment settings)
 _default_generator: BaseGenerator | None = None
-_default_embedding_model: BaseEmbeddingModel | None = None
 
 DEFAULT_MODEL = "openai/gpt-4o-mini"
 DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"
+MAX_REPORTED_FAILURES_ENV_VAR = "GISKARD_CHECKS_MAX_REPORTED_FAILURES"
 
 
 class GiskardChecksSettings(BaseSettings):
@@ -46,19 +46,15 @@ class GiskardChecksSettings(BaseSettings):
     @field_validator("max_reported_failures", mode="before")
     @classmethod
     def _normalize_max_reported_failures(cls, value: object) -> int | None:
-        if value is None or value == "":
+        if value is None or value == "" or isinstance(value, bool):
             return None
-        if isinstance(value, bool):
+        if not isinstance(value, (int, str)):
             return None
-        if isinstance(value, int):
-            return value if value >= 0 else None
-        if isinstance(value, str):
-            try:
-                parsed = int(value)
-            except ValueError:
-                return None
-            return parsed if parsed >= 0 else None
-        return None
+        try:
+            parsed = int(value)
+        except ValueError:
+            return None
+        return parsed if parsed >= 0 else None
 
 
 def get_settings() -> GiskardChecksSettings:
@@ -92,27 +88,13 @@ def get_default_generator() -> BaseGenerator:
     return Generator(model=get_settings().default_model)
 
 
-def set_default_embedding_model(embedding_model: BaseEmbeddingModel) -> None:
-    """Set the default embedding model for all checks.
-
-    Parameters
-    ----------
-    embedding_model : BaseEmbeddingModel
-        The embedding model to use as default for all embedding checks.
-    """
-    global _default_embedding_model
-    _default_embedding_model = embedding_model
-
-
-def get_default_embedding_model() -> BaseEmbeddingModel:
+def get_default_embedding_model() -> EmbeddingModel:
     """Get the current default embedding model.
 
     Returns
     -------
-    BaseEmbeddingModel
-        The runtime override if set, otherwise a model built from
-        :envvar:`GISKARD_CHECKS_DEFAULT_EMBEDDING_MODEL`, or text-embedding-3-small.
+    EmbeddingModel
+        A model built from :envvar:`GISKARD_CHECKS_DEFAULT_EMBEDDING_MODEL`,
+        or text-embedding-3-small by default.
     """
-    if _default_embedding_model is not None:
-        return _default_embedding_model
     return EmbeddingModel(model=get_settings().default_embedding_model)

--- a/libs/giskard-checks/src/giskard/checks/settings.py
+++ b/libs/giskard-checks/src/giskard/checks/settings.py
@@ -1,11 +1,81 @@
-from giskard.agents import BaseEmbeddingModel, BaseGenerator, EmbeddingModel, Generator
+"""Runtime and environment configuration for giskard-checks."""
 
-# Global default generator
+from functools import lru_cache
+
+from giskard.agents import BaseEmbeddingModel, BaseGenerator, EmbeddingModel, Generator
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Runtime overrides (take precedence over environment settings)
 _default_generator: BaseGenerator | None = None
 _default_embedding_model: BaseEmbeddingModel | None = None
 
+DEFAULT_MODEL = "openai/gpt-4o-mini"
+DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"
 
-def set_default_generator(generator: "BaseGenerator") -> None:
+
+class GiskardChecksSettings(BaseSettings):
+    """Environment-backed settings for giskard-checks.
+
+    Values can be set via environment variables prefixed with ``GISKARD_CHECKS_``
+    or in a ``.env`` file at the project root.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="GISKARD_CHECKS_",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+    default_model: str = Field(
+        default=DEFAULT_MODEL,
+        description="Default LLM model identifier for checks without an explicit generator.",
+    )
+    default_embedding_model: str = Field(
+        default=DEFAULT_EMBEDDING_MODEL,
+        description="Default embedding model identifier for checks without an explicit model.",
+    )
+    disable_rich_pretty: bool = Field(
+        default=False,
+        description="Disable rich.pretty installation for REPL output.",
+    )
+    max_reported_failures: int | None = Field(
+        default=None,
+        description="Maximum number of failures to include in suite reports. None means unlimited.",
+    )
+
+    @field_validator("max_reported_failures", mode="before")
+    @classmethod
+    def _normalize_max_reported_failures(cls, value: object) -> int | None:
+        if value is None or value == "":
+            return None
+        if isinstance(value, int):
+            parsed = value
+        elif isinstance(value, str):
+            try:
+                parsed = int(value)
+            except ValueError:
+                return None
+        else:
+            return None
+        if parsed < 0:
+            return None
+        return parsed
+
+
+@lru_cache
+def get_settings() -> GiskardChecksSettings:
+    """Return cached settings loaded from the environment."""
+    return GiskardChecksSettings()
+
+
+def clear_settings_cache() -> None:
+    """Clear the cached settings instance (for tests and env reloads)."""
+    get_settings.cache_clear()
+
+
+def set_default_generator(generator: BaseGenerator) -> None:
     """Set the default LLM generator for all checks.
 
     Parameters
@@ -23,13 +93,15 @@ def get_default_generator() -> BaseGenerator:
     Returns
     -------
     BaseGenerator
-        The current default generator, or a default GPT-4o-mini generator
-        if none has been set.
+        The runtime override if set, otherwise a generator built from
+        :envvar:`GISKARD_CHECKS_DEFAULT_MODEL`, or a default GPT-4o-mini generator.
     """
-    return _default_generator or Generator(model="openai/gpt-4o-mini")
+    if _default_generator is not None:
+        return _default_generator
+    return Generator(model=get_settings().default_model)
 
 
-def set_default_embedding_model(embedding_model: "BaseEmbeddingModel") -> None:
+def set_default_embedding_model(embedding_model: BaseEmbeddingModel) -> None:
     """Set the default embedding model for all checks.
 
     Parameters
@@ -47,7 +119,9 @@ def get_default_embedding_model() -> BaseEmbeddingModel:
     Returns
     -------
     BaseEmbeddingModel
-        The current default embedding model, or a default text-embedding-3-small model
-        if none has been set.
+        The runtime override if set, otherwise a model built from
+        :envvar:`GISKARD_CHECKS_DEFAULT_EMBEDDING_MODEL`, or text-embedding-3-small.
     """
-    return _default_embedding_model or EmbeddingModel(model="text-embedding-3-small")
+    if _default_embedding_model is not None:
+        return _default_embedding_model
+    return EmbeddingModel(model=get_settings().default_embedding_model)

--- a/libs/giskard-checks/src/giskard/checks/settings.py
+++ b/libs/giskard-checks/src/giskard/checks/settings.py
@@ -66,10 +66,6 @@ def get_settings() -> GiskardChecksSettings:
     return GiskardChecksSettings()
 
 
-def clear_settings_cache() -> None:
-    """No-op retained for test compatibility."""
-
-
 def set_default_generator(generator: BaseGenerator) -> None:
     """Set the default LLM generator for all checks.
 

--- a/libs/giskard-checks/src/giskard/checks/settings.py
+++ b/libs/giskard-checks/src/giskard/checks/settings.py
@@ -1,7 +1,5 @@
 """Runtime and environment configuration for giskard-checks."""
 
-from functools import lru_cache
-
 from giskard.agents import BaseEmbeddingModel, BaseGenerator, EmbeddingModel, Generator
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -50,29 +48,26 @@ class GiskardChecksSettings(BaseSettings):
     def _normalize_max_reported_failures(cls, value: object) -> int | None:
         if value is None or value == "":
             return None
+        if isinstance(value, bool):
+            return None
         if isinstance(value, int):
-            parsed = value
-        elif isinstance(value, str):
+            return value if value >= 0 else None
+        if isinstance(value, str):
             try:
                 parsed = int(value)
             except ValueError:
                 return None
-        else:
-            return None
-        if parsed < 0:
-            return None
-        return parsed
+            return parsed if parsed >= 0 else None
+        return None
 
 
-@lru_cache
 def get_settings() -> GiskardChecksSettings:
-    """Return cached settings loaded from the environment."""
+    """Return settings loaded from the environment."""
     return GiskardChecksSettings()
 
 
 def clear_settings_cache() -> None:
-    """Clear the cached settings instance (for tests and env reloads)."""
-    get_settings.cache_clear()
+    """No-op retained for test compatibility."""
 
 
 def set_default_generator(generator: BaseGenerator) -> None:

--- a/libs/giskard-checks/tests/conftest.py
+++ b/libs/giskard-checks/tests/conftest.py
@@ -1,5 +1,14 @@
+import giskard.checks.settings as settings_module
 import pytest
 from giskard.core import disable_telemetry
+
+
+@pytest.fixture(autouse=True)
+def reset_default_generator():
+    """Restore the global default generator after each test."""
+    original = settings_module._default_generator
+    yield
+    settings_module._default_generator = original
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/libs/giskard-checks/tests/core/test_mixin.py
+++ b/libs/giskard-checks/tests/core/test_mixin.py
@@ -1,19 +1,9 @@
 from unittest.mock import MagicMock
 
-import pytest
+import giskard.checks.settings as settings
 from giskard.agents.generators.base import BaseGenerator
 from giskard.checks.core.mixin import WithGeneratorMixin
 from giskard.checks.settings import set_default_generator
-
-
-@pytest.fixture(autouse=True)
-def reset_default_generator():
-    """Restore the global default generator after each test."""
-    import giskard.checks.settings as settings
-
-    original = settings._default_generator
-    yield
-    settings._default_generator = original
 
 
 class ConcreteCheck(WithGeneratorMixin):
@@ -43,7 +33,6 @@ def test_explicit_generator_is_not_overridden():
 
 def test_default_generator_is_returned_when_none_set():
     """When no global set and no explicit generator, must return a generator."""
-    import giskard.checks.settings as settings
 
     settings._default_generator = None
     check = ConcreteCheck()

--- a/libs/giskard-checks/tests/core/test_settings.py
+++ b/libs/giskard-checks/tests/core/test_settings.py
@@ -11,16 +11,6 @@ from giskard.checks.settings import (
 )
 
 
-@pytest.fixture(autouse=True)
-def reset_checks_settings():
-    """Restore runtime overrides after each test."""
-    original_generator = settings_module._default_generator
-    original_embedding = settings_module._default_embedding_model
-    yield
-    settings_module._default_generator = original_generator
-    settings_module._default_embedding_model = original_embedding
-
-
 def test_default_generator_uses_settings_model(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("GISKARD_CHECKS_DEFAULT_MODEL", "google/gemini-3.5-flash")
 
@@ -60,8 +50,6 @@ def test_default_embedding_model_uses_settings(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_default_embedding_model_falls_back_to_builtin_default():
-    settings_module._default_embedding_model = None
-
     embedding_model = get_default_embedding_model()
 
     assert isinstance(embedding_model, EmbeddingModel)

--- a/libs/giskard-checks/tests/core/test_settings.py
+++ b/libs/giskard-checks/tests/core/test_settings.py
@@ -1,0 +1,96 @@
+import giskard.checks.settings as settings_module
+import pytest
+from giskard.agents import EmbeddingModel, Generator
+from giskard.checks.settings import (
+    DEFAULT_EMBEDDING_MODEL,
+    DEFAULT_MODEL,
+    clear_settings_cache,
+    get_default_embedding_model,
+    get_default_generator,
+    get_settings,
+    set_default_generator,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_checks_settings():
+    """Restore runtime overrides and settings cache after each test."""
+    original_generator = settings_module._default_generator
+    original_embedding = settings_module._default_embedding_model
+    clear_settings_cache()
+    yield
+    settings_module._default_generator = original_generator
+    settings_module._default_embedding_model = original_embedding
+    clear_settings_cache()
+
+
+def test_default_generator_uses_settings_model(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("GISKARD_CHECKS_DEFAULT_MODEL", "google/gemini-3.5-flash")
+    clear_settings_cache()
+
+    generator = get_default_generator()
+
+    assert isinstance(generator, Generator)
+    assert generator.model == "google/gemini-3.5-flash"
+
+
+def test_default_generator_falls_back_to_builtin_default():
+    settings_module._default_generator = None
+    clear_settings_cache()
+
+    generator = get_default_generator()
+
+    assert isinstance(generator, Generator)
+    assert generator.model == DEFAULT_MODEL
+
+
+def test_set_default_generator_overrides_settings(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("GISKARD_CHECKS_DEFAULT_MODEL", "google/gemini-3.5-flash")
+    clear_settings_cache()
+    explicit = Generator(model="anthropic/claude-haiku-4-5-20251001")
+
+    set_default_generator(explicit)
+
+    assert get_default_generator() is explicit
+
+
+def test_default_embedding_model_uses_settings(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(
+        "GISKARD_CHECKS_DEFAULT_EMBEDDING_MODEL", "google/gemini-embedding-001"
+    )
+    clear_settings_cache()
+
+    embedding_model = get_default_embedding_model()
+
+    assert isinstance(embedding_model, EmbeddingModel)
+    assert embedding_model.model == "google/gemini-embedding-001"
+
+
+def test_default_embedding_model_falls_back_to_builtin_default():
+    settings_module._default_embedding_model = None
+    clear_settings_cache()
+
+    embedding_model = get_default_embedding_model()
+
+    assert isinstance(embedding_model, EmbeddingModel)
+    assert embedding_model.model == DEFAULT_EMBEDDING_MODEL
+
+
+def test_settings_max_reported_failures_validation(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("GISKARD_CHECKS_MAX_REPORTED_FAILURES", "3")
+    clear_settings_cache()
+    assert get_settings().max_reported_failures == 3
+
+    monkeypatch.setenv("GISKARD_CHECKS_MAX_REPORTED_FAILURES", "invalid")
+    clear_settings_cache()
+    assert get_settings().max_reported_failures is None
+
+    monkeypatch.setenv("GISKARD_CHECKS_MAX_REPORTED_FAILURES", "-1")
+    clear_settings_cache()
+    assert get_settings().max_reported_failures is None
+
+
+def test_settings_disable_rich_pretty(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("GISKARD_CHECKS_DISABLE_RICH_PRETTY", "true")
+    clear_settings_cache()
+    assert get_settings().disable_rich_pretty is True

--- a/libs/giskard-checks/tests/core/test_settings.py
+++ b/libs/giskard-checks/tests/core/test_settings.py
@@ -4,7 +4,6 @@ from giskard.agents import EmbeddingModel, Generator
 from giskard.checks.settings import (
     DEFAULT_EMBEDDING_MODEL,
     DEFAULT_MODEL,
-    clear_settings_cache,
     get_default_embedding_model,
     get_default_generator,
     get_settings,
@@ -14,19 +13,16 @@ from giskard.checks.settings import (
 
 @pytest.fixture(autouse=True)
 def reset_checks_settings():
-    """Restore runtime overrides and settings cache after each test."""
+    """Restore runtime overrides after each test."""
     original_generator = settings_module._default_generator
     original_embedding = settings_module._default_embedding_model
-    clear_settings_cache()
     yield
     settings_module._default_generator = original_generator
     settings_module._default_embedding_model = original_embedding
-    clear_settings_cache()
 
 
 def test_default_generator_uses_settings_model(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("GISKARD_CHECKS_DEFAULT_MODEL", "google/gemini-3.5-flash")
-    clear_settings_cache()
 
     generator = get_default_generator()
 
@@ -36,7 +32,6 @@ def test_default_generator_uses_settings_model(monkeypatch: pytest.MonkeyPatch):
 
 def test_default_generator_falls_back_to_builtin_default():
     settings_module._default_generator = None
-    clear_settings_cache()
 
     generator = get_default_generator()
 
@@ -46,7 +41,6 @@ def test_default_generator_falls_back_to_builtin_default():
 
 def test_set_default_generator_overrides_settings(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("GISKARD_CHECKS_DEFAULT_MODEL", "google/gemini-3.5-flash")
-    clear_settings_cache()
     explicit = Generator(model="anthropic/claude-haiku-4-5-20251001")
 
     set_default_generator(explicit)
@@ -58,7 +52,6 @@ def test_default_embedding_model_uses_settings(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv(
         "GISKARD_CHECKS_DEFAULT_EMBEDDING_MODEL", "google/gemini-embedding-001"
     )
-    clear_settings_cache()
 
     embedding_model = get_default_embedding_model()
 
@@ -68,7 +61,6 @@ def test_default_embedding_model_uses_settings(monkeypatch: pytest.MonkeyPatch):
 
 def test_default_embedding_model_falls_back_to_builtin_default():
     settings_module._default_embedding_model = None
-    clear_settings_cache()
 
     embedding_model = get_default_embedding_model()
 
@@ -78,23 +70,18 @@ def test_default_embedding_model_falls_back_to_builtin_default():
 
 def test_settings_max_reported_failures_validation(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("GISKARD_CHECKS_MAX_REPORTED_FAILURES", "3")
-    clear_settings_cache()
     assert get_settings().max_reported_failures == 3
 
     monkeypatch.setenv("GISKARD_CHECKS_MAX_REPORTED_FAILURES", "invalid")
-    clear_settings_cache()
     assert get_settings().max_reported_failures is None
 
     monkeypatch.setenv("GISKARD_CHECKS_MAX_REPORTED_FAILURES", "-1")
-    clear_settings_cache()
     assert get_settings().max_reported_failures is None
 
     monkeypatch.setenv("GISKARD_CHECKS_MAX_REPORTED_FAILURES", "true")
-    clear_settings_cache()
     assert get_settings().max_reported_failures is None
 
 
 def test_settings_disable_rich_pretty(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("GISKARD_CHECKS_DISABLE_RICH_PRETTY", "true")
-    clear_settings_cache()
     assert get_settings().disable_rich_pretty is True

--- a/libs/giskard-checks/tests/core/test_settings.py
+++ b/libs/giskard-checks/tests/core/test_settings.py
@@ -89,6 +89,10 @@ def test_settings_max_reported_failures_validation(monkeypatch: pytest.MonkeyPat
     clear_settings_cache()
     assert get_settings().max_reported_failures is None
 
+    monkeypatch.setenv("GISKARD_CHECKS_MAX_REPORTED_FAILURES", "true")
+    clear_settings_cache()
+    assert get_settings().max_reported_failures is None
+
 
 def test_settings_disable_rich_pretty(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("GISKARD_CHECKS_DISABLE_RICH_PRETTY", "true")

--- a/libs/giskard-checks/tests/core/test_suite.py
+++ b/libs/giskard-checks/tests/core/test_suite.py
@@ -7,7 +7,6 @@ import pytest
 from giskard.checks import Equals, Scenario, Suite
 from giskard.checks.core.interaction import Trace
 from giskard.checks.core.result import (
-    MAX_REPORTED_FAILURES_ENV_VAR,
     CheckResult,
     GroupedSuiteResult,
     GroupStats,
@@ -19,6 +18,7 @@ from giskard.checks.core.result import (
     TestCaseResult as CheckTestCaseResult,
 )
 from giskard.checks.scenarios.suite import _OverallOnly, _SuiteProgress
+from giskard.checks.settings import MAX_REPORTED_FAILURES_ENV_VAR
 from rich.console import Console
 from rich.progress import MofNCompleteColumn, Progress
 from rich.text import Text

--- a/libs/giskard-checks/tests/core/test_suite.py
+++ b/libs/giskard-checks/tests/core/test_suite.py
@@ -19,6 +19,7 @@ from giskard.checks.core.result import (
     TestCaseResult as CheckTestCaseResult,
 )
 from giskard.checks.scenarios.suite import _OverallOnly, _SuiteProgress
+from giskard.checks.settings import clear_settings_cache
 from rich.console import Console
 from rich.progress import MofNCompleteColumn, Progress
 from rich.text import Text
@@ -222,6 +223,7 @@ def test_suite_result_rich_console_respects_max_reported_failures_env(
     monkeypatch: pytest.MonkeyPatch,
 ):
     monkeypatch.setenv(MAX_REPORTED_FAILURES_ENV_VAR, "2")
+    clear_settings_cache()
     result = SuiteResult(
         results=[failed_scenario("s1"), failed_scenario("s2"), failed_scenario("s3")],
         duration_ms=3,
@@ -241,6 +243,7 @@ def test_suite_result_rich_console_reports_all_failures_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ):
     monkeypatch.delenv(MAX_REPORTED_FAILURES_ENV_VAR, raising=False)
+    clear_settings_cache()
     result = SuiteResult(
         results=[failed_scenario(f"s{i}") for i in range(1, 22)],
         duration_ms=3,
@@ -260,6 +263,7 @@ def test_suite_result_rich_console_can_hide_all_failure_details(
     monkeypatch: pytest.MonkeyPatch,
 ):
     monkeypatch.setenv(MAX_REPORTED_FAILURES_ENV_VAR, "0")
+    clear_settings_cache()
     result = SuiteResult(
         results=[failed_scenario("s1"), failed_scenario("s2"), failed_scenario("s3")],
         duration_ms=3,
@@ -279,6 +283,7 @@ def test_suite_result_rich_console_ignores_invalid_failure_limit_env(
     monkeypatch: pytest.MonkeyPatch,
 ):
     monkeypatch.setenv(MAX_REPORTED_FAILURES_ENV_VAR, "invalid")
+    clear_settings_cache()
     result = SuiteResult(
         results=[failed_scenario(f"s{i}") for i in range(1, 22)],
         duration_ms=3,

--- a/libs/giskard-checks/tests/core/test_suite.py
+++ b/libs/giskard-checks/tests/core/test_suite.py
@@ -19,7 +19,6 @@ from giskard.checks.core.result import (
     TestCaseResult as CheckTestCaseResult,
 )
 from giskard.checks.scenarios.suite import _OverallOnly, _SuiteProgress
-from giskard.checks.settings import clear_settings_cache
 from rich.console import Console
 from rich.progress import MofNCompleteColumn, Progress
 from rich.text import Text
@@ -223,7 +222,6 @@ def test_suite_result_rich_console_respects_max_reported_failures_env(
     monkeypatch: pytest.MonkeyPatch,
 ):
     monkeypatch.setenv(MAX_REPORTED_FAILURES_ENV_VAR, "2")
-    clear_settings_cache()
     result = SuiteResult(
         results=[failed_scenario("s1"), failed_scenario("s2"), failed_scenario("s3")],
         duration_ms=3,
@@ -243,7 +241,6 @@ def test_suite_result_rich_console_reports_all_failures_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ):
     monkeypatch.delenv(MAX_REPORTED_FAILURES_ENV_VAR, raising=False)
-    clear_settings_cache()
     result = SuiteResult(
         results=[failed_scenario(f"s{i}") for i in range(1, 22)],
         duration_ms=3,
@@ -263,7 +260,6 @@ def test_suite_result_rich_console_can_hide_all_failure_details(
     monkeypatch: pytest.MonkeyPatch,
 ):
     monkeypatch.setenv(MAX_REPORTED_FAILURES_ENV_VAR, "0")
-    clear_settings_cache()
     result = SuiteResult(
         results=[failed_scenario("s1"), failed_scenario("s2"), failed_scenario("s3")],
         duration_ms=3,
@@ -283,7 +279,6 @@ def test_suite_result_rich_console_ignores_invalid_failure_limit_env(
     monkeypatch: pytest.MonkeyPatch,
 ):
     monkeypatch.setenv(MAX_REPORTED_FAILURES_ENV_VAR, "invalid")
-    clear_settings_cache()
     result = SuiteResult(
         results=[failed_scenario(f"s{i}") for i in range(1, 22)],
         duration_ms=3,

--- a/libs/giskard-checks/tests/integration/test_stateful.py
+++ b/libs/giskard-checks/tests/integration/test_stateful.py
@@ -14,6 +14,7 @@ from giskard.checks import (
     Scenario,
     Trace,
     WithSpy,
+    get_default_generator,
 )
 from giskard.llm.types import ChatMessage, UserMessage
 from pydantic import BaseModel, Field, computed_field
@@ -48,12 +49,12 @@ def mock_apply_tool(mail: str, message: str) -> str:
 
 
 @pytest.fixture
-def generator() -> agents.Generator:
-    return agents.Generator(model="openai/gpt-4o-mini")
+def generator() -> agents.BaseGenerator:
+    return get_default_generator()
 
 
 @pytest.fixture
-def mock_agent(generator: agents.Generator) -> agents.ChatWorkflow[ChatMessage]:
+def mock_agent(generator: agents.BaseGenerator) -> agents.ChatWorkflow[ChatMessage]:
     return generator.chat(message=system_prompt, role="system").with_tools(
         mock_apply_tool
     )
@@ -188,7 +189,7 @@ class UserSimulatorOutput(BaseModel):
 
 # tests
 async def test_user_simulator(
-    generator: agents.Generator,
+    generator: agents.BaseGenerator,
     adapter: Callable[
         [ChatMessage, ConversationTraces],
         Awaitable[Interaction[ChatMessage, ChatMessage]],

--- a/libs/giskard-checks/tests/integration/test_stateless.py
+++ b/libs/giskard-checks/tests/integration/test_stateless.py
@@ -12,6 +12,7 @@ from giskard.checks import (
     Scenario,
     Trace,
     WithSpy,
+    get_default_generator,
 )
 from giskard.llm.types import ChatMessage, UserMessage
 from pydantic import BaseModel, Field, computed_field
@@ -46,12 +47,12 @@ def mock_apply_tool(mail: str, message: str) -> str:
 
 
 @pytest.fixture
-def generator() -> agents.Generator:
-    return agents.Generator(model="openai/gpt-4o-mini")
+def generator() -> agents.BaseGenerator:
+    return get_default_generator()
 
 
 @pytest.fixture
-def mock_agent(generator: agents.Generator) -> agents.ChatWorkflow[ChatMessage]:
+def mock_agent(generator: agents.BaseGenerator) -> agents.ChatWorkflow[ChatMessage]:
     return generator.chat(message=system_prompt, role="system").with_tools(
         mock_apply_tool
     )
@@ -159,7 +160,7 @@ class UserSimulatorOutput(BaseModel):
 
 # tests
 async def test_user_simulator(
-    generator: agents.Generator,
+    generator: agents.BaseGenerator,
     adapter: Callable[[ChatMessage, MessageTraces], Awaitable[ChatMessage]],
 ):
     async def user_simulator(

--- a/uv.lock
+++ b/uv.lock
@@ -960,6 +960,7 @@ dependencies = [
     { name = "jsonschema" },
     { name = "numpy" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "regex" },
     { name = "rich" },
 ]
@@ -986,6 +987,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.23.0,<5" },
     { name = "numpy", specifier = ">=2.4.1,<3" },
     { name = "pydantic", specifier = ">=2.12,<3" },
+    { name = "pydantic-settings", specifier = ">=2.7,<3" },
     { name = "regex", specifier = ">=2026.1.15" },
     { name = "rich", specifier = ">=14.2.0,<16" },
     { name = "textstat", marker = "extra == 'readability'", specifier = ">=0.7.0" },
@@ -2301,6 +2303,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
     { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
     { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `pydantic-settings` to `giskard-checks` so library configuration can be driven by environment variables (or a `.env` file), with `set_default_generator()` retained as a runtime override.

## Settings

New `GiskardChecksSettings` class (`GISKARD_CHECKS_*` prefix):

| Env var | Purpose | Default |
|---------|---------|---------|
| `GISKARD_CHECKS_DEFAULT_MODEL` | Default LLM for checks/scan | `openai/gpt-4o-mini` |
| `GISKARD_CHECKS_DEFAULT_EMBEDDING_MODEL` | Default embedding model | `text-embedding-3-small` |
| `GISKARD_CHECKS_MAX_REPORTED_FAILURES` | Suite report failure cap | unlimited |
| `GISKARD_CHECKS_DISABLE_RICH_PRETTY` | Disable rich REPL pretty-print | `false` |

**Precedence:** `set_default_generator()` / `set_default_embedding_model()` runtime overrides beat environment settings.

## Impact on scan

`giskard-scan` already calls `get_default_generator()` for recommendations — it automatically picks up `GISKARD_CHECKS_DEFAULT_MODEL` with no scan code changes.

## CI / tests

- Integration workflow for checks now sets `GISKARD_CHECKS_DEFAULT_MODEL` and `GISKARD_CHECKS_DEFAULT_EMBEDDING_MODEL` instead of `TEST_MODEL`.
- Integration test fixtures use `get_default_generator()` instead of hardcoded model strings.
- New unit tests cover settings resolution, validation, and override precedence.

## Verification

```
make check          # passed
make test-unit PACKAGE=giskard-checks  # 727 passed, 4 skipped
make test-unit PACKAGE=giskard-scan    # 153 passed
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8b40a98-5772-488a-9fab-6535a619f16d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8b40a98-5772-488a-9fab-6535a619f16d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

