### PR TITLE
fix(scan): copy garak probe tags onto scenario results

### DIFF
--- a/libs/giskard-scan/src/giskard/scan/integrations/garak/_adapter.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/garak/_adapter.py
@@ -292,7 +292,7 @@ class GarakScanAdapter:
                             attempt.conversations[conversation_idx]
                         ),
                         duration_ms=0,
-                        tags=list(probe.tags),
+                        tags=list(getattr(probe, "tags", [])),
                     )
                 )
 

--- a/libs/giskard-scan/src/giskard/scan/integrations/garak/_adapter.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/garak/_adapter.py
@@ -292,7 +292,7 @@ class GarakScanAdapter:
                             attempt.conversations[conversation_idx]
                         ),
                         duration_ms=0,
-                        tags=list(getattr(probe, "tags", [])),
+                        tags=list(getattr(probe, "tags", None) or []),
                     )
                 )
 

--- a/libs/giskard-scan/src/giskard/scan/integrations/garak/_adapter.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/garak/_adapter.py
@@ -292,6 +292,7 @@ class GarakScanAdapter:
                             attempt.conversations[conversation_idx]
                         ),
                         duration_ms=0,
+                        tags=list(probe.tags),
                     )
                 )
 

--- a/libs/giskard-scan/src/giskard/scan/integrations/garak/_adapter.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/garak/_adapter.py
@@ -292,7 +292,7 @@ class GarakScanAdapter:
                             attempt.conversations[conversation_idx]
                         ),
                         duration_ms=0,
-                        tags=list(getattr(probe, "tags", None) or []),
+                        tags=list(probe.tags),
                     )
                 )
 

--- a/libs/giskard-scan/tests/integrations/garak/test_garak_e2e.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_garak_e2e.py
@@ -17,8 +17,19 @@ Marked ``functional``: it runs whenever garak is installed and is skipped otherw
 """
 
 import pytest
+
+pytest.importorskip("garak")
+
+from typing import cast
+
+from garak._plugins import load_plugin
+from garak.probes.base import Probe
 from giskard.checks import SuiteResult
-from giskard.scan.integrations.garak._adapter import GarakScanAdapter, garak_available
+from giskard.scan.integrations.garak._adapter import (
+    GarakScanAdapter,
+    _resolve_probes,
+    garak_available,
+)
 
 pytestmark = pytest.mark.functional
 
@@ -27,8 +38,6 @@ _PROBE = "probes.goodside.ThreatenJSON"
 
 @pytest.mark.skipif(not garak_available(), reason="garak is not installed")
 def test_resolve_probes_empty_list_returns_no_probes() -> None:
-    from giskard.scan.integrations.garak._adapter import _resolve_probes
-
     assert _resolve_probes([]) == []
 
 
@@ -64,11 +73,6 @@ async def test_run_actual_garak_probe() -> None:
     # A detector actually scored the attempt, producing one check result.
     assert len(scenario.steps) == 1
     assert len(scenario.steps[0].results) >= 1
-
-    from typing import cast
-
-    from garak._plugins import load_plugin
-    from garak.probes.base import Probe
 
     probe = cast("Probe", load_plugin(_PROBE))
     assert scenario.tags == list(probe.tags)

--- a/libs/giskard-scan/tests/integrations/garak/test_garak_e2e.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_garak_e2e.py
@@ -64,3 +64,8 @@ async def test_run_actual_garak_probe() -> None:
     # A detector actually scored the attempt, producing one check result.
     assert len(scenario.steps) == 1
     assert len(scenario.steps[0].results) >= 1
+
+    from garak._plugins import load_plugin
+
+    probe = load_plugin(_PROBE)
+    assert scenario.tags == list(probe.tags)

--- a/libs/giskard-scan/tests/integrations/garak/test_garak_e2e.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_garak_e2e.py
@@ -65,7 +65,10 @@ async def test_run_actual_garak_probe() -> None:
     assert len(scenario.steps) == 1
     assert len(scenario.steps[0].results) >= 1
 
-    from garak._plugins import load_plugin
+    from typing import cast
 
-    probe = load_plugin(_PROBE)
+    from garak._plugins import load_plugin
+    from garak.probes.base import Probe
+
+    probe = cast("Probe", load_plugin(_PROBE))
     assert scenario.tags == list(probe.tags)

--- a/libs/giskard-scan/tests/integrations/garak/test_garak_run.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_garak_run.py
@@ -66,6 +66,7 @@ class _OverProducingDetector:
 
 class _FakeProbe:
     probename = "fake.Probe"
+    tags = ["owasp:llm01", "quality:Security:PromptStability"]
 
     def __init__(self, attempts: list[Attempt]) -> None:
         self._attempts = attempts
@@ -134,6 +135,7 @@ async def test_run_produces_suite_result_from_fake_probe(
     assert result.duration_ms >= 0
     for scenario in result.results:
         assert scenario.scenario_name.startswith("Garak fake.Probe")
+        assert scenario.tags == probe.tags
 
 
 async def test_run_failure_score_marks_check_failed(

--- a/libs/giskard-scan/tests/integrations/garak/test_garak_run.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_garak_run.py
@@ -77,6 +77,7 @@ class _FakeProbe:
 
 class _FailingProbe:
     probename = "fake.FailingProbe"
+    tags: list[str] = []
 
     def probe(self, generator: object) -> list[Attempt]:
         raise RuntimeError("probe blew up")
@@ -84,6 +85,7 @@ class _FailingProbe:
 
 class _CacheCheckingProbe:
     probename = "fake.CacheProbe"
+    tags: list[str] = []
 
     def __init__(self, probe_id: str) -> None:
         self.probe_id = probe_id

--- a/libs/giskard-scan/tests/integrations/garak/test_garak_structured_input.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_garak_structured_input.py
@@ -150,6 +150,7 @@ class _StructuredInputProbe:
     """Fake probe that drives TargetGenerator._call_model (structured path)."""
 
     probename = "fake.StructuredProbe"
+    tags: list[str] = []
 
     def __init__(self, probe_id: str) -> None:
         self.probe_id = probe_id


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Garak scan scenarios were missing taxonomy tags because `GarakScanAdapter` built `ScenarioResult` objects without copying the probe's `tags`.

This change snapshots each garak probe's `tags` onto every scenario result it produces, matching how the standard scenario runner copies `scenario.tags` at execution time.

## Changes

- Pass `tags=list(getattr(probe, "tags", []))` when assembling `ScenarioResult` in `_adapter.py`
- Assert tag propagation in `test_garak_run.py` (fake probe) and `test_garak_e2e.py` (real garak probe)

## Verification

- `make test-garak`: 38 passed
- `make test-unit PACKAGE=giskard-scan`: 187 passed, 4 deselected
- `make format`: all files unchanged
- `make check`: pre-existing 12 pyright errors in garak test stubs (unchanged count)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1f083b1-1a01-4e72-8315-5ecc99741fcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1f083b1-1a01-4e72-8315-5ecc99741fcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

