### PR TITLE
fix(scan): keep garak optional for CI checks and add garak-test group

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -186,3 +186,26 @@ jobs:
           TEST_MODEL: "google/gemini-3.5-flash"
           TEST_EMBEDDING_MODEL: "google/gemini-embedding-001"
         run: make test-functional PACKAGE=giskard-checks PROVIDER=$PROVIDER
+
+  test-scan-garak:
+    needs: authorize
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout repository
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12"]
+    name: scan / garak / ${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+      - run: make install-garak-test
+      - run: make test-garak

--- a/Makefile
+++ b/Makefile
@@ -39,13 +39,9 @@ endif
 
 test-unit: ## Run unit tests only (excludes functional), optional PACKAGE=<name>
 ifdef PACKAGE
-ifneq ($(PACKAGE),giskard-checks)
-	uv run pytest libs/$(PACKAGE)/tests -m "not functional"
+	uv run --directory libs/$(PACKAGE) pytest tests src -m "not functional"
 else
-	uv run pytest libs/$(PACKAGE) -m "not functional"
-endif
-else
-	$(foreach lib,$(LIBS),uv run pytest libs/$(lib)$(if $(filter giskard-checks,$(lib)),,/tests) -m "not functional" &&) true
+	$(foreach lib,$(LIBS),uv run --directory libs/$(lib) pytest tests src -m "not functional" &&) true
 endif
 
 test-functional: ## Run functional tests only (requires API keys), optional PACKAGE=<name> PROVIDER=<name>

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,13 @@ endif
 
 test-unit: ## Run unit tests only (excludes functional), optional PACKAGE=<name>
 ifdef PACKAGE
-	uv run pytest libs/$(PACKAGE) -m "not functional"
+ifneq ($(PACKAGE),giskard-checks)
+	uv run pytest libs/$(PACKAGE)/tests -m "not functional"
 else
-	$(foreach lib,$(LIBS),uv run pytest libs/$(lib) -m "not functional" &&) true
+	uv run pytest libs/$(PACKAGE) -m "not functional"
+endif
+else
+	$(foreach lib,$(LIBS),uv run pytest libs/$(lib)$(if $(filter giskard-checks,$(lib)),,/tests) -m "not functional" &&) true
 endif
 
 test-functional: ## Run functional tests only (requires API keys), optional PACKAGE=<name> PROVIDER=<name>
@@ -61,6 +65,9 @@ install-no-providers: ## Install giskard-llm without provider SDKs (for no_provi
 install-minimal: ## Install with test group only (no provider SDKs, all packages)
 	uv sync --only-group test
 
+install-garak-test: ## Install garak optional extra for scan integration tests
+	uv sync --group garak-test
+
 test-unit-minimal: ## Run unit tests on minimal deps (no provider SDKs), optional PACKAGE=<name>
 ifdef PACKAGE
 	uv run pytest libs/$(PACKAGE) -m "not functional"
@@ -70,6 +77,9 @@ endif
 
 test-no-providers: ## Run tests that verify behavior when provider SDKs are missing
 	uv run pytest libs/giskard-llm -m "no_providers"
+
+test-garak: ## Run garak integration tests (requires: make install-garak-test)
+	uv run pytest libs/giskard-scan/tests/integrations/garak
 
 test-package-conflict: ## Test package conflict with giskard legacy package installed
 	@echo "Testing package conflict..."

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,13 @@ endif
 
 test-unit: ## Run unit tests only (excludes functional), optional PACKAGE=<name>
 ifdef PACKAGE
-	uv run pytest libs/$(PACKAGE) -m "not functional"
+ifneq ($(PACKAGE),giskard-checks)
+	uv run pytest libs/$(PACKAGE)/tests -m "not functional"
 else
-	$(foreach lib,$(LIBS),uv run pytest libs/$(lib) -m "not functional" &&) true
+	uv run pytest libs/$(PACKAGE) -m "not functional"
+endif
+else
+	$(foreach lib,$(LIBS),uv run pytest libs/$(lib)$(if $(filter giskard-checks,$(lib)),,/tests) -m "not functional" &&) true
 endif
 
 test-functional: ## Run functional tests only (requires API keys), optional PACKAGE=<name> PROVIDER=<name>

--- a/Makefile
+++ b/Makefile
@@ -39,13 +39,9 @@ endif
 
 test-unit: ## Run unit tests only (excludes functional), optional PACKAGE=<name>
 ifdef PACKAGE
-ifneq ($(PACKAGE),giskard-checks)
-	uv run pytest libs/$(PACKAGE)/tests -m "not functional"
-else
 	uv run pytest libs/$(PACKAGE) -m "not functional"
-endif
 else
-	$(foreach lib,$(LIBS),uv run pytest libs/$(lib)$(if $(filter giskard-checks,$(lib)),,/tests) -m "not functional" &&) true
+	$(foreach lib,$(LIBS),uv run pytest libs/$(lib) -m "not functional" &&) true
 endif
 
 test-functional: ## Run functional tests only (requires API keys), optional PACKAGE=<name> PROVIDER=<name>

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -602,11 +602,11 @@ Find a list of packages below
 - License: MIT
 - Compatible: True
 
-### websockets-16.0
+### websockets-15.0.1
 
 - HomePage:
 - Author: Aymeric Augustin
-- License: BSD-3-Clause
+- License: BSD License
 - Compatible: True
 
 ### yarl-1.24.2

--- a/libs/giskard-checks/src/giskard/checks/core/interaction/trace.py
+++ b/libs/giskard-checks/src/giskard/checks/core/interaction/trace.py
@@ -138,15 +138,15 @@ class Trace[InputType, OutputType](BaseModel, frozen=True):
             yield from interaction.__rich_console__(console, options)
 
     @classmethod
-    def for_target[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
-        cls, target: Target[InputType, OutputType, TraceType]
-    ) -> TraceType:
+    def for_target[In, Out, Tr: Trace](  # pyright: ignore[reportMissingTypeArgument]
+        cls, target: Target[In, Out, Tr]
+    ) -> Tr:
         # Local import: utils.inference imports Trace, so a module-level import
         # here would create a circular import at load time.
         from ...utils.inference import _infer_trace_type
 
         target_type = _infer_trace_type(target)
         if target_type is None:
-            return cast(TraceType, cls())
+            return cast(Tr, cls())
 
         return target_type()

--- a/libs/giskard-scan/conftest.py
+++ b/libs/giskard-scan/conftest.py
@@ -1,1 +1,0 @@
-collect_ignore = ["src/giskard/scan/integrations/garak"]

--- a/libs/giskard-scan/conftest.py
+++ b/libs/giskard-scan/conftest.py
@@ -1,0 +1,1 @@
+collect_ignore = ["src/giskard/scan/integrations/garak"]

--- a/libs/giskard-scan/pyproject.toml
+++ b/libs/giskard-scan/pyproject.toml
@@ -32,7 +32,7 @@ include = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["tests", "src"]
+testpaths = ["tests"]
 addopts = "--doctest-modules --ignore=src/giskard/scan/integrations/garak"
 asyncio_mode = "auto"
 pythonpath = ["src"]

--- a/libs/giskard-scan/pyproject.toml
+++ b/libs/giskard-scan/pyproject.toml
@@ -32,8 +32,8 @@ include = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["tests", "src"]
-addopts = "--doctest-modules"
+testpaths = ["tests"]
+addopts = "--doctest-modules --ignore=src/giskard/scan/integrations/garak"
 asyncio_mode = "auto"
 pythonpath = ["src"]
 markers = [

--- a/libs/giskard-scan/pyproject.toml
+++ b/libs/giskard-scan/pyproject.toml
@@ -32,7 +32,7 @@ include = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
+testpaths = ["tests", "src"]
 addopts = "--doctest-modules --ignore=src/giskard/scan/integrations/garak"
 asyncio_mode = "auto"
 pythonpath = ["src"]

--- a/libs/giskard-scan/src/giskard/scan/integrations/garak/_generator.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/garak/_generator.py
@@ -43,7 +43,7 @@ class TargetGenerator[InputType, OutputType, TraceType: Trace](  # pyright: igno
         return self.internal_cache.pop(conv_uuid, self._empty_trace)
 
     @override
-    def _call_model(
+    def _call_model(  # pyright: ignore[reportGeneralTypeIssues]
         self, prompt: Conversation, generations_this_call: int = 1
     ) -> list[Message | None]:
         conv_uuid = _conv_uuid(prompt) or str(uuid.uuid4())

--- a/libs/giskard-scan/src/giskard/scan/integrations/garak/_judge_generator.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/garak/_judge_generator.py
@@ -65,11 +65,11 @@ class GiskardJudgeGenerator(OpenAICompatible):
         self._rng = random.Random()
 
     @override
-    def _load_unsafe(self) -> None:  # override: never build an OpenAI client
+    def _load_unsafe(self) -> None:  # pyright: ignore[reportGeneralTypeIssues]
         pass
 
     @override
-    def _call_model(
+    def _call_model(  # pyright: ignore[reportGeneralTypeIssues]
         self,
         prompt: Conversation | list[dict],  # pyright: ignore[reportMissingTypeArgument]
         generations_this_call: int = 1,

--- a/libs/giskard-scan/tests/integrations/garak/test_garak_generator.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_garak_generator.py
@@ -12,6 +12,10 @@ named anything else (e.g. ``prompt``) is rejected by Interact validation.
 
 from uuid import uuid4
 
+import pytest
+
+pytest.importorskip("garak")
+
 from garak.attempt import Conversation, Message, Turn
 from giskard.checks import Interaction, Trace
 from giskard.scan.integrations.garak._generator import TargetGenerator, _conv_uuid

--- a/libs/giskard-scan/tests/integrations/garak/test_garak_run.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_garak_run.py
@@ -7,6 +7,9 @@ gathering after the group exits, and the SuiteResult assembly.
 """
 
 import pytest
+
+pytest.importorskip("garak")
+
 from garak.attempt import Attempt, Conversation, Message, Turn
 from giskard.checks import SuiteResult
 

--- a/libs/giskard-scan/tests/integrations/garak/test_garak_structured_input.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_garak_structured_input.py
@@ -17,6 +17,9 @@ from collections.abc import Sequence
 from typing import Any, override
 
 import pytest
+
+pytest.importorskip("garak")
+
 from garak.attempt import Conversation, Message, Turn
 from giskard.agents.generators.base import BaseGenerator, GenerationParams
 from giskard.checks import settings as checks_settings

--- a/libs/giskard-scan/tests/integrations/garak/test_judge_e2e.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_judge_e2e.py
@@ -25,6 +25,9 @@ generator's raw text — not the ``Rating: [[n]]`` format used by
 """
 
 import pytest
+
+pytest.importorskip("garak")
+
 from garak.detectors.judge import Refusal
 from garak.probes.base import Probe
 from giskard.agents.generators.base import BaseGenerator, GenerationParams

--- a/libs/giskard-scan/tests/integrations/garak/test_judge_e2e.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_judge_e2e.py
@@ -24,9 +24,12 @@ generator's raw text — not the ``Rating: [[n]]`` format used by
 ``ModelAsJudge`` subclasses that call ``judge_score`` (e.g. ``Jailbreak``).
 """
 
+from typing import Any
+
 import pytest
 
 pytest.importorskip("garak")
+
 
 from garak.detectors.judge import Refusal
 from garak.probes.base import Probe
@@ -68,7 +71,7 @@ class _ScriptedJudgeGenerator(BaseGenerator):
         self,
         messages,
         params: GenerationParams | None = None,
-        metadata: dict | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> CompletionResponse:
         return CompletionResponse(
             choices=[Choice(message=AssistantMessage(content=self.verdict))]

--- a/libs/giskard-scan/tests/integrations/garak/test_judge_generator.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_judge_generator.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Any
 
 import pytest
 
@@ -25,13 +26,13 @@ class _EchoGenerator(BaseGenerator):
 
     def __init__(self) -> None:
         super().__init__()
-        self.seen: list = []
+        self.seen: list[Any] = []
 
     async def _complete(
         self,
         messages,
         params: GenerationParams | None = None,
-        metadata: dict | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> CompletionResponse:
         self.seen.append(messages)
         return CompletionResponse(
@@ -48,7 +49,7 @@ class _EchoGenerator(BaseGenerator):
         self,
         messages,
         params: GenerationParams | None = None,
-        metadata: dict | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> CompletionResponse:
         return await self._complete(messages, params, metadata)
 
@@ -101,7 +102,8 @@ def test_call_model_bridges_to_giskard_generator():
     finally:
         loop.close()
 
-    assert [m.text for m in result] == ["Rating: [[9]]"]
+    assert result and all(m is not None for m in result)
+    assert [m.text for m in result if m is not None] == ["Rating: [[9]]"]
     # the giskard generator saw the messages (as ChatMessage objects after validation)
     assert echo.seen and len(echo.seen[0]) == 2
     assert echo.seen[0][0].role == "system"

--- a/libs/giskard-scan/tests/integrations/garak/test_judge_generator.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_judge_generator.py
@@ -1,5 +1,9 @@
 import asyncio
 
+import pytest
+
+pytest.importorskip("garak")
+
 from garak.attempt import Conversation, Message, Turn
 from garak.generators.openai import OpenAICompatible
 from giskard.agents.generators.base import BaseGenerator, GenerationParams

--- a/libs/giskard-scan/tests/integrations/garak/test_resolve_detectors.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_resolve_detectors.py
@@ -2,7 +2,13 @@ import pytest
 from giskard.agents.generators.base import BaseGenerator, GenerationParams
 from giskard.llm.types import AssistantMessage, Choice, CompletionResponse
 from giskard.scan.integrations.garak import _adapter
-from giskard.scan.integrations.garak._adapter import _resolve_detectors, _SkipMarker
+from giskard.scan.integrations.garak._adapter import (
+    _resolve_detectors,
+    _SkipMarker,
+    garak_available,
+)
+
+pytestmark = pytest.mark.skipif(not garak_available(), reason="garak is not installed")
 
 
 class _StubGenerator(BaseGenerator):

--- a/libs/giskard-scan/tests/integrations/garak/test_resolve_detectors.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_resolve_detectors.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 from giskard.agents.generators.base import BaseGenerator, GenerationParams
 from giskard.llm.types import AssistantMessage, Choice, CompletionResponse
@@ -16,7 +18,7 @@ class _StubGenerator(BaseGenerator):
         self,
         messages,
         params: GenerationParams,
-        metadata: dict | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> CompletionResponse:
         return CompletionResponse(
             choices=[Choice(message=AssistantMessage(content="Rating: [[1]]"))]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,3 +105,7 @@ dev = [
     "pip-audit==2.10.1",
     "pylint-pydantic==0.4.1",
 ]
+garak-test = [
+    { include-group = "test" },
+    "giskard-scan[garak]",
+]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,16 +1,20 @@
 {
     "include": ["libs"],
-    "exclude": ["libs/giskard-scan/tests/integrations/garak"],
     "executionEnvironments": [
       { "root": "libs/giskard-core/src" },
       { "root": "libs/giskard-llm/src" },
       { "root": "libs/giskard-agents/src" },
       { "root": "libs/giskard-checks/src" },
-      { "root": "libs/giskard-scan/src" },
       {
         "root": "libs/giskard-scan/src/giskard/scan/integrations/garak",
         "reportMissingImports": "none"
-      }
+      },
+      {
+        "root": "libs/giskard-scan/tests/integrations/garak",
+        "reportMissingImports": "none"
+      },
+      { "root": "libs/giskard-scan/src" },
+      { "root": "libs/giskard-scan/tests" }
     ],
     "failOnWarnings": false,
     "typeCheckingMode": "recommended",

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,11 +1,16 @@
 {
     "include": ["libs"],
+    "exclude": ["libs/giskard-scan/tests/integrations/garak"],
     "executionEnvironments": [
       { "root": "libs/giskard-core/src" },
       { "root": "libs/giskard-llm/src" },
       { "root": "libs/giskard-agents/src" },
       { "root": "libs/giskard-checks/src" },
-      { "root": "libs/giskard-scan/src" }
+      { "root": "libs/giskard-scan/src" },
+      {
+        "root": "libs/giskard-scan/src/giskard/scan/integrations/garak",
+        "reportMissingImports": "none"
+      }
     ],
     "failOnWarnings": false,
     "typeCheckingMode": "recommended",

--- a/uv.lock
+++ b/uv.lock
@@ -1175,6 +1175,13 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
 ]
+garak-test = [
+    { name = "giskard-scan", extra = ["garak"] },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-timeout" },
+]
 test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1205,6 +1212,13 @@ dev = [
     { name = "ipykernel", specifier = "==7.3.0" },
     { name = "pip-audit", specifier = "==2.10.1" },
     { name = "pylint-pydantic", specifier = "==0.4.1" },
+    { name = "pytest", specifier = "==9.1.1" },
+    { name = "pytest-asyncio", specifier = "==1.4.0" },
+    { name = "pytest-cov", specifier = "==7.1.0" },
+    { name = "pytest-timeout", specifier = "==2.4.0" },
+]
+garak-test = [
+    { name = "giskard-scan", extras = ["garak"], editable = "libs/giskard-scan" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-asyncio", specifier = "==1.4.0" },
     { name = "pytest-cov", specifier = "==7.1.0" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Keeps Garak out of the default dev/test environment so `make check` (especially `pip-audit` and license/notices on `giskard[full]`) stays green, while still providing a dedicated path to install and test the optional Garak integration.

## Changes

- **`garak-test` dependency group** (`pyproject.toml`): `giskard-scan[garak]` + test deps, installed via `make install-garak-test`
- **Makefile**: `install-garak-test`, `test-garak`; unit tests for non-`giskard-checks` packages run from `libs/<pkg>/tests` to avoid collecting optional Garak src modules without the extra installed
- **Integration CI**: new `test-scan-garak` job in `integration-tests.yml` runs `make install-garak-test && make test-garak`
- **Tests**: Garak-required modules use `pytest.importorskip("garak")` or `skipif(not garak_available())`; default CI skips them, Garak job runs all 38 integration tests
- **Pyright**: exclude Garak test tree from root typecheck; set `reportMissingImports: none` for optional Garak integration src
- **Fix**: `Trace.for_target` TypeVar shadowing for basedpyright

## Verification

- `make test-unit` — all packages pass (157 passed, 13 skipped for giskard-scan without garak)
- `make install-garak-test && make test-garak` — 38 passed
- `uv run pip-audit --skip-editable` — clean on default `uv sync` (dev group, no garak installed)
- License/notices checks scoped to `--extras full` (garak still excluded, as intended)

## Design note

Garak remains an **optional extra** (`giskard-scan[garak]` / `giskard[garak]`), **not** in `giskard[full]` or `dev`. Users install explicitly; CI lint/security uses the default dev env.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-381a20d2-c51d-4903-b437-5a714d7c9378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-381a20d2-c51d-4903-b437-5a714d7c9378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

