### PR TITLE
fix(scan): name garak check results after probe detector plugins

### DIFF
--- a/libs/giskard-scan/src/giskard/scan/integrations/garak/_adapter.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/garak/_adapter.py
@@ -136,7 +136,7 @@ def _detector_class(name: str) -> "type[Detector] | None":
 
 def _resolve_detectors(
     probe: "Probe", loop: "asyncio.AbstractEventLoop | None"
-) -> "tuple[list[Detector], list[_SkipMarker]]":
+) -> "tuple[list[tuple[str, Detector]], list[_SkipMarker]]":
     from garak._plugins import load_plugin
     from garak.detectors.judge import ModelAsJudge
     from garak.exception import APIKeyMissingError, GarakException
@@ -147,7 +147,7 @@ def _resolve_detectors(
         probe.extended_detectors
     )
 
-    detectors: list[Detector] = []
+    detectors: list[tuple[str, Detector]] = []
     skipped: list[_SkipMarker] = []
     for name in detector_names:
         full_name = f"detectors.{name}"
@@ -156,15 +156,20 @@ def _resolve_detectors(
         # Judge detectors: install the Giskard generator so no judge key is needed.
         if detector_cls is not None and issubclass(detector_cls, ModelAsJudge):
             detectors.append(
-                cast(
-                    "Detector",
-                    make_judge_detector(detector_cls, get_default_generator(), loop),
+                (
+                    name,
+                    cast(
+                        "Detector",
+                        make_judge_detector(
+                            detector_cls, get_default_generator(), loop
+                        ),
+                    ),
                 )
             )
             continue
 
         try:
-            detectors.append(cast("Detector", load_plugin(full_name)))
+            detectors.append((name, cast("Detector", load_plugin(full_name))))
         except GarakException as exc:
             cause = exc.__cause__
             if isinstance(cause, APIKeyMissingError):
@@ -185,7 +190,7 @@ class GarakScanAdapter:
     def _evaluate_attempt(
         self,
         attempt: "Attempt",
-        detectors: "list[Detector]",
+        detectors: "list[tuple[str, Detector]]",
         skipped: "Iterable[_SkipMarker]" = (),
     ) -> list[TestCaseResult]:
         check_results = defaultdict(list)
@@ -196,11 +201,14 @@ class GarakScanAdapter:
                 check_results[conversation_idx].append(
                     CheckResult.skip(
                         message=f"detector skipped: {marker.reason}",
-                        details={"detector": marker.name},
+                        details={
+                            "check_name": marker.name,
+                            "detector": marker.name,
+                        },
                     )
                 )
 
-        for detector in detectors:
+        for detector_label, detector in detectors:
             try:
                 # detect() is typed as Iterable; materialize so we can measure it
                 # and index safely (a one-shot generator would be exhausted below).
@@ -215,7 +223,7 @@ class GarakScanAdapter:
                     logger.warning(
                         "Detector %s returned %d scores for %d conversations; "
                         "extra scores are ignored",
-                        detector.name,
+                        detector_label,
                         len(scores),
                         conversation_count,
                     )
@@ -225,23 +233,32 @@ class GarakScanAdapter:
                         check_results[conversation_idx].append(
                             CheckResult.skip(
                                 message="detector returned no score",
-                                details={"detector": detector.name},
+                                details={
+                                    "check_name": detector_label,
+                                    "detector": detector_label,
+                                },
                             )
                         )
                     elif score > _HIT_THRESHOLD:
                         check_results[conversation_idx].append(
                             CheckResult.failure(
                                 message=detector.hit_desc,
-                                details={"detector": detector.name},
-                                metrics=[Metric(name=str(detector.name), value=score)],
+                                details={
+                                    "check_name": detector_label,
+                                    "detector": detector_label,
+                                },
+                                metrics=[Metric(name=detector_label, value=score)],
                             )
                         )
                     else:
                         check_results[conversation_idx].append(
                             CheckResult.success(
                                 message=detector.pass_desc,
-                                details={"detector": detector.name},
-                                metrics=[Metric(name=str(detector.name), value=score)],
+                                details={
+                                    "check_name": detector_label,
+                                    "detector": detector_label,
+                                },
+                                metrics=[Metric(name=detector_label, value=score)],
                             )
                         )
             except Exception as exc:  # noqa: BLE001 — a broken detector skips, not aborts
@@ -249,7 +266,11 @@ class GarakScanAdapter:
                     check_results[conversation_idx].append(
                         CheckResult.error(
                             message="detector raised",
-                            details={"detector": detector.name, "error": repr(exc)},
+                            details={
+                                "check_name": detector_label,
+                                "detector": detector_label,
+                                "error": repr(exc),
+                            },
                         )
                     )
 

--- a/libs/giskard-scan/tests/integrations/garak/test_garak_run.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_garak_run.py
@@ -21,6 +21,9 @@ def _patch_resolvers(monkeypatch: pytest.MonkeyPatch, probes, detectors):
     globals, so we patch — and return the adapter from — the exact live module.
     See conftest.py ``block_garak_import`` for why a top-level import could bind a
     stale module and silently run the real garak catalog.
+
+    ``detectors`` is a list of ``(label, detector)`` pairs, matching
+    ``_resolve_detectors`` output.
     """
     from giskard.scan.integrations.garak import _adapter
 
@@ -32,7 +35,7 @@ def _patch_resolvers(monkeypatch: pytest.MonkeyPatch, probes, detectors):
 
 
 class _FakeDetector:
-    name = "fake.Detector"
+    detectorname = "garak.detectors.fake.Detector"
     hit_desc = "hit"
     pass_desc = "pass"
 
@@ -45,7 +48,7 @@ class _FakeDetector:
 
 
 class _TruncatedDetector:
-    name = "fake.TruncatedDetector"
+    detectorname = "garak.detectors.fake.TruncatedDetector"
     hit_desc = "hit"
     pass_desc = "pass"
 
@@ -56,7 +59,7 @@ class _TruncatedDetector:
 class _OverProducingDetector:
     """Returns more scores than the attempt has conversations."""
 
-    name = "fake.OverProducingDetector"
+    detectorname = "garak.detectors.fake.OverProducingDetector"
     hit_desc = "hit"
     pass_desc = "pass"
 
@@ -126,7 +129,9 @@ async def test_run_produces_suite_result_from_fake_probe(
 ) -> None:
     probe = _FakeProbe([_attempt("a1"), _attempt("a2")])
     adapter_cls = _patch_resolvers(
-        monkeypatch, probes=[probe], detectors=[_FakeDetector(score=0.9)]
+        monkeypatch,
+        probes=[probe],
+        detectors=[("fake.Detector", _FakeDetector(score=0.9))],
     )
 
     result = await adapter_cls().run(target=target)
@@ -146,7 +151,7 @@ async def test_run_failure_score_marks_check_failed(
     adapter_cls = _patch_resolvers(
         monkeypatch,
         probes=[_FakeProbe([_attempt("a1")])],
-        detectors=[_FakeDetector(score=0.9)],  # > 0.5 -> failure
+        detectors=[("fake.Detector", _FakeDetector(score=0.9))],  # > 0.5 -> failure
     )
 
     result = await adapter_cls().run(target=target)
@@ -154,6 +159,7 @@ async def test_run_failure_score_marks_check_failed(
     check_results = result.results[0].steps[0].results
     assert len(check_results) == 1
     assert check_results[0].failed
+    assert check_results[0].details["check_name"] == "fake.Detector"
 
 
 async def test_run_ignores_probe_exception(
@@ -162,7 +168,7 @@ async def test_run_ignores_probe_exception(
     adapter_cls = _patch_resolvers(
         monkeypatch,
         probes=[_FakeProbe([_attempt("a1")]), _FailingProbe()],
-        detectors=[_FakeDetector(score=0.1)],
+        detectors=[("fake.Detector", _FakeDetector(score=0.1))],
     )
 
     result = await adapter_cls().run(target=target)
@@ -177,7 +183,7 @@ async def test_run_uses_separate_generator_per_probe(
     adapter_cls = _patch_resolvers(
         monkeypatch,
         probes=[_CacheCheckingProbe("p1"), _CacheCheckingProbe("p2")],
-        detectors=[_FakeDetector(score=0.1)],
+        detectors=[("fake.Detector", _FakeDetector(score=0.1))],
     )
 
     result = await adapter_cls().run(target=target)
@@ -189,7 +195,7 @@ async def test_run_with_no_probes_returns_empty_suite(
     monkeypatch: pytest.MonkeyPatch, target
 ) -> None:
     adapter_cls = _patch_resolvers(
-        monkeypatch, probes=[], detectors=[_FakeDetector(score=0.1)]
+        monkeypatch, probes=[], detectors=[("fake.Detector", _FakeDetector(score=0.1))]
     )
 
     result = await adapter_cls().run(target=target)
@@ -206,7 +212,7 @@ async def test_third_party_scan_routes_to_garak_adapter(
     _patch_resolvers(
         monkeypatch,
         probes=[_FakeProbe([_attempt("a1")])],
-        detectors=[_FakeDetector(score=0.9)],
+        detectors=[("fake.Detector", _FakeDetector(score=0.9))],
     )
 
     result = await third_party_scan(target, tool="garak")
@@ -238,7 +244,7 @@ async def test_run_marks_missing_detector_scores_as_skip(
     adapter_cls = _patch_resolvers(
         monkeypatch,
         probes=[probe],
-        detectors=[_TruncatedDetector()],
+        detectors=[("fake.TruncatedDetector", _TruncatedDetector())],
     )
 
     result = await adapter_cls().run(target=target)
@@ -264,7 +270,7 @@ async def test_run_warns_and_drops_extra_detector_scores(
     adapter_cls = _patch_resolvers(
         monkeypatch,
         probes=[probe],
-        detectors=[_OverProducingDetector()],
+        detectors=[("fake.OverProducingDetector", _OverProducingDetector())],
     )
 
     with caplog.at_level("WARNING"):

--- a/libs/giskard-scan/tests/integrations/garak/test_garak_structured_input.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_garak_structured_input.py
@@ -207,7 +207,7 @@ async def test_parallel_probes_with_structured_target_use_main_loop(
     adapter_cls = _patch_resolvers(
         monkeypatch,
         probes=[_StructuredInputProbe("p1"), _StructuredInputProbe("p2")],
-        detectors=[_FakeDetector()],
+        detectors=[("fake.Detector", _FakeDetector())],
     )
 
     result = await adapter_cls().run(target=target)

--- a/libs/giskard-scan/tests/integrations/garak/test_judge_e2e.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_judge_e2e.py
@@ -119,12 +119,7 @@ async def test_judge_probe_scores_refusal_as_pass(
         assert not check_result.errored
         assert not check_result.skipped
         assert check_result.passed
-        # ``details["detector"]`` is ``detector.name``, which falls back to the
-        # base ``Detector`` class object (garak/detectors/base.py:62) here since
-        # neither ``judge.Refusal`` nor our dynamic ``_GiskardJudge`` wrapper set
-        # their own ``name`` — so it can't identify which detector ran. Instead
-        # check the detector-specific ``pass_desc`` message that only
-        # ``judge.Refusal`` sets (garak/detectors/judge.py:138).
+        assert check_result.details["check_name"] == "judge.Refusal"
         assert check_result.message == Refusal.pass_desc
 
 
@@ -148,4 +143,5 @@ async def test_judge_probe_scores_compliance_as_fail(
         assert not check_result.errored
         assert not check_result.skipped
         assert check_result.failed
+        assert check_result.details["check_name"] == "judge.Refusal"
         assert check_result.message == Refusal.hit_desc

--- a/libs/giskard-scan/tests/integrations/garak/test_resolve_detectors.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_resolve_detectors.py
@@ -46,9 +46,11 @@ def test_judge_detector_gets_giskard_generator(monkeypatch):
     detectors, skipped = _resolve_detectors(_JudgeProbe.__new__(_JudgeProbe), None)
     assert skipped == []
     assert len(detectors) == 1
+    detector_label, detector = detectors[0]
+    assert detector_label == "judge.Refusal"
     from giskard.scan.integrations.garak._judge_generator import GiskardJudgeGenerator
 
-    assert isinstance(detectors[0].evaluation_generator, GiskardJudgeGenerator)
+    assert isinstance(detector.evaluation_generator, GiskardJudgeGenerator)
 
 
 def test_env_var_detector_without_key_is_skipped(monkeypatch):
@@ -109,3 +111,4 @@ def test_skipped_detectors_emit_skip_results(monkeypatch):
         assert skip_result.skipped, f"Expected skip status, got {skip_result.status}"
         assert "PERSPECTIVE_API_KEY" in str(skip_result.message)
         assert skip_result.details["detector"] == "perspective.Toxicity"
+        assert skip_result.details["check_name"] == "perspective.Toxicity"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Garak scan results were showing generic `check_1`, `check_2`, … labels because `CheckResult` details lacked `check_name`. Giskard uses `check_name` for display and JUnit export.

Garak itself keys detector results by the short plugin name declared on the probe (e.g. `always.Fail`, `judge.Refusal`), matching `garak.harnesses.base` behavior. This change propagates that label into every garak-derived `CheckResult`.

## Changes

- `_resolve_detectors` now returns `(label, detector)` pairs using the probe's `primary_detector` / `extended_detectors` names
- `_evaluate_attempt` sets `check_name` and `detector` details from that label (including judge wrappers where `detectorname` would otherwise be a dynamic class path)
- Metric names use the same detector label instead of `detector.name` (which often falls back to the base `Detector` class)
- Tests updated to assert proper `check_name` values

## Verification

```
make format
make test-garak   # 38 passed
make test-unit PACKAGE=giskard-scan  # 187 passed, 4 deselected
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ee1f69c-f07b-4452-8dbe-0075c927f3f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ee1f69c-f07b-4452-8dbe-0075c927f3f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

