### PR TITLE
feat(lidar): integrate lidar scan into third_party_scan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,12 @@ install-minimal: ## Install with test group only (no provider SDKs, all packages
 install-garak-test: ## Install garak optional extra for scan integration tests
 	uv sync --group garak-test
 
+install-lidar-test: ## Install lidar private dependency for scan integration tests
+	uv sync --group lidar-test
+
+test-lidar: install-lidar-test ## Run lidar integration tests
+	uv run pytest libs/giskard-scan/tests/integrations/lidar -v
+
 test-unit-minimal: ## Run unit tests on minimal deps (no provider SDKs), optional PACKAGE=<name>
 ifdef PACKAGE
 	uv run pytest libs/$(PACKAGE) -m "not functional"

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -396,7 +396,7 @@ Find a list of packages below
 - License: Apache License 2.0
 - Compatible: True
 
-### numpy-2.5.0
+### numpy-2.4.6
 
 - HomePage:
 - Author: Travis E. Oliphant et al.

--- a/libs/giskard-scan/README.md
+++ b/libs/giskard-scan/README.md
@@ -27,6 +27,7 @@ result = asyncio.run(
     third_party_scan(
         target,
         tool="garak",
+        description="A helpful assistant",  # required; lidar builds its target profile from this, garak ignores it
         probes=["probes.goodside.ThreatenJSON"],  # omit to run all active probes
         target_mode="multiturn",  # "singleturn" skips garak's iterative probes
     )

--- a/libs/giskard-scan/pyproject.toml
+++ b/libs/giskard-scan/pyproject.toml
@@ -33,7 +33,7 @@ include = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--doctest-modules --ignore=src/giskard/scan/integrations/garak"
+addopts = "--doctest-modules --ignore=src/giskard/scan/integrations/garak --ignore=src/giskard/scan/integrations/lidar"
 asyncio_mode = "auto"
 pythonpath = ["src"]
 markers = [

--- a/libs/giskard-scan/src/giskard/scan/integrations/_entry_point.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/_entry_point.py
@@ -7,14 +7,14 @@ from giskard.checks import SuiteResult, Target, Trace
 
 async def third_party_scan[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
     target: Target[InputType, OutputType, TraceType],
-    tool: Literal["garak"] = "garak",
+    tool: Literal["garak", "lidar"] = "garak",
     **kwargs: Any,
 ) -> SuiteResult:
     """Run an external security scanner against a Giskard target.
 
     Args:
         target: Agent or provider target to evaluate.
-        tool: Scanner to use. Only ``"garak"`` is supported today.
+        tool: Scanner to use. ``"garak"`` or ``"lidar"``.
         **kwargs: Tool-specific options. For garak:
             ``probes: list[str] | None`` restricts which probes run; omitted
             means all active loadable probes, while an empty list runs none.
@@ -28,6 +28,10 @@ async def third_party_scan[InputType, OutputType, TraceType: Trace](  # pyright:
         from .garak import GarakScanAdapter
 
         adapter = GarakScanAdapter()
+    elif tool == "lidar":
+        from .lidar import LidarScanAdapter
+
+        adapter = LidarScanAdapter()
     else:
-        raise ValueError(f"Unknown tool {tool!r}. Available: ['garak']")
+        raise ValueError(f"Unknown tool {tool!r}. Available: ['garak', 'lidar']")
     return await adapter.run(target, **kwargs)

--- a/libs/giskard-scan/src/giskard/scan/integrations/_entry_point.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/_entry_point.py
@@ -7,7 +7,7 @@ from giskard.checks import SuiteResult, Target, Trace
 
 async def third_party_scan[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
     target: Target[InputType, OutputType, TraceType],
-    tool: Literal["garak", "lidar"] = "garak",
+    tool: Literal["garak", "lidar"],
     *,
     description: str,
     languages: list[str] | None = None,

--- a/libs/giskard-scan/src/giskard/scan/integrations/_entry_point.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/_entry_point.py
@@ -8,6 +8,9 @@ from giskard.checks import SuiteResult, Target, Trace
 async def third_party_scan[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
     target: Target[InputType, OutputType, TraceType],
     tool: Literal["garak", "lidar"] = "garak",
+    *,
+    description: str,
+    languages: list[str] | None = None,
     **kwargs: Any,
 ) -> SuiteResult:
     """Run an external security scanner against a Giskard target.
@@ -15,6 +18,12 @@ async def third_party_scan[InputType, OutputType, TraceType: Trace](  # pyright:
     Args:
         target: Agent or provider target to evaluate.
         tool: Scanner to use. ``"garak"`` or ``"lidar"``.
+        description: Natural-language description of the agent under test.
+            For lidar this becomes the ``TargetInfo.agent_description`` that
+            probes use to build their attacks. Garak has no target-profile
+            concept and ignores it.
+        languages: BCP-47 language codes the agent handles. For lidar this
+            becomes ``TargetInfo.languages``. Garak ignores it.
         **kwargs: Tool-specific options. For garak:
             ``probes: list[str] | None`` restricts which probes run; omitted
             means all active loadable probes, while an empty list runs none.
@@ -24,9 +33,7 @@ async def third_party_scan[InputType, OutputType, TraceType: Trace](  # pyright:
             ``probes: list[str] | None`` restricts which probes run by id
             (e.g. ``"deepset-injection:1.0"``); ``None`` runs all.
             ``tags: list[str] | None`` restricts probes by tag; ``None`` runs
-            all. ``target_mode`` is ignored. Note: lidar probes generally need
-            a discovered target profile, which this integration does not enable,
-            so many probes report SKIP.
+            all. ``target_mode`` is ignored.
 
     Returns:
         The completed suite result.
@@ -34,11 +41,14 @@ async def third_party_scan[InputType, OutputType, TraceType: Trace](  # pyright:
     if tool == "garak":
         from .garak import GarakScanAdapter
 
-        adapter = GarakScanAdapter()
+        # Garak has no TargetInfo concept: drop the context args so its
+        # run() signature is unaffected.
+        return await GarakScanAdapter().run(target, **kwargs)
     elif tool == "lidar":
         from .lidar import LidarScanAdapter
 
-        adapter = LidarScanAdapter()
+        return await LidarScanAdapter().run(
+            target, description=description, languages=languages, **kwargs
+        )
     else:
         raise ValueError(f"Unknown tool {tool!r}. Available: ['garak', 'lidar']")
-    return await adapter.run(target, **kwargs)

--- a/libs/giskard-scan/src/giskard/scan/integrations/_entry_point.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/_entry_point.py
@@ -33,7 +33,9 @@ async def third_party_scan[InputType, OutputType, TraceType: Trace](  # pyright:
             ``probes: list[str] | None`` restricts which probes run by id
             (e.g. ``"deepset-injection:1.0"``); ``None`` runs all.
             ``tags: list[str] | None`` restricts probes by tag; ``None`` runs
-            all. ``target_mode`` is ignored.
+            all. ``target_mode: str`` (default ``"multiturn"``) skips lidar's
+            multi-turn probes (crescendo, goat, ...) when set to
+            ``"singleturn"``.
 
     Returns:
         The completed suite result.

--- a/libs/giskard-scan/src/giskard/scan/integrations/_entry_point.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/_entry_point.py
@@ -20,6 +20,13 @@ async def third_party_scan[InputType, OutputType, TraceType: Trace](  # pyright:
             means all active loadable probes, while an empty list runs none.
             ``target_mode: str`` (default ``"multiturn"``) skips garak
             iterative probes when set to ``"singleturn"``.
+          For lidar:
+            ``probes: list[str] | None`` restricts which probes run by id
+            (e.g. ``"deepset-injection:1.0"``); ``None`` runs all.
+            ``tags: list[str] | None`` restricts probes by tag; ``None`` runs
+            all. ``target_mode`` is ignored. Note: lidar probes generally need
+            a discovered target profile, which this integration does not enable,
+            so many probes report SKIP.
 
     Returns:
         The completed suite result.

--- a/libs/giskard-scan/src/giskard/scan/integrations/_shared.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/_shared.py
@@ -1,0 +1,21 @@
+"""Helpers shared across third-party scanner adapters."""
+
+from typing import Any
+
+
+def reject_unexpected_kwargs(tool: str, kwargs: dict[str, Any]) -> None:
+    """Raise ``TypeError`` if ``kwargs`` still holds keys after the adapter popped
+    the options it recognizes.
+
+    Each adapter knows its own valid kwargs and pops them; anything left over is a
+    caller typo (e.g. ``probe`` for ``probes``) that would otherwise be silently
+    dropped. The message names the public ``third_party_scan(tool=...)`` entry point
+    the caller actually used, so it stays useful even though validation happens in
+    the adapter.
+    """
+    if kwargs:
+        unexpected = ", ".join(repr(key) for key in kwargs)
+        raise TypeError(
+            f"third_party_scan(tool={tool!r}) got unexpected keyword "
+            f"argument(s): {unexpected}"
+        )

--- a/libs/giskard-scan/src/giskard/scan/integrations/garak/_adapter.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/garak/_adapter.py
@@ -21,6 +21,7 @@ from giskard.checks import (
 )
 
 from ...generators.base import TargetMode
+from .._shared import reject_unexpected_kwargs
 
 if TYPE_CHECKING:
     from garak.attempt import Attempt
@@ -324,6 +325,7 @@ class GarakScanAdapter:
 
         probes = _resolve_probes(kwargs.pop("probes", None))
         target_mode: TargetMode = kwargs.pop("target_mode", "multiturn")
+        reject_unexpected_kwargs("garak", kwargs)
 
         if target_mode == "singleturn":
             probes = [

--- a/libs/giskard-scan/src/giskard/scan/integrations/lidar/__init__.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/lidar/__init__.py
@@ -1,0 +1,7 @@
+"""Lidar integration for giskard.scan."""
+
+from ._adapter import LidarScanAdapter
+
+__all__ = [
+    "LidarScanAdapter",
+]

--- a/libs/giskard-scan/src/giskard/scan/integrations/lidar/_adapter.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/lidar/_adapter.py
@@ -1,0 +1,24 @@
+"""Adapter that runs the private lidar scanner through Giskard scan."""
+
+import logging
+from importlib.util import find_spec
+
+logger = logging.getLogger(__name__)
+
+
+def lidar_available() -> bool:
+    """Return True if the private lidar dependency is importable."""
+    return find_spec("lidar") is not None
+
+
+def _require_lidar() -> None:
+    if not lidar_available():
+        raise ImportError(
+            "lidar is not installed. It is a private Giskard package and is not "
+            "available on PyPI. Install it from git: "
+            "pip install git+https://github.com/Giskard-AI/lidar.git@v0.2.7"
+        )
+
+
+class LidarScanAdapter:
+    """Build and run a Giskard suite from a lidar scan. Filled in by later tasks."""

--- a/libs/giskard-scan/src/giskard/scan/integrations/lidar/_adapter.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/lidar/_adapter.py
@@ -16,6 +16,8 @@ from giskard.checks import (
     get_default_generator,
 )
 
+from .._shared import reject_unexpected_kwargs
+
 if TYPE_CHECKING:
     # Type-only: lidar's compat Message union. Never imported at runtime — the
     # function only reads .role/.content, so no lidar dependency is introduced.
@@ -105,6 +107,7 @@ class LidarScanAdapter:
         tags = kwargs.pop("tags", None)
         if kwargs.pop("target_mode", None) is not None:
             logger.debug("target_mode is ignored for lidar; lidar owns turn logic.")
+        reject_unexpected_kwargs("lidar", kwargs)
 
         target_info = TargetInfo(
             agent_description=description,
@@ -113,24 +116,20 @@ class LidarScanAdapter:
 
         bridged = ScanTargetGenerator(target=target)
         start = time.perf_counter()
-        try:
-            # run_scan returns a ScanRun immediately (the scan runs in the background);
-            # await wait_for_completion() to block, then read .scan_result off it.
-            scan_run = await run_scan(
-                target=bridged,  # pyright: ignore[reportArgumentType]
-                target_info=target_info,
-                probe_ids=probes,
-                tags_filter=tags,
-                generator=get_default_generator(),
-                discover_target_info=False,
-                base_seed=None,
-            )
-            await scan_run.wait_for_completion()
-            scan_result = scan_run.scan_result
-        except Exception as exc:  # noqa: BLE001 — total failure -> empty suite, not abort
-            logger.warning("lidar run_scan raised: %s", exc)
-            elapsed_ms = int((time.perf_counter() - start) * 1000)
-            return SuiteResult(results=[], duration_ms=elapsed_ms)
+        # run_scan returns a ScanRun immediately (scan runs in the background); await
+        # wait_for_completion() to block, then read .scan_result off it. Failures
+        # propagate: an empty suite would read as "scan succeeded, no vulnerabilities".
+        scan_run = await run_scan(
+            target=bridged,  # pyright: ignore[reportArgumentType]
+            target_info=target_info,
+            probe_ids=probes,
+            tags_filter=tags,
+            generator=get_default_generator(),
+            discover_target_info=False,
+            base_seed=None,
+        )
+        await scan_run.wait_for_completion()
+        scan_result = scan_run.scan_result
 
         duration_ms = int((time.perf_counter() - start) * 1000)
         if scan_result is None:  # completed but produced nothing -> empty suite

--- a/libs/giskard-scan/src/giskard/scan/integrations/lidar/_adapter.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/lidar/_adapter.py
@@ -22,6 +22,37 @@ from .._shared import reject_unexpected_kwargs
 
 logger = logging.getLogger(__name__)
 
+# Lidar tags its multiturn probes (crescendo, goat, ...) with this. It is the
+# ONLY uniform signal lidar exposes for "this probe drives a multi-turn
+# conversation" — there is no shared base class or attribute to isinstance on
+# (unlike garak's IterativeProbe). We use it to drop those probes when the
+# caller declares a single-turn target. A guard test pins this string so a lidar
+# rename fails loudly instead of silently leaking multiturn probes into
+# singleturn mode. See test_lidar_singleturn.py.
+_MULTITURN_TAG = "gsk:probe-type='multi-turn'"
+
+
+def _singleturn_probe_ids(
+    probes: "list[str] | None", tags: "list[str] | None"
+) -> list[str]:
+    """Resolve the probe ids to run in single-turn mode.
+
+    Lidar's ``tags_filter`` is inclusion-only (a probe is kept if it matches
+    ANY tag), so it cannot express "exclude multiturn". Instead we resolve the
+    exact class set lidar would run for the caller's ``probes``/``tags`` filters,
+    then drop every probe carrying ``_MULTITURN_TAG``. The surviving ids are
+    passed to ``run_scan`` with ``tags_filter=None`` (the tag filter has already
+    been applied here).
+    """
+    from lidar.utils.probe_registry import ProbeRegistry
+
+    candidates = ProbeRegistry().get_probes(tags, probe_ids=probes)
+    return [
+        info.id
+        for probe_cls in candidates
+        if _MULTITURN_TAG not in (info := probe_cls.info()).tags
+    ]
+
 
 def lidar_available() -> bool:
     """Return True if the private lidar dependency is importable."""
@@ -107,10 +138,25 @@ class LidarScanAdapter:
 
         probes = kwargs.pop("probes", None)
         tags = kwargs.pop("tags", None)
-        if kwargs.pop("target_mode", None) is not None:
-            # TODO: filter out multiturn probes if target_mode is singleturn
-            logger.debug("target_mode is ignored for lidar; lidar owns turn logic.")
+        # target_mode is a scan-wide hint about the target's conversational
+        # ability. Lidar owns its own turn logic, so the only thing "singleturn"
+        # can mean here is: don't run probes that require a multi-turn exchange
+        # (crescendo, goat, ...). Those probes have no single-turn form — a
+        # 1-turn crescendo is not a valid attack — so we SKIP them, mirroring
+        # garak's IterativeProbe skip. "multiturn" (the default) runs everything.
+        target_mode = kwargs.pop("target_mode", None)
         reject_unexpected_kwargs("lidar", kwargs)
+
+        # tags_filter is applied by run_scan for the default path; in singleturn
+        # mode we resolve+filter the probe ids ourselves and pass tags_filter=None
+        # so lidar doesn't intersect the tag filter a second time.
+        tags_filter: list[str] | None = tags
+        if target_mode == "singleturn":
+            probes = _singleturn_probe_ids(probes, tags)
+            tags_filter = None
+            if not probes:
+                logger.debug("target_mode='singleturn' left no lidar probes to run.")
+                return SuiteResult(results=[], duration_ms=0)
 
         target_info = TargetInfo(
             agent_description=description,
@@ -126,7 +172,7 @@ class LidarScanAdapter:
             target=bridged,  # pyright: ignore[reportArgumentType]
             target_info=target_info,
             probe_ids=probes,
-            tags_filter=tags,
+            tags_filter=tags_filter,
             generator=get_default_generator(),
             discover_target_info=False,
             base_seed=None,

--- a/libs/giskard-scan/src/giskard/scan/integrations/lidar/_adapter.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/lidar/_adapter.py
@@ -1,6 +1,7 @@
 """Adapter that runs the private lidar scanner through Giskard scan."""
 
 import logging
+import time
 from importlib.util import find_spec
 from typing import TYPE_CHECKING
 
@@ -12,6 +13,7 @@ from giskard.checks import (
     SuiteResult,
     TestCaseResult,
     Trace,
+    get_default_generator,
 )
 
 if TYPE_CHECKING:
@@ -79,7 +81,43 @@ def _severity_label(severity: object) -> "str | None":
 
 
 class LidarScanAdapter:
-    """Build and run a Giskard suite from a lidar scan. Filled in by later tasks."""
+    """Build and run a Giskard suite from a lidar scan."""
+
+    async def run(self, target, **kwargs) -> SuiteResult:
+        _require_lidar()
+        from lidar import run_scan
+
+        from ._target import ScanTargetGenerator
+
+        probes = kwargs.pop("probes", None)
+        tags = kwargs.pop("tags", None)
+        if kwargs.pop("target_mode", None) is not None:
+            logger.debug("target_mode is ignored for lidar; lidar owns turn logic.")
+
+        bridged = ScanTargetGenerator(target=target)
+        start = time.perf_counter()
+        try:
+            # run_scan returns a ScanRun immediately (the scan runs in the background);
+            # await wait_for_completion() to block, then read .scan_result off it.
+            scan_run = await run_scan(
+                target=bridged,
+                probe_ids=probes,
+                tags_filter=tags,
+                generator=get_default_generator(),
+                discover_target_info=False,
+                base_seed=None,
+            )
+            await scan_run.wait_for_completion()
+            scan_result = scan_run.scan_result
+        except Exception as exc:  # noqa: BLE001 — total failure -> empty suite, not abort
+            logger.warning("lidar run_scan raised: %s", exc)
+            elapsed_ms = int((time.perf_counter() - start) * 1000)
+            return SuiteResult(results=[], duration_ms=elapsed_ms)
+
+        duration_ms = int((time.perf_counter() - start) * 1000)
+        if scan_result is None:  # completed but produced nothing -> empty suite
+            return SuiteResult(results=[], duration_ms=duration_ms)
+        return await self._to_suite_result(scan_result, duration_ms)
 
     async def _to_suite_result(self, scan_result, duration_ms: int) -> SuiteResult:
         scenario_results: list[ScenarioResult] = []

--- a/libs/giskard-scan/src/giskard/scan/integrations/lidar/_adapter.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/lidar/_adapter.py
@@ -84,6 +84,14 @@ class LidarScanAdapter:
     """Build and run a Giskard suite from a lidar scan."""
 
     async def run(self, target, **kwargs) -> SuiteResult:
+        """Run a lidar scan against ``target`` and return a scan SuiteResult.
+
+        Note: ``discover_target_info`` is hardcoded to False. Most lidar probes
+        depend on a discovered ``TargetInfo`` and will be reported as SKIP when it
+        is absent; those that do not need it run normally. Target discovery is left
+        off to keep runs deterministic and offline-friendly (it would otherwise
+        drive an LLM to profile the target before scanning).
+        """
         _require_lidar()
         from lidar import run_scan
 

--- a/libs/giskard-scan/src/giskard/scan/integrations/lidar/_adapter.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/lidar/_adapter.py
@@ -3,7 +3,7 @@
 import logging
 import time
 from importlib.util import find_spec
-from typing import TYPE_CHECKING
+from typing import Any
 
 from giskard.checks import (
     CheckResult,
@@ -11,17 +11,14 @@ from giskard.checks import (
     Metric,
     ScenarioResult,
     SuiteResult,
+    Target,
     TestCaseResult,
     Trace,
     get_default_generator,
 )
+from giskard.llm.types import ChatMessage
 
 from .._shared import reject_unexpected_kwargs
-
-if TYPE_CHECKING:
-    # Type-only: lidar's compat Message union. Never imported at runtime — the
-    # function only reads .role/.content, so no lidar dependency is introduced.
-    from lidar.giskard_compat import Message
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +37,7 @@ def _require_lidar() -> None:
         )
 
 
-async def _trace_from_messages(messages: "list[Message]") -> Trace:  # pyright: ignore[reportMissingTypeArgument]
+async def _trace_from_messages(messages: list[ChatMessage]) -> Trace:  # pyright: ignore[reportMissingTypeArgument]
     """Rebuild a scan Trace from a lidar attempt's flat message list.
 
     Lidar owns its own executor and hands back finished conversations, so we
@@ -85,8 +82,13 @@ def _severity_label(severity: object) -> "str | None":
 class LidarScanAdapter:
     """Build and run a Giskard suite from a lidar scan."""
 
-    async def run(
-        self, target, *, description, languages=None, **kwargs
+    async def run[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
+        self,
+        target: Target[InputType, OutputType, TraceType],
+        *,
+        description: str,
+        languages: list[str] | None = None,
+        **kwargs: Any,
     ) -> SuiteResult:
         """Run a lidar scan against ``target`` and return a scan SuiteResult.
 
@@ -106,6 +108,7 @@ class LidarScanAdapter:
         probes = kwargs.pop("probes", None)
         tags = kwargs.pop("tags", None)
         if kwargs.pop("target_mode", None) is not None:
+            # TODO: filter out multiturn probes if target_mode is singleturn
             logger.debug("target_mode is ignored for lidar; lidar owns turn logic.")
         reject_unexpected_kwargs("lidar", kwargs)
 

--- a/libs/giskard-scan/src/giskard/scan/integrations/lidar/_adapter.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/lidar/_adapter.py
@@ -2,6 +2,14 @@
 
 import logging
 from importlib.util import find_spec
+from typing import TYPE_CHECKING
+
+from giskard.checks import Interaction, Trace
+
+if TYPE_CHECKING:
+    # Type-only: lidar's compat Message union. Never imported at runtime — the
+    # function only reads .role/.content, so no lidar dependency is introduced.
+    from lidar.giskard_compat import Message
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +26,33 @@ def _require_lidar() -> None:
             "available on PyPI. Install it from git: "
             "pip install git+https://github.com/Giskard-AI/lidar.git@v0.2.7"
         )
+
+
+async def _trace_from_messages(messages: "list[Message]") -> Trace:
+    """Rebuild a scan Trace from a lidar attempt's flat message list.
+
+    Lidar owns its own executor and hands back finished conversations, so we
+    reconstruct a display trace by pairing each user turn with the assistant
+    reply that follows it. System/tool messages carry no input/output pair and
+    are skipped. A trailing user message with no reply yields outputs=None.
+    """
+    interactions: list[Interaction] = []
+    pending_input: str | None = None
+    for message in messages:
+        if message.role == "user":
+            if pending_input is not None:
+                interactions.append(Interaction(inputs=pending_input, outputs=None))
+            pending_input = message.content
+        elif message.role == "assistant":
+            if pending_input is not None:
+                interactions.append(
+                    Interaction(inputs=pending_input, outputs=message.content)
+                )
+                pending_input = None
+        # system / tool messages: no input/output pairing, skip
+    if pending_input is not None:
+        interactions.append(Interaction(inputs=pending_input, outputs=None))
+    return await Trace.from_interactions(*interactions)
 
 
 class LidarScanAdapter:

--- a/libs/giskard-scan/src/giskard/scan/integrations/lidar/_adapter.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/lidar/_adapter.py
@@ -137,9 +137,33 @@ class LidarScanAdapter:
         duration_ms = int((time.perf_counter() - start) * 1000)
         if scan_result is None:  # completed but produced nothing -> empty suite
             return SuiteResult(results=[], duration_ms=duration_ms)
-        return await self._to_suite_result(scan_result, duration_ms)
+        return await self._to_suite_result(scan_result, duration_ms, bridged)
 
-    async def _to_suite_result(self, scan_result, duration_ms: int) -> SuiteResult:
+    async def _trace_from_target_calls(self, attempt, bridged) -> Trace:  # pyright: ignore[reportMissingTypeArgument]
+        """Rebuild a scan Trace by joining lidar's per-call records to the typed
+        interactions the bridge captured.
+
+        ``attempt.target_calls`` is lidar's authoritative, ordered list of
+        ``target.complete`` calls for this attempt; each carries the ``call_id``
+        the bridge keyed its structured ``Interaction`` on. Joining on that id
+        preserves the real typed inputs/outputs instead of re-pairing flattened
+        ``attempt.messages`` strings. When the attempt made no target calls
+        (e.g. the probe errored before reaching the target), fall back to the
+        message reconstruction so a partial transcript still displays.
+        """
+        target_calls = getattr(attempt, "target_calls", None) or []
+        if not target_calls:
+            return await _trace_from_messages(attempt.messages)
+        interactions: list[Interaction] = []  # pyright: ignore[reportMissingTypeArgument]
+        for target_call in target_calls:
+            interaction = bridged._by_call_id.get(target_call.call_id)
+            if interaction is not None:
+                interactions.append(interaction)
+        return await Trace.from_interactions(*interactions)
+
+    async def _to_suite_result(
+        self, scan_result, duration_ms: int, bridged
+    ) -> SuiteResult:
         scenario_results: list[ScenarioResult] = []  # pyright: ignore[reportMissingTypeArgument]
         for execution in scan_result.results:
             probe_info = execution.probe_info
@@ -167,7 +191,9 @@ class LidarScanAdapter:
                     ScenarioResult(
                         scenario_name=f"Lidar {probe_info.name} #{attempt_idx + 1}",
                         steps=[TestCaseResult(results=[check], duration_ms=0)],
-                        final_trace=await _trace_from_messages(attempt.messages),
+                        final_trace=await self._trace_from_target_calls(
+                            attempt, bridged
+                        ),
                         tags=list(probe_info.tags),
                         duration_ms=0,
                     )

--- a/libs/giskard-scan/src/giskard/scan/integrations/lidar/_adapter.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/lidar/_adapter.py
@@ -4,7 +4,15 @@ import logging
 from importlib.util import find_spec
 from typing import TYPE_CHECKING
 
-from giskard.checks import Interaction, Trace
+from giskard.checks import (
+    CheckResult,
+    Interaction,
+    Metric,
+    ScenarioResult,
+    SuiteResult,
+    TestCaseResult,
+    Trace,
+)
 
 if TYPE_CHECKING:
     # Type-only: lidar's compat Message union. Never imported at runtime — the
@@ -55,5 +63,100 @@ async def _trace_from_messages(messages: "list[Message]") -> Trace:
     return await Trace.from_interactions(*interactions)
 
 
+_SEVERITY_SCORE = {
+    "safe": 0.0,
+    "minor": 0.33,
+    "major": 0.66,
+    "critical": 1.0,
+}
+
+
+def _severity_label(severity: object) -> "str | None":
+    """Normalize a lidar Severity enum (or None) to its string label."""
+    if severity is None:
+        return None
+    return getattr(severity, "value", str(severity))
+
+
 class LidarScanAdapter:
     """Build and run a Giskard suite from a lidar scan. Filled in by later tasks."""
+
+    async def _to_suite_result(self, scan_result, duration_ms: int) -> SuiteResult:
+        scenario_results: list[ScenarioResult] = []
+        for execution in scan_result.results:
+            probe_info = execution.probe_info
+            result = execution.result
+            # Errored / skipped probes carry no ProbeResult (result is None):
+            # surface them as a single visible error/skip scenario, don't crash.
+            if result is None:
+                check = self._execution_to_check(execution)
+                scenario_results.append(
+                    ScenarioResult(
+                        scenario_name=f"Lidar {probe_info.name}",
+                        steps=[TestCaseResult(results=[check], duration_ms=0)],
+                        # ScenarioResult.final_trace is a required Trace field
+                        # (no None allowed); an errored probe never produced any
+                        # interactions, so use an empty trace as the "no trace" value.
+                        final_trace=await Trace.from_interactions(),
+                        tags=list(probe_info.tags),
+                        duration_ms=0,
+                    )
+                )
+                continue
+            for attempt_idx, attempt in enumerate(result.attempts):
+                check = self._attempt_to_check(probe_info, attempt)
+                scenario_results.append(
+                    ScenarioResult(
+                        scenario_name=f"Lidar {probe_info.name} #{attempt_idx + 1}",
+                        steps=[TestCaseResult(results=[check], duration_ms=0)],
+                        final_trace=await _trace_from_messages(attempt.messages),
+                        tags=list(probe_info.tags),
+                        duration_ms=0,
+                    )
+                )
+        return SuiteResult(results=scenario_results, duration_ms=duration_ms)
+
+    def _execution_to_check(self, execution) -> CheckResult:
+        """Map an errored/skipped ProbeExecution (result is None) to a check."""
+        probe_info = execution.probe_info
+        details: dict[str, object] = {
+            "check_name": probe_info.name,
+            "probe_id": probe_info.id,
+        }
+        status = str(getattr(execution, "status", "")).lower()
+        message = str(execution.error) if execution.error is not None else status
+        if "skip" in status:
+            return CheckResult.skip(message=message or "skipped", details=details)
+        return CheckResult.error(message=message or "errored", details=details)
+
+    def _attempt_to_check(self, probe_info, attempt) -> CheckResult:
+        label = _severity_label(attempt.severity)
+        details: dict[str, object] = {
+            "check_name": probe_info.name,
+            "probe_id": probe_info.id,
+        }
+        if label is not None:
+            details["severity"] = label
+        # Carry lidar's per-attempt evidence dict (eval_result, objective,
+        # injected payloads, ...) so nothing the probe produced is dropped.
+        if getattr(attempt, "metadata", None):
+            details["metadata"] = dict(attempt.metadata)
+        # Only emit a metric for a severity we have a score for. An unknown
+        # severity label (e.g. lidar adds a new level) degrades gracefully to
+        # no metric rather than crashing the whole probe's scenario.
+        score = _SEVERITY_SCORE.get(label) if label is not None else None
+        metrics = (
+            [Metric(name=probe_info.name, value=score)] if score is not None else []
+        )
+
+        if attempt.error is not None:
+            return CheckResult.error(message=attempt.reason, details=details)
+        # Polarity flip: lidar "successful" means the ATTACK succeeded, which is a
+        # vulnerability => scan failure.
+        if attempt.successful:
+            return CheckResult.failure(
+                message=attempt.reason, details=details, metrics=metrics
+            )
+        return CheckResult.success(
+            message=attempt.reason, details=details, metrics=metrics
+        )

--- a/libs/giskard-scan/src/giskard/scan/integrations/lidar/_adapter.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/lidar/_adapter.py
@@ -83,17 +83,21 @@ def _severity_label(severity: object) -> "str | None":
 class LidarScanAdapter:
     """Build and run a Giskard suite from a lidar scan."""
 
-    async def run(self, target, **kwargs) -> SuiteResult:
+    async def run(
+        self, target, *, description, languages=None, **kwargs
+    ) -> SuiteResult:
         """Run a lidar scan against ``target`` and return a scan SuiteResult.
 
-        Note: ``discover_target_info`` is hardcoded to False. Most lidar probes
-        depend on a discovered ``TargetInfo`` and will be reported as SKIP when it
-        is absent; those that do not need it run normally. Target discovery is left
-        off to keep runs deterministic and offline-friendly (it would otherwise
-        drive an LLM to profile the target before scanning).
+        ``description`` and ``languages`` build the ``TargetInfo`` that lidar
+        probes read to construct their attacks. ``discover_target_info`` stays
+        False: the target profile now comes from the caller, so lidar never
+        needs to run its own discovery pass. ``agent_name`` / ``company_name`` /
+        ``competitors`` are left at their None/[] defaults; probes that read them
+        only use them as prompt-template values and degrade gracefully.
         """
         _require_lidar()
         from lidar import run_scan
+        from lidar.resources.target_info import TargetInfo
 
         from ._target import ScanTargetGenerator
 
@@ -102,6 +106,11 @@ class LidarScanAdapter:
         if kwargs.pop("target_mode", None) is not None:
             logger.debug("target_mode is ignored for lidar; lidar owns turn logic.")
 
+        target_info = TargetInfo(
+            agent_description=description,
+            languages=languages or [],
+        )
+
         bridged = ScanTargetGenerator(target=target)
         start = time.perf_counter()
         try:
@@ -109,6 +118,7 @@ class LidarScanAdapter:
             # await wait_for_completion() to block, then read .scan_result off it.
             scan_run = await run_scan(
                 target=bridged,
+                target_info=target_info,
                 probe_ids=probes,
                 tags_filter=tags,
                 generator=get_default_generator(),

--- a/libs/giskard-scan/src/giskard/scan/integrations/lidar/_adapter.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/lidar/_adapter.py
@@ -38,7 +38,7 @@ def _require_lidar() -> None:
         )
 
 
-async def _trace_from_messages(messages: "list[Message]") -> Trace:
+async def _trace_from_messages(messages: "list[Message]") -> Trace:  # pyright: ignore[reportMissingTypeArgument]
     """Rebuild a scan Trace from a lidar attempt's flat message list.
 
     Lidar owns its own executor and hands back finished conversations, so we
@@ -46,13 +46,13 @@ async def _trace_from_messages(messages: "list[Message]") -> Trace:
     reply that follows it. System/tool messages carry no input/output pair and
     are skipped. A trailing user message with no reply yields outputs=None.
     """
-    interactions: list[Interaction] = []
+    interactions: list[Interaction] = []  # pyright: ignore[reportMissingTypeArgument]
     pending_input: str | None = None
     for message in messages:
         if message.role == "user":
             if pending_input is not None:
                 interactions.append(Interaction(inputs=pending_input, outputs=None))
-            pending_input = message.content
+            pending_input = message.content  # pyright: ignore[reportAssignmentType]
         elif message.role == "assistant":
             if pending_input is not None:
                 interactions.append(
@@ -117,7 +117,7 @@ class LidarScanAdapter:
             # run_scan returns a ScanRun immediately (the scan runs in the background);
             # await wait_for_completion() to block, then read .scan_result off it.
             scan_run = await run_scan(
-                target=bridged,
+                target=bridged,  # pyright: ignore[reportArgumentType]
                 target_info=target_info,
                 probe_ids=probes,
                 tags_filter=tags,
@@ -138,7 +138,7 @@ class LidarScanAdapter:
         return await self._to_suite_result(scan_result, duration_ms)
 
     async def _to_suite_result(self, scan_result, duration_ms: int) -> SuiteResult:
-        scenario_results: list[ScenarioResult] = []
+        scenario_results: list[ScenarioResult] = []  # pyright: ignore[reportMissingTypeArgument]
         for execution in scan_result.results:
             probe_info = execution.probe_info
             result = execution.result

--- a/libs/giskard-scan/src/giskard/scan/integrations/lidar/_target.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/lidar/_target.py
@@ -44,13 +44,13 @@ class ScanTargetGenerator(BaseGenerator):
     # scan Target (often a plain function) is not JSON-serializable. A PrivateAttr is
     # excluded from model_dump, so the scan runs; model_copy(update={"middlewares":
     # ...}) still preserves it because model_copy carries private attrs over.
-    _scan_target: Target = PrivateAttr()
+    _scan_target: Target = PrivateAttr()  # pyright: ignore[reportMissingTypeArgument]
 
     # Per-thread trace cache. default_factory gives each instance its own dict
     # (not a shared mutable class-level default).
-    _threads: dict[str, Trace] = PrivateAttr(default_factory=dict)
+    _threads: dict[str, Trace] = PrivateAttr(default_factory=dict)  # pyright: ignore[reportMissingTypeArgument]
 
-    def __init__(self, target: Target, **data: Any):
+    def __init__(self, target: Target, **data: Any):  # pyright: ignore[reportMissingTypeArgument]
         super().__init__(**data)
         self._scan_target = target
 

--- a/libs/giskard-scan/src/giskard/scan/integrations/lidar/_target.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/lidar/_target.py
@@ -16,7 +16,7 @@ from giskard.agents import BaseGenerator
 # Message/Response/make_response come from lidar's compat layer — import LAZILY inside
 # _call_model (below), NOT here, so this module imports without lidar installed.
 # These ARE the workspace giskard.checks (the scan side of the bridge).
-from giskard.checks import DatasetInputGenerator, Interact, Target, Trace
+from giskard.checks import DatasetInputGenerator, Interact, Interaction, Target, Trace
 from pydantic import PrivateAttr
 
 
@@ -50,6 +50,12 @@ class ScanTargetGenerator(BaseGenerator):
     # (not a shared mutable class-level default).
     _threads: dict[str, Trace] = PrivateAttr(default_factory=dict)  # pyright: ignore[reportMissingTypeArgument]
 
+    # Structured interactions this bridge built, keyed by lidar's per-call
+    # call_id (from get_current_target_call_id()). The adapter joins
+    # attempt.target_calls back to these to rebuild a lossless display Trace,
+    # instead of reconstructing it from flattened attempt.messages.
+    _by_call_id: dict[str, Interaction] = PrivateAttr(default_factory=dict)  # pyright: ignore[reportMissingTypeArgument]
+
     def __init__(self, target: Target, **data: Any):  # pyright: ignore[reportMissingTypeArgument]
         super().__init__(**data)
         self._scan_target = target
@@ -60,7 +66,10 @@ class ScanTargetGenerator(BaseGenerator):
         params: Any = None,
         metadata: "dict[str, Any] | None" = None,
     ) -> Any:  # -> lidar.giskard_compat.Response
-        # Lazy: lidar's compat layer, only importable when lidar is installed.
+        # Lazy: lidar's compat layer + call-id side channel, only importable when
+        # lidar is installed. get_current_target_call_id() returns the in-flight
+        # call id set by lidar's TargetCallTrackingMiddleware for THIS complete().
+        from lidar.core.models.target import get_current_target_call_id
         from lidar.giskard_compat import make_response
 
         thread_id = (metadata or {}).get("thread_id") or str(uuid.uuid4())
@@ -75,6 +84,14 @@ class ScanTargetGenerator(BaseGenerator):
         )
         trace = await trace.with_interaction(interaction)
         self._threads[thread_id] = trace
+
+        # Keep the typed Interaction we just built, keyed by lidar's call_id, so
+        # the adapter can join attempt.target_calls back to it at result time and
+        # avoid reconstructing a lossy trace from flattened messages. call_id is
+        # None only outside a tracked complete() (e.g. discovery) — skip then.
+        call_id = get_current_target_call_id()
+        if call_id is not None and trace.last is not None:
+            self._by_call_id[call_id] = trace.last
 
         outputs = trace.last.outputs if trace.last is not None else None
         reply = str(outputs) if outputs is not None else ""

--- a/libs/giskard-scan/src/giskard/scan/integrations/lidar/_target.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/lidar/_target.py
@@ -1,0 +1,82 @@
+"""Bridge a giskard.scan Target into a lidar Target (a giskard.agents BaseGenerator).
+
+IMPORTANT: this module imports lidar's pinned ``giskard.agents`` (``BaseGenerator``,
+``Response``). Those symbols are NOT the giskard-oss workspace ``giskard.agents`` —
+they resolve to whatever lidar installed on sys.path. This module is therefore
+imported LAZILY (inside LidarScanAdapter.run), never at package import time, so
+`import giskard.scan.integrations.lidar` does not require lidar to be present.
+"""
+
+import uuid
+from typing import Any
+
+# Resolves to LIDAR's giskard.agents at runtime (lidar is on sys.path when this runs).
+# BaseGenerator is the workspace giskard.agents type — always importable, no lidar needed.
+from giskard.agents import BaseGenerator
+
+# Message/Response/make_response come from lidar's compat layer — import LAZILY inside
+# _call_model (below), NOT here, so this module imports without lidar installed.
+# These ARE the workspace giskard.checks (the scan side of the bridge).
+from giskard.checks import DatasetInputGenerator, Interact, Target, Trace
+from pydantic import PrivateAttr
+
+
+class ScanTargetGenerator(BaseGenerator):
+    """Presents a scan Target to lidar as a lidar Target.
+
+    Subclasses lidar's BaseGenerator (Pydantic) so it satisfies lidar's
+    runtime_checkable Target protocol, which the scanner probes with isinstance
+    and calls model_copy(update={"middlewares": ...}) / model_dump on. A plain
+    wrapper cannot satisfy that; a BaseGenerator subclass gets those for free.
+
+    Statefulness via thread_id round-trip (mirrors the app's HubTarget):
+    multiturn probes negotiate session state through Response.metadata["thread_id"].
+    We keep one accumulating scan Trace per thread_id in ``_threads`` and always
+    return the thread_id, so the probe can send only the latest turn next time and
+    still have the Target driven with full accumulated context. This mirrors garak's
+    TargetGenerator.internal_cache, keyed on metadata["thread_id"] instead of
+    Message.notes["uuid"].
+    """
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    scan_target: Target
+
+    # Private (leading underscore) pydantic attr for the per-thread trace cache.
+    # default_factory ensures each instance gets its own dict (not a shared mutable
+    # class-level default).
+    _threads: dict[str, Trace] = PrivateAttr(default_factory=dict)
+
+    def __init__(self, target: Target, **data: Any):
+        super().__init__(scan_target=target, **data)
+
+    async def _call_model(
+        self,
+        messages: Any,
+        params: Any = None,
+        metadata: "dict[str, Any] | None" = None,
+    ) -> Any:  # -> lidar.giskard_compat.Response
+        # Lazy: lidar's compat layer, only importable when lidar is installed.
+        from lidar.giskard_compat import make_response
+
+        thread_id = (metadata or {}).get("thread_id") or str(uuid.uuid4())
+        # Accumulated trace for this thread (empty on first turn). Trace is frozen,
+        # so with_interaction returns a NEW trace we write back under the same key.
+        trace = self._threads.get(thread_id) or Trace.for_target(self.scan_target)
+
+        text = messages[-1].content if messages else ""
+        interaction = Interact(
+            inputs=DatasetInputGenerator(prompt=text),
+            outputs=self.scan_target,
+        )
+        trace = await trace.with_interaction(interaction)
+        self._threads[thread_id] = trace
+
+        outputs = trace.last.outputs if trace.last is not None else None
+        reply = str(outputs) if outputs is not None else ""
+        # Round-trip the thread_id so the probe threads subsequent turns.
+        # make_response builds a lidar.giskard_compat.Response (subclass of
+        # giskard's CompletionResponse) that carries a settable .metadata dict.
+        return make_response(
+            role="assistant", content=reply, metadata={"thread_id": thread_id}
+        )

--- a/libs/giskard-scan/src/giskard/scan/integrations/lidar/_target.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/lidar/_target.py
@@ -1,16 +1,15 @@
 """Bridge a giskard.scan Target into a lidar Target (a giskard.agents BaseGenerator).
 
-IMPORTANT: this module imports lidar's pinned ``giskard.agents`` (``BaseGenerator``,
-``Response``). Those symbols are NOT the giskard-oss workspace ``giskard.agents`` —
-they resolve to whatever lidar installed on sys.path. This module is therefore
-imported LAZILY (inside LidarScanAdapter.run), never at package import time, so
-`import giskard.scan.integrations.lidar` does not require lidar to be present.
+``BaseGenerator`` is the workspace ``giskard.agents`` type and is imported eagerly
+(no lidar needed). lidar's compat types (``make_response``) are imported LAZILY
+inside ``_call_model`` so ``import giskard.scan.integrations.lidar`` works without
+lidar installed. lidar adapts the workspace ``giskard.agents`` via its own
+``giskard_compat`` layer — there is no second copy of ``giskard.agents``.
 """
 
 import uuid
 from typing import Any
 
-# Resolves to LIDAR's giskard.agents at runtime (lidar is on sys.path when this runs).
 # BaseGenerator is the workspace giskard.agents type — always importable, no lidar needed.
 from giskard.agents import BaseGenerator
 
@@ -40,15 +39,20 @@ class ScanTargetGenerator(BaseGenerator):
 
     model_config = {"arbitrary_types_allowed": True}
 
-    scan_target: Target
+    # The scan Target is a PRIVATE attr, not a pydantic field: lidar's scanner
+    # serializes the generator via model_dump(mode="json") for run metadata, and a
+    # scan Target (often a plain function) is not JSON-serializable. A PrivateAttr is
+    # excluded from model_dump, so the scan runs; model_copy(update={"middlewares":
+    # ...}) still preserves it because model_copy carries private attrs over.
+    _scan_target: Target = PrivateAttr()
 
-    # Private (leading underscore) pydantic attr for the per-thread trace cache.
-    # default_factory ensures each instance gets its own dict (not a shared mutable
-    # class-level default).
+    # Per-thread trace cache. default_factory gives each instance its own dict
+    # (not a shared mutable class-level default).
     _threads: dict[str, Trace] = PrivateAttr(default_factory=dict)
 
     def __init__(self, target: Target, **data: Any):
-        super().__init__(scan_target=target, **data)
+        super().__init__(**data)
+        self._scan_target = target
 
     async def _call_model(
         self,
@@ -62,12 +66,12 @@ class ScanTargetGenerator(BaseGenerator):
         thread_id = (metadata or {}).get("thread_id") or str(uuid.uuid4())
         # Accumulated trace for this thread (empty on first turn). Trace is frozen,
         # so with_interaction returns a NEW trace we write back under the same key.
-        trace = self._threads.get(thread_id) or Trace.for_target(self.scan_target)
+        trace = self._threads.get(thread_id) or Trace.for_target(self._scan_target)
 
         text = messages[-1].content if messages else ""
         interaction = Interact(
             inputs=DatasetInputGenerator(prompt=text),
-            outputs=self.scan_target,
+            outputs=self._scan_target,
         )
         trace = await trace.with_interaction(interaction)
         self._threads[thread_id] = trace

--- a/libs/giskard-scan/src/giskard/scan/utils/knowledge_base.py
+++ b/libs/giskard-scan/src/giskard/scan/utils/knowledge_base.py
@@ -143,7 +143,7 @@ class KnowledgeBase(WithEmbeddingMixin):
             raise ValueError("Query embedding must be a 1D vector")
         if not np.all(np.isfinite(query_vector)):
             raise ValueError("Query embedding must not contain non-finite values")
-        query_norm = np.linalg.norm(query_vector)
+        query_norm = float(np.linalg.norm(query_vector))
         if query_norm == 0:
             raise ValueError("Query embedding must not be a zero vector")
 

--- a/libs/giskard-scan/tests/integrations/garak/test_garak_run.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_garak_run.py
@@ -222,8 +222,8 @@ async def test_third_party_scan_rejects_unknown_tool(target) -> None:
     with pytest.raises(ValueError, match="Unknown tool"):
         await third_party_scan(
             target,
-            tool="nope",
-            description="A test agent",  # pyright: ignore[reportArgumentType]
+            tool="nope",  # pyright: ignore[reportArgumentType]
+            description="A test agent",
         )
 
 

--- a/libs/giskard-scan/tests/integrations/garak/test_garak_run.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_garak_run.py
@@ -209,7 +209,7 @@ async def test_third_party_scan_routes_to_garak_adapter(
         detectors=[_FakeDetector(score=0.9)],
     )
 
-    result = await third_party_scan(target, tool="garak")
+    result = await third_party_scan(target, tool="garak", description="A test agent")
 
     assert isinstance(result, SuiteResult)
     assert len(result.results) == 1
@@ -220,7 +220,18 @@ async def test_third_party_scan_rejects_unknown_tool(target) -> None:
     from giskard.scan.integrations import third_party_scan
 
     with pytest.raises(ValueError, match="Unknown tool"):
-        await third_party_scan(target, tool="nope")  # pyright: ignore[reportArgumentType]
+        await third_party_scan(
+            target,
+            tool="nope",
+            description="A test agent",  # pyright: ignore[reportArgumentType]
+        )
+
+
+async def test_third_party_scan_requires_description(target) -> None:
+    from giskard.scan.integrations import third_party_scan
+
+    with pytest.raises(TypeError):
+        await third_party_scan(target, tool="garak")  # pyright: ignore[reportCallIssue]
 
 
 async def test_run_marks_missing_detector_scores_as_skip(

--- a/libs/giskard-scan/tests/integrations/garak/test_garak_run.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_garak_run.py
@@ -197,6 +197,18 @@ async def test_run_with_no_probes_returns_empty_suite(
     assert result.results == []
 
 
+async def test_run_rejects_unexpected_kwargs(
+    monkeypatch: pytest.MonkeyPatch, target
+) -> None:
+    # A typo'd option (e.g. probe vs probes) must raise, not be silently dropped.
+    adapter_cls = _patch_resolvers(
+        monkeypatch, probes=[], detectors=[_FakeDetector(score=0.1)]
+    )
+
+    with pytest.raises(TypeError, match="probe"):
+        await adapter_cls().run(target=target, probe=["x"])
+
+
 async def test_third_party_scan_routes_to_garak_adapter(
     monkeypatch: pytest.MonkeyPatch, target
 ) -> None:

--- a/libs/giskard-scan/tests/integrations/lidar/test_lidar_capture.py
+++ b/libs/giskard-scan/tests/integrations/lidar/test_lidar_capture.py
@@ -41,7 +41,9 @@ async def test_bridge_captures_interaction_by_call_id():
     # The tracking middleware attaches the TargetCall (with its call_id) to the
     # returned response; the bridge must have stored the built Interaction under
     # that same call_id.
-    call_id = response._target_call.call_id
+    # response is lidar's Response subclass at runtime (it carries the sidecar);
+    # statically it's typed as the base CompletionResponse, hence the ignore.
+    call_id = response._target_call.call_id  # pyright: ignore[reportAttributeAccessIssue]
     assert call_id in bridge._by_call_id
     interaction = bridge._by_call_id[call_id]
     assert isinstance(interaction, Interaction)
@@ -57,8 +59,8 @@ async def test_bridge_captures_each_turn_of_a_multiturn_call():
     for i in range(3):
         history.append(make_message(role="user", content=f"turn {i}"))
         response = await bridge.complete(history)
-        history.append(response.message)
-        call_ids.append(response._target_call.call_id)
+        history.append(response.message)  # pyright: ignore[reportAttributeAccessIssue]
+        call_ids.append(response._target_call.call_id)  # pyright: ignore[reportAttributeAccessIssue]
 
     assert len(set(call_ids)) == 3  # distinct call per turn
     for i, call_id in enumerate(call_ids):
@@ -87,8 +89,8 @@ async def test_structured_round_trip_through_model_copy():
     for i in range(2):
         history.append(make_message(role="user", content=f"input {i}"))
         response = await tracked.complete(history)
-        history.append(response.message)
-        call_ids.append(response._target_call.call_id)
+        history.append(response.message)  # pyright: ignore[reportAttributeAccessIssue]
+        call_ids.append(response._target_call.call_id)  # pyright: ignore[reportAttributeAccessIssue]
 
     # Verify the shared-dict invariant: original and copy share _by_call_id.
     assert bridge._by_call_id is tracked._by_call_id, (

--- a/libs/giskard-scan/tests/integrations/lidar/test_lidar_capture.py
+++ b/libs/giskard-scan/tests/integrations/lidar/test_lidar_capture.py
@@ -1,0 +1,62 @@
+import pytest
+
+# Real lidar types; skip the module when lidar is absent (dir has no __init__.py).
+pytest.importorskip("lidar")
+
+from giskard.checks import Interaction  # noqa: E402
+from giskard.scan.integrations.lidar._target import ScanTargetGenerator  # noqa: E402
+from lidar.core.models.target import (  # noqa: E402
+    TargetCallTrackingMiddleware,
+    TargetErrorMiddleware,
+)
+from lidar.giskard_compat import make_message  # noqa: E402
+
+
+def _refusing_target(inputs: str) -> str:
+    return "I cannot help with that."
+
+
+def _with_tracking(bridge: ScanTargetGenerator) -> ScanTargetGenerator:
+    # Mirror lidar's scanner: append its tracking + error middleware so
+    # get_current_target_call_id() is set around each complete() call.
+    return bridge.model_copy(
+        update={
+            "middlewares": [
+                *bridge.middlewares,
+                TargetCallTrackingMiddleware(),
+                TargetErrorMiddleware(),
+            ]
+        }
+    )
+
+
+async def test_bridge_captures_interaction_by_call_id():
+    bridge = _with_tracking(ScanTargetGenerator(target=_refusing_target))
+
+    response = await bridge.complete([make_message(role="user", content="hi")])
+
+    # The tracking middleware attaches the TargetCall (with its call_id) to the
+    # returned response; the bridge must have stored the built Interaction under
+    # that same call_id.
+    call_id = response._target_call.call_id
+    assert call_id in bridge._by_call_id
+    interaction = bridge._by_call_id[call_id]
+    assert isinstance(interaction, Interaction)
+    assert interaction.inputs == "hi"
+    assert interaction.outputs == "I cannot help with that."
+
+
+async def test_bridge_captures_each_turn_of_a_multiturn_call():
+    bridge = _with_tracking(ScanTargetGenerator(target=_refusing_target))
+
+    history = []
+    call_ids = []
+    for i in range(3):
+        history.append(make_message(role="user", content=f"turn {i}"))
+        response = await bridge.complete(history)
+        history.append(response.message)
+        call_ids.append(response._target_call.call_id)
+
+    assert len(set(call_ids)) == 3  # distinct call per turn
+    for i, call_id in enumerate(call_ids):
+        assert bridge._by_call_id[call_id].inputs == f"turn {i}"

--- a/libs/giskard-scan/tests/integrations/lidar/test_lidar_capture.py
+++ b/libs/giskard-scan/tests/integrations/lidar/test_lidar_capture.py
@@ -1,9 +1,12 @@
+from dataclasses import dataclass
+
 import pytest
 
 # Real lidar types; skip the module when lidar is absent (dir has no __init__.py).
 pytest.importorskip("lidar")
 
 from giskard.checks import Interaction  # noqa: E402
+from giskard.scan.integrations.lidar._adapter import LidarScanAdapter  # noqa: E402
 from giskard.scan.integrations.lidar._target import ScanTargetGenerator  # noqa: E402
 from lidar.core.models.target import (  # noqa: E402
     TargetCallTrackingMiddleware,
@@ -60,3 +63,65 @@ async def test_bridge_captures_each_turn_of_a_multiturn_call():
     assert len(set(call_ids)) == 3  # distinct call per turn
     for i, call_id in enumerate(call_ids):
         assert bridge._by_call_id[call_id].inputs == f"turn {i}"
+
+
+async def test_structured_round_trip_through_model_copy():
+    """Test that _trace_from_target_calls rebuilds interactions from the shared dict.
+
+    This test composes the two REAL halves of the integration:
+    1. Bridge captures typed Interaction objects via model_copy's shared _by_call_id
+    2. Adapter rebuilds a Trace by joining attempt.target_calls to those interactions
+
+    The critical invariant: the adapter must return the SAME Interaction objects
+    (identity, not reconstruction), proving that the pydantic v2 shallow-copy of
+    __pydantic_private__ correctly shares the dict between the model_copy and the
+    original bridged instance.
+    """
+    # Create bridge with tracking middleware; model_copy shares the _by_call_id dict.
+    bridge = ScanTargetGenerator(target=_refusing_target)
+    tracked = _with_tracking(bridge)
+
+    # Drive two turns and collect call_ids in order.
+    history = []
+    call_ids = []
+    for i in range(2):
+        history.append(make_message(role="user", content=f"input {i}"))
+        response = await tracked.complete(history)
+        history.append(response.message)
+        call_ids.append(response._target_call.call_id)
+
+    # Verify the shared-dict invariant: original and copy share _by_call_id.
+    assert bridge._by_call_id is tracked._by_call_id, (
+        "model_copy must preserve __pydantic_private__ reference, not deep-copy"
+    )
+
+    # Build a minimal fake attempt with target_calls (each carrying call_id) and messages.
+    @dataclass(frozen=True)
+    class FakeTargetCall:
+        call_id: str
+
+    class FakeAttempt:
+        def __init__(self, target_calls, messages):
+            self.target_calls = target_calls
+            self.messages = messages
+
+    fake_target_calls = [FakeTargetCall(cid) for cid in call_ids]
+    attempt = FakeAttempt(target_calls=fake_target_calls, messages=[])
+
+    # Call the adapter's method to rebuild the trace.
+    adapter = LidarScanAdapter()
+    trace = await adapter._trace_from_target_calls(attempt, tracked)
+
+    # Assert the rebuilt trace contains exactly the typed Interaction objects
+    # captured by the bridge, not reconstructions.
+    assert len(trace.interactions) == 2
+    for i, call_id in enumerate(call_ids):
+        expected_interaction = tracked._by_call_id[call_id]
+        actual_interaction = trace.interactions[i]
+        # Identity assertion: must be the SAME object, not a copy.
+        assert actual_interaction is expected_interaction, (
+            f"Interaction {i} must be the same object; model_copy's dict sharing broke"
+        )
+        # Sanity check on content.
+        assert actual_interaction.inputs == f"input {i}"
+        assert actual_interaction.outputs == "I cannot help with that."

--- a/libs/giskard-scan/tests/integrations/lidar/test_lidar_e2e.py
+++ b/libs/giskard-scan/tests/integrations/lidar/test_lidar_e2e.py
@@ -1,13 +1,9 @@
 """End-to-end functional tests that drive a real lidar scan through the bridge.
 
 The offline test exercises the whole chain (bridge -> lidar scanner -> result
-mapping) without an LLM key: with ``discover_target_info=False`` lidar reports
-the probe as SKIP, but the scan still runs and produces a valid ``SuiteResult``
-with a rebuilt trace, which is what this test asserts.
-
-The key-gated test enables target discovery and asserts a real probe verdict; it
-runs only where an OpenAI key is available (lidar drives an LLM to profile the
-target and to judge attempts).
+mapping) and asserts a valid ``SuiteResult`` is produced. The key-gated test
+supplies a description, so the probe gets a real ``TargetInfo`` and runs online,
+yielding a genuine PASS/FAIL/ERROR verdict rather than a SKIP.
 """
 
 import os
@@ -21,7 +17,6 @@ from giskard.scan.integrations.lidar import LidarScanAdapter  # noqa: E402
 
 pytestmark = pytest.mark.functional
 
-# A cheap, deterministic static-payload probe; keeps runs fast and offline.
 _PROBE = "deepset-injection:1.0"
 
 
@@ -31,11 +26,12 @@ def _refusing_target(inputs: str) -> str:
 
 
 async def test_lidar_scan_runs_end_to_end_and_returns_suite_result():
-    # Runs offline. With discovery off the probe SKIPs, but the bridge, the
-    # scanner round-trip, and the result mapping all execute for real.
+    # Runs offline. The bridge, scanner round-trip, and result mapping all
+    # execute for real; assert a valid SuiteResult is produced.
     suite = await LidarScanAdapter().run(
         _refusing_target,
-        description="A customer-support bot",
+        description="A helpful assistant",
+        languages=["en"],
         probes=[_PROBE],
         tags=None,
     )
@@ -43,8 +39,6 @@ async def test_lidar_scan_runs_end_to_end_and_returns_suite_result():
     assert suite.results, "expected at least one scenario for the requested probe"
     for scenario in suite.results:
         assert scenario.scenario_name.startswith("Lidar ")
-        # final_trace is a required field on ScenarioResult; the bridge always
-        # supplies one (rebuilt from the attempt, or an empty Trace).
         assert scenario.final_trace is not None
         check = scenario.steps[0].results[0]
         assert check.details["check_name"]
@@ -53,21 +47,21 @@ async def test_lidar_scan_runs_end_to_end_and_returns_suite_result():
 
 @pytest.mark.skipif(
     not os.getenv("OPENAI_API_KEY"),
-    reason="lidar target discovery + judge need an OpenAI key",
+    reason="lidar probe + judge need an OpenAI key for a real verdict",
 )
-async def test_lidar_scan_with_discovery_produces_a_verdict():
-    # With a key present, target discovery succeeds and the probe actually runs,
-    # yielding a real PASS/FAIL/ERROR verdict rather than a SKIP.
-    adapter = LidarScanAdapter()
-    suite = await adapter.run(
+async def test_lidar_scan_with_description_produces_a_verdict():
+    # With a key present the probe runs online against a real TargetInfo built
+    # from the description, yielding a real PASS/FAIL/ERROR verdict (not SKIP).
+    suite = await LidarScanAdapter().run(
         _refusing_target,
-        description="A customer-support bot",
+        description="A customer-support assistant for ACME Corp",
+        languages=["en"],
         probes=[_PROBE],
         tags=None,
     )
     assert isinstance(suite, SuiteResult)
     assert suite.results
     statuses = [s.steps[0].results[0] for s in suite.results]
-    # At least one attempt produced a non-skip verdict (the refusing target
-    # should mostly pass, but we only assert the chain reached a real verdict).
-    assert any(c.passed or c.failed or c.errored for c in statuses)
+    assert any(c.passed or c.failed or c.errored for c in statuses), (
+        "expected a real verdict, got only skips"
+    )

--- a/libs/giskard-scan/tests/integrations/lidar/test_lidar_e2e.py
+++ b/libs/giskard-scan/tests/integrations/lidar/test_lidar_e2e.py
@@ -33,7 +33,12 @@ def _refusing_target(inputs: str) -> str:
 async def test_lidar_scan_runs_end_to_end_and_returns_suite_result():
     # Runs offline. With discovery off the probe SKIPs, but the bridge, the
     # scanner round-trip, and the result mapping all execute for real.
-    suite = await LidarScanAdapter().run(_refusing_target, probes=[_PROBE], tags=None)
+    suite = await LidarScanAdapter().run(
+        _refusing_target,
+        description="A customer-support bot",
+        probes=[_PROBE],
+        tags=None,
+    )
     assert isinstance(suite, SuiteResult)
     assert suite.results, "expected at least one scenario for the requested probe"
     for scenario in suite.results:
@@ -54,7 +59,12 @@ async def test_lidar_scan_with_discovery_produces_a_verdict():
     # With a key present, target discovery succeeds and the probe actually runs,
     # yielding a real PASS/FAIL/ERROR verdict rather than a SKIP.
     adapter = LidarScanAdapter()
-    suite = await adapter.run(_refusing_target, probes=[_PROBE], tags=None)
+    suite = await adapter.run(
+        _refusing_target,
+        description="A customer-support bot",
+        probes=[_PROBE],
+        tags=None,
+    )
     assert isinstance(suite, SuiteResult)
     assert suite.results
     statuses = [s.steps[0].results[0] for s in suite.results]

--- a/libs/giskard-scan/tests/integrations/lidar/test_lidar_e2e.py
+++ b/libs/giskard-scan/tests/integrations/lidar/test_lidar_e2e.py
@@ -1,0 +1,63 @@
+"""End-to-end functional tests that drive a real lidar scan through the bridge.
+
+The offline test exercises the whole chain (bridge -> lidar scanner -> result
+mapping) without an LLM key: with ``discover_target_info=False`` lidar reports
+the probe as SKIP, but the scan still runs and produces a valid ``SuiteResult``
+with a rebuilt trace, which is what this test asserts.
+
+The key-gated test enables target discovery and asserts a real probe verdict; it
+runs only where an OpenAI key is available (lidar drives an LLM to profile the
+target and to judge attempts).
+"""
+
+import os
+
+import pytest
+
+pytest.importorskip("lidar")
+
+from giskard.checks import SuiteResult  # noqa: E402
+from giskard.scan.integrations.lidar import LidarScanAdapter  # noqa: E402
+
+pytestmark = pytest.mark.functional
+
+# A cheap, deterministic static-payload probe; keeps runs fast and offline.
+_PROBE = "deepset-injection:1.0"
+
+
+def _refusing_target(inputs: str) -> str:
+    """Minimal scan Target: a plain function that refuses every input."""
+    return "I cannot help with that."
+
+
+async def test_lidar_scan_runs_end_to_end_and_returns_suite_result():
+    # Runs offline. With discovery off the probe SKIPs, but the bridge, the
+    # scanner round-trip, and the result mapping all execute for real.
+    suite = await LidarScanAdapter().run(_refusing_target, probes=[_PROBE], tags=None)
+    assert isinstance(suite, SuiteResult)
+    assert suite.results, "expected at least one scenario for the requested probe"
+    for scenario in suite.results:
+        assert scenario.scenario_name.startswith("Lidar ")
+        # final_trace is a required field on ScenarioResult; the bridge always
+        # supplies one (rebuilt from the attempt, or an empty Trace).
+        assert scenario.final_trace is not None
+        check = scenario.steps[0].results[0]
+        assert check.details["check_name"]
+        assert check.details["probe_id"]
+
+
+@pytest.mark.skipif(
+    not os.getenv("OPENAI_API_KEY"),
+    reason="lidar target discovery + judge need an OpenAI key",
+)
+async def test_lidar_scan_with_discovery_produces_a_verdict():
+    # With a key present, target discovery succeeds and the probe actually runs,
+    # yielding a real PASS/FAIL/ERROR verdict rather than a SKIP.
+    adapter = LidarScanAdapter()
+    suite = await adapter.run(_refusing_target, probes=[_PROBE], tags=None)
+    assert isinstance(suite, SuiteResult)
+    assert suite.results
+    statuses = [s.steps[0].results[0] for s in suite.results]
+    # At least one attempt produced a non-skip verdict (the refusing target
+    # should mostly pass, but we only assert the chain reached a real verdict).
+    assert any(c.passed or c.failed or c.errored for c in statuses)

--- a/libs/giskard-scan/tests/integrations/lidar/test_lidar_guard.py
+++ b/libs/giskard-scan/tests/integrations/lidar/test_lidar_guard.py
@@ -1,0 +1,18 @@
+import pytest
+from giskard.scan.integrations.lidar import _adapter
+
+
+def test_require_lidar_raises_private_message(monkeypatch):
+    monkeypatch.setattr(_adapter, "find_spec", lambda name: None)
+    with pytest.raises(ImportError) as exc_info:
+        _adapter._require_lidar()
+    message = str(exc_info.value)
+    assert "private" in message.lower()
+    assert "git+https://github.com/Giskard-AI/lidar.git@v0.2.7" in message
+
+
+def test_lidar_available_reflects_find_spec(monkeypatch):
+    monkeypatch.setattr(_adapter, "find_spec", lambda name: object())
+    assert _adapter.lidar_available() is True
+    monkeypatch.setattr(_adapter, "find_spec", lambda name: None)
+    assert _adapter.lidar_available() is False

--- a/libs/giskard-scan/tests/integrations/lidar/test_lidar_mapping.py
+++ b/libs/giskard-scan/tests/integrations/lidar/test_lidar_mapping.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import Any
 
 import pytest
 
@@ -33,16 +34,16 @@ class FakeProbeInfo:
 @dataclass
 class FakeAttempt:
     successful: bool
-    messages: list = field(default_factory=list)
+    messages: list[Any] = field(default_factory=list)
     severity: object = None
     reason: str = ""
     error: object = None
-    metadata: dict = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
 class FakeResult:
-    attempts: list
+    attempts: list[Any]
 
 
 @dataclass
@@ -55,7 +56,7 @@ class FakeProbeExecution:
 
 @dataclass
 class FakeScanResult:
-    results: list
+    results: list[Any]
 
 
 def _msgs():

--- a/libs/giskard-scan/tests/integrations/lidar/test_lidar_mapping.py
+++ b/libs/giskard-scan/tests/integrations/lidar/test_lidar_mapping.py
@@ -16,7 +16,7 @@ from lidar.giskard_compat import make_message  # noqa: E402
 
 
 class _EmptyBridge:
-    _by_call_id: dict = {}
+    _by_call_id: dict[str, object] = {}
 
 
 # ProbeExecution / ProbeInfo / Attempt are still faked (hard to construct, like

--- a/libs/giskard-scan/tests/integrations/lidar/test_lidar_mapping.py
+++ b/libs/giskard-scan/tests/integrations/lidar/test_lidar_mapping.py
@@ -283,6 +283,42 @@ async def test_multiple_attempts_yield_numbered_scenarios():
     assert names == ["Lidar X #1", "Lidar X #2"]
 
 
+async def test_run_builds_target_info_from_description(monkeypatch):
+    from giskard.scan.integrations.lidar import LidarScanAdapter
+
+    captured = {}
+
+    class _FakeScanRun:
+        scan_result = None
+
+        async def wait_for_completion(self):
+            return None
+
+    async def fake_run_scan(**kwargs):
+        captured.update(kwargs)
+        return _FakeScanRun()
+
+    # run_scan is imported inside run() via `from lidar import run_scan`,
+    # so patch it on the lidar module.
+    import lidar
+
+    monkeypatch.setattr(lidar, "run_scan", fake_run_scan)
+
+    def _target(inputs: str) -> str:
+        return "ok"
+
+    await LidarScanAdapter().run(
+        _target, description="A customer-support bot for ACME", languages=["en"]
+    )
+
+    target_info = captured["target_info"]
+    assert target_info is not None
+    assert target_info.agent_description == "A customer-support bot for ACME"
+    assert target_info.languages == ["en"]
+    # discovery stays off; context comes from the caller
+    assert captured["discover_target_info"] is False
+
+
 async def test_errored_probe_with_no_result_maps_to_error_scenario():
     # ProbeExecution with result=None (probe errored) -> one visible error
     # scenario, no crash on the missing .attempts.

--- a/libs/giskard-scan/tests/integrations/lidar/test_lidar_mapping.py
+++ b/libs/giskard-scan/tests/integrations/lidar/test_lidar_mapping.py
@@ -1,0 +1,309 @@
+from dataclasses import dataclass, field
+from enum import Enum
+
+import pytest
+
+# Match the garak tests: real lidar messages, skip the module when lidar is absent.
+pytest.importorskip("lidar")
+
+from giskard.checks import SuiteResult  # noqa: E402
+from giskard.scan.integrations.lidar._adapter import (  # noqa: E402
+    _SEVERITY_SCORE,
+    LidarScanAdapter,
+)
+from lidar.giskard_compat import make_message  # noqa: E402
+
+
+# ProbeExecution / ProbeInfo / Attempt are still faked (hard to construct, like
+# garak's _FakeProbe) — only the messages use the real lidar type via make_message.
+class Severity(str, Enum):
+    SAFE = "safe"
+    MINOR = "minor"
+    MAJOR = "major"
+    CRITICAL = "critical"
+
+
+@dataclass
+class FakeProbeInfo:
+    id: str
+    name: str
+    tags: list[str] = field(default_factory=list)
+
+
+@dataclass
+class FakeAttempt:
+    successful: bool
+    messages: list = field(default_factory=list)
+    severity: object = None
+    reason: str = ""
+    error: object = None
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass
+class FakeResult:
+    attempts: list
+
+
+@dataclass
+class FakeProbeExecution:
+    probe_info: FakeProbeInfo
+    result: object = None  # FakeResult, or None for errored/skipped probes
+    status: str = "completed"
+    error: object = None
+
+
+@dataclass
+class FakeScanResult:
+    results: list
+
+
+def _msgs():
+    return [
+        make_message(role="user", content="attack"),
+        make_message(role="assistant", content="reply"),
+    ]
+
+
+async def test_successful_attempt_maps_to_failure():
+    scan_result = FakeScanResult(
+        results=[
+            FakeProbeExecution(
+                probe_info=FakeProbeInfo(
+                    id="link-injection:1.0", name="Link Injection", tags=["injection"]
+                ),
+                result=FakeResult(
+                    attempts=[
+                        FakeAttempt(
+                            successful=True,
+                            messages=_msgs(),
+                            severity=Severity.CRITICAL,
+                            reason="leaked",
+                        ),
+                    ]
+                ),
+            )
+        ]
+    )
+    suite = await LidarScanAdapter()._to_suite_result(scan_result, duration_ms=42)
+
+    assert isinstance(suite, SuiteResult)
+    assert suite.duration_ms == 42
+    assert len(suite.results) == 1
+    scenario = suite.results[0]
+    assert scenario.scenario_name == "Lidar Link Injection #1"
+    assert scenario.tags == ["injection"]
+
+    check = scenario.steps[0].results[0]
+    assert check.failed  # attack succeeded => failure
+    assert check.message == "leaked"
+    assert check.details["check_name"] == "Link Injection"
+    assert check.details["probe_id"] == "link-injection:1.0"
+    assert check.details["severity"] == "critical"
+    assert check.metrics[0].name == "Link Injection"
+    assert check.metrics[0].value == _SEVERITY_SCORE["critical"]
+
+
+async def test_unsuccessful_attempt_maps_to_success():
+    scan_result = FakeScanResult(
+        results=[
+            FakeProbeExecution(
+                probe_info=FakeProbeInfo(id="pii-leak:1.0", name="PII Leak"),
+                result=FakeResult(
+                    attempts=[
+                        FakeAttempt(
+                            successful=False,
+                            messages=_msgs(),
+                            severity=Severity.SAFE,
+                            reason="held",
+                        ),
+                    ]
+                ),
+            )
+        ]
+    )
+    suite = await LidarScanAdapter()._to_suite_result(scan_result, duration_ms=1)
+    check = suite.results[0].steps[0].results[0]
+    assert check.passed
+
+
+async def test_errored_attempt_maps_to_error():
+    scan_result = FakeScanResult(
+        results=[
+            FakeProbeExecution(
+                probe_info=FakeProbeInfo(id="x:1.0", name="X"),
+                result=FakeResult(
+                    attempts=[
+                        FakeAttempt(
+                            successful=False,
+                            messages=[],
+                            severity=None,
+                            reason="boom",
+                            error=object(),
+                        ),
+                    ]
+                ),
+            )
+        ]
+    )
+    suite = await LidarScanAdapter()._to_suite_result(scan_result, duration_ms=1)
+    check = suite.results[0].steps[0].results[0]
+    assert check.errored
+
+
+async def test_none_severity_omits_metric_and_label():
+    scan_result = FakeScanResult(
+        results=[
+            FakeProbeExecution(
+                probe_info=FakeProbeInfo(id="x:1.0", name="X"),
+                result=FakeResult(
+                    attempts=[
+                        FakeAttempt(
+                            successful=True, messages=_msgs(), severity=None, reason="r"
+                        ),
+                    ]
+                ),
+            )
+        ]
+    )
+    suite = await LidarScanAdapter()._to_suite_result(scan_result, duration_ms=1)
+    check = suite.results[0].steps[0].results[0]
+    assert check.metrics == []
+    assert "severity" not in check.details
+
+
+async def test_unknown_severity_degrades_without_crashing():
+    # A severity label with no score in _SEVERITY_SCORE (e.g. lidar adds a new
+    # level) must not crash: the severity is still recorded, but no metric.
+    class _FutureSeverity(str, Enum):
+        BLOCKER = "blocker"
+
+    scan_result = FakeScanResult(
+        results=[
+            FakeProbeExecution(
+                probe_info=FakeProbeInfo(id="x:1.0", name="X"),
+                result=FakeResult(
+                    attempts=[
+                        FakeAttempt(
+                            successful=True,
+                            messages=_msgs(),
+                            severity=_FutureSeverity.BLOCKER,
+                            reason="r",
+                        ),
+                    ]
+                ),
+            )
+        ]
+    )
+    suite = await LidarScanAdapter()._to_suite_result(scan_result, duration_ms=1)
+    check = suite.results[0].steps[0].results[0]
+    assert check.metrics == []
+    assert check.details["severity"] == "blocker"
+
+
+async def test_attempt_metadata_carried_into_details():
+    scan_result = FakeScanResult(
+        results=[
+            FakeProbeExecution(
+                probe_info=FakeProbeInfo(id="x:1.0", name="X"),
+                result=FakeResult(
+                    attempts=[
+                        FakeAttempt(
+                            successful=True,
+                            messages=_msgs(),
+                            severity=Severity.MAJOR,
+                            reason="r",
+                            metadata={
+                                "objective": "exfiltrate",
+                                "injected_url": "http://x",
+                            },
+                        ),
+                    ]
+                ),
+            )
+        ]
+    )
+    suite = await LidarScanAdapter()._to_suite_result(scan_result, duration_ms=1)
+    check = suite.results[0].steps[0].results[0]
+    assert check.details["metadata"] == {
+        "objective": "exfiltrate",
+        "injected_url": "http://x",
+    }
+
+
+async def test_empty_metadata_omits_key():
+    scan_result = FakeScanResult(
+        results=[
+            FakeProbeExecution(
+                probe_info=FakeProbeInfo(id="x:1.0", name="X"),
+                result=FakeResult(
+                    attempts=[
+                        FakeAttempt(
+                            successful=False,
+                            messages=_msgs(),
+                            severity=Severity.SAFE,
+                            reason="r",
+                        ),
+                    ]
+                ),
+            )
+        ]
+    )
+    suite = await LidarScanAdapter()._to_suite_result(scan_result, duration_ms=1)
+    check = suite.results[0].steps[0].results[0]
+    assert "metadata" not in check.details
+
+
+async def test_multiple_attempts_yield_numbered_scenarios():
+    scan_result = FakeScanResult(
+        results=[
+            FakeProbeExecution(
+                probe_info=FakeProbeInfo(id="x:1.0", name="X"),
+                result=FakeResult(
+                    attempts=[
+                        FakeAttempt(
+                            successful=True,
+                            messages=_msgs(),
+                            severity=Severity.MAJOR,
+                            reason="1",
+                        ),
+                        FakeAttempt(
+                            successful=False,
+                            messages=_msgs(),
+                            severity=Severity.SAFE,
+                            reason="2",
+                        ),
+                    ]
+                ),
+            )
+        ]
+    )
+    suite = await LidarScanAdapter()._to_suite_result(scan_result, duration_ms=1)
+    names = [s.scenario_name for s in suite.results]
+    assert names == ["Lidar X #1", "Lidar X #2"]
+
+
+async def test_errored_probe_with_no_result_maps_to_error_scenario():
+    # ProbeExecution with result=None (probe errored) -> one visible error
+    # scenario, no crash on the missing .attempts.
+    scan_result = FakeScanResult(
+        results=[
+            FakeProbeExecution(
+                probe_info=FakeProbeInfo(id="boom:1.0", name="Boom"),
+                result=None,
+                status="errored",
+                error="probe blew up",
+            )
+        ]
+    )
+    suite = await LidarScanAdapter()._to_suite_result(scan_result, duration_ms=1)
+    assert len(suite.results) == 1
+    scenario = suite.results[0]
+    assert scenario.scenario_name == "Lidar Boom"
+    # ScenarioResult.final_trace is a required Trace (no None allowed);
+    # an errored probe never produced interactions, so expect an empty trace.
+    assert scenario.final_trace.interactions == []
+    check = scenario.steps[0].results[0]
+    assert check.errored
+    assert check.details["check_name"] == "Boom"
+    assert check.details["probe_id"] == "boom:1.0"

--- a/libs/giskard-scan/tests/integrations/lidar/test_lidar_mapping.py
+++ b/libs/giskard-scan/tests/integrations/lidar/test_lidar_mapping.py
@@ -284,7 +284,23 @@ async def test_multiple_attempts_yield_numbered_scenarios():
     assert names == ["Lidar X #1", "Lidar X #2"]
 
 
-async def test_run_builds_target_info_from_description(monkeypatch):
+@pytest.fixture
+def target():
+    def _target(inputs: str) -> str:
+        return "ok"
+
+    return _target
+
+
+def _patch_run_scan(monkeypatch, fake):
+    # run_scan is imported inside run() via `from lidar import run_scan`,
+    # so patch it on the lidar module.
+    import lidar
+
+    monkeypatch.setattr(lidar, "run_scan", fake)
+
+
+async def test_run_builds_target_info_from_description(monkeypatch, target):
     from giskard.scan.integrations.lidar import LidarScanAdapter
 
     captured = {}
@@ -299,17 +315,10 @@ async def test_run_builds_target_info_from_description(monkeypatch):
         captured.update(kwargs)
         return _FakeScanRun()
 
-    # run_scan is imported inside run() via `from lidar import run_scan`,
-    # so patch it on the lidar module.
-    import lidar
-
-    monkeypatch.setattr(lidar, "run_scan", fake_run_scan)
-
-    def _target(inputs: str) -> str:
-        return "ok"
+    _patch_run_scan(monkeypatch, fake_run_scan)
 
     await LidarScanAdapter().run(
-        _target, description="A customer-support bot for ACME", languages=["en"]
+        target, description="A customer-support bot for ACME", languages=["en"]
     )
 
     target_info = captured["target_info"]
@@ -318,6 +327,29 @@ async def test_run_builds_target_info_from_description(monkeypatch):
     assert target_info.languages == ["en"]
     # discovery stays off; context comes from the caller
     assert captured["discover_target_info"] is False
+
+
+async def test_run_propagates_run_scan_failure(monkeypatch, target):
+    # A total run_scan failure must surface, not be swallowed into an empty
+    # (falsely-passing) suite.
+    from giskard.scan.integrations.lidar import LidarScanAdapter
+
+    async def boom_run_scan(**kwargs):
+        raise RuntimeError("missing API key")
+
+    _patch_run_scan(monkeypatch, boom_run_scan)
+
+    with pytest.raises(RuntimeError, match="missing API key"):
+        await LidarScanAdapter().run(target, description="A bot")
+
+
+async def test_run_rejects_unexpected_kwargs(target):
+    # A typo'd option (e.g. probe vs probes) must raise, not be silently dropped.
+    # Raises before reaching run_scan, so no patch needed.
+    from giskard.scan.integrations.lidar import LidarScanAdapter
+
+    with pytest.raises(TypeError, match="probe"):
+        await LidarScanAdapter().run(target, description="A bot", probe=["x:1.0"])
 
 
 async def test_errored_probe_with_no_result_maps_to_error_scenario():

--- a/libs/giskard-scan/tests/integrations/lidar/test_lidar_mapping.py
+++ b/libs/giskard-scan/tests/integrations/lidar/test_lidar_mapping.py
@@ -15,6 +15,10 @@ from giskard.scan.integrations.lidar._adapter import (  # noqa: E402
 from lidar.giskard_compat import make_message  # noqa: E402
 
 
+class _EmptyBridge:
+    _by_call_id: dict = {}
+
+
 # ProbeExecution / ProbeInfo / Attempt are still faked (hard to construct, like
 # garak's _FakeProbe) — only the messages use the real lidar type via make_message.
 class Severity(str, Enum):
@@ -86,7 +90,9 @@ async def test_successful_attempt_maps_to_failure():
             )
         ]
     )
-    suite = await LidarScanAdapter()._to_suite_result(scan_result, duration_ms=42)
+    suite = await LidarScanAdapter()._to_suite_result(
+        scan_result, duration_ms=42, bridged=_EmptyBridge()
+    )
 
     assert isinstance(suite, SuiteResult)
     assert suite.duration_ms == 42
@@ -123,7 +129,9 @@ async def test_unsuccessful_attempt_maps_to_success():
             )
         ]
     )
-    suite = await LidarScanAdapter()._to_suite_result(scan_result, duration_ms=1)
+    suite = await LidarScanAdapter()._to_suite_result(
+        scan_result, duration_ms=1, bridged=_EmptyBridge()
+    )
     check = suite.results[0].steps[0].results[0]
     assert check.passed
 
@@ -147,7 +155,9 @@ async def test_errored_attempt_maps_to_error():
             )
         ]
     )
-    suite = await LidarScanAdapter()._to_suite_result(scan_result, duration_ms=1)
+    suite = await LidarScanAdapter()._to_suite_result(
+        scan_result, duration_ms=1, bridged=_EmptyBridge()
+    )
     check = suite.results[0].steps[0].results[0]
     assert check.errored
 
@@ -167,7 +177,9 @@ async def test_none_severity_omits_metric_and_label():
             )
         ]
     )
-    suite = await LidarScanAdapter()._to_suite_result(scan_result, duration_ms=1)
+    suite = await LidarScanAdapter()._to_suite_result(
+        scan_result, duration_ms=1, bridged=_EmptyBridge()
+    )
     check = suite.results[0].steps[0].results[0]
     assert check.metrics == []
     assert "severity" not in check.details
@@ -196,7 +208,9 @@ async def test_unknown_severity_degrades_without_crashing():
             )
         ]
     )
-    suite = await LidarScanAdapter()._to_suite_result(scan_result, duration_ms=1)
+    suite = await LidarScanAdapter()._to_suite_result(
+        scan_result, duration_ms=1, bridged=_EmptyBridge()
+    )
     check = suite.results[0].steps[0].results[0]
     assert check.metrics == []
     assert check.details["severity"] == "blocker"
@@ -224,7 +238,9 @@ async def test_attempt_metadata_carried_into_details():
             )
         ]
     )
-    suite = await LidarScanAdapter()._to_suite_result(scan_result, duration_ms=1)
+    suite = await LidarScanAdapter()._to_suite_result(
+        scan_result, duration_ms=1, bridged=_EmptyBridge()
+    )
     check = suite.results[0].steps[0].results[0]
     assert check.details["metadata"] == {
         "objective": "exfiltrate",
@@ -250,7 +266,9 @@ async def test_empty_metadata_omits_key():
             )
         ]
     )
-    suite = await LidarScanAdapter()._to_suite_result(scan_result, duration_ms=1)
+    suite = await LidarScanAdapter()._to_suite_result(
+        scan_result, duration_ms=1, bridged=_EmptyBridge()
+    )
     check = suite.results[0].steps[0].results[0]
     assert "metadata" not in check.details
 
@@ -279,7 +297,9 @@ async def test_multiple_attempts_yield_numbered_scenarios():
             )
         ]
     )
-    suite = await LidarScanAdapter()._to_suite_result(scan_result, duration_ms=1)
+    suite = await LidarScanAdapter()._to_suite_result(
+        scan_result, duration_ms=1, bridged=_EmptyBridge()
+    )
     names = [s.scenario_name for s in suite.results]
     assert names == ["Lidar X #1", "Lidar X #2"]
 
@@ -365,7 +385,9 @@ async def test_errored_probe_with_no_result_maps_to_error_scenario():
             )
         ]
     )
-    suite = await LidarScanAdapter()._to_suite_result(scan_result, duration_ms=1)
+    suite = await LidarScanAdapter()._to_suite_result(
+        scan_result, duration_ms=1, bridged=_EmptyBridge()
+    )
     assert len(suite.results) == 1
     scenario = suite.results[0]
     assert scenario.scenario_name == "Lidar Boom"

--- a/libs/giskard-scan/tests/integrations/lidar/test_lidar_singleturn.py
+++ b/libs/giskard-scan/tests/integrations/lidar/test_lidar_singleturn.py
@@ -1,0 +1,139 @@
+"""target_mode='singleturn' drops lidar's multi-turn probes.
+
+Lidar exposes no structural "multiturn" marker (no shared base class), so the
+adapter filters on the ``gsk:probe-type='multi-turn'`` tag. The guard test pins
+that tag string against a real multi-turn probe so a lidar rename fails loudly
+here instead of silently leaking multi-turn probes into single-turn scans.
+"""
+
+import pytest
+
+# Real lidar registry/probes; skip the module when lidar is absent.
+pytest.importorskip("lidar")
+
+from giskard.checks import SuiteResult  # noqa: E402
+from giskard.scan.integrations.lidar._adapter import (  # noqa: E402
+    _MULTITURN_TAG,
+    LidarScanAdapter,
+    _singleturn_probe_ids,
+)
+from lidar.utils.probe_registry import ProbeRegistry  # noqa: E402
+
+
+def test_multiturn_tag_still_marks_a_known_multiturn_probe():
+    # Guard: if lidar renames the tag, crescendo stops carrying _MULTITURN_TAG
+    # and this fails — surfacing the break instead of silently running crescendo
+    # under target_mode='singleturn'.
+    (crescendo,) = ProbeRegistry().get_probes(None, probe_ids=["crescendo:1.0"])
+    assert _MULTITURN_TAG in crescendo.info().tags
+
+
+def test_singleturn_drops_multiturn_probes_keeps_singleturn():
+    ids = _singleturn_probe_ids(
+        probes=["crescendo:1.0", "goat:1.0", "deepset-injection:1.0"], tags=None
+    )
+    # crescendo + goat are multi-turn -> dropped; deepset is single-turn -> kept.
+    assert ids == ["deepset-injection:1.0"]
+
+
+def test_singleturn_over_only_multiturn_probes_yields_empty():
+    ids = _singleturn_probe_ids(probes=["crescendo:1.0", "goat:1.0"], tags=None)
+    assert ids == []
+
+
+@pytest.fixture
+def target():
+    def _target(inputs: str) -> str:
+        return "ok"
+
+    return _target
+
+
+def _patch_run_scan(monkeypatch, fake):
+    import lidar
+
+    monkeypatch.setattr(lidar, "run_scan", fake)
+
+
+async def test_run_singleturn_passes_filtered_ids_and_no_tag_filter(
+    monkeypatch, target
+):
+    captured = {}
+
+    class _FakeScanRun:
+        scan_result = None
+
+        async def wait_for_completion(self):
+            return None
+
+    async def fake_run_scan(**kwargs):
+        captured.update(kwargs)
+        return _FakeScanRun()
+
+    _patch_run_scan(monkeypatch, fake_run_scan)
+
+    await LidarScanAdapter().run(
+        target,
+        description="A bot",
+        probes=["crescendo:1.0", "deepset-injection:1.0"],
+        target_mode="singleturn",
+    )
+
+    # Only the single-turn probe reaches run_scan, and the tag filter is cleared
+    # because filtering already happened during id resolution.
+    assert captured["probe_ids"] == ["deepset-injection:1.0"]
+    assert captured["tags_filter"] is None
+
+
+async def test_run_singleturn_all_multiturn_returns_empty_suite_without_scanning(
+    monkeypatch, target
+):
+    called = False
+
+    async def fake_run_scan(**kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("run_scan must not be called when no probes remain")
+
+    _patch_run_scan(monkeypatch, fake_run_scan)
+
+    suite = await LidarScanAdapter().run(
+        target,
+        description="A bot",
+        probes=["crescendo:1.0", "goat:1.0"],
+        target_mode="singleturn",
+    )
+
+    assert isinstance(suite, SuiteResult)
+    assert suite.results == []
+    assert called is False
+
+
+async def test_run_multiturn_default_passes_probes_and_tags_through(
+    monkeypatch, target
+):
+    # The default (no target_mode / "multiturn") path is unchanged: probes and
+    # tags pass straight to run_scan, no registry resolution.
+    captured = {}
+
+    class _FakeScanRun:
+        scan_result = None
+
+        async def wait_for_completion(self):
+            return None
+
+    async def fake_run_scan(**kwargs):
+        captured.update(kwargs)
+        return _FakeScanRun()
+
+    _patch_run_scan(monkeypatch, fake_run_scan)
+
+    await LidarScanAdapter().run(
+        target,
+        description="A bot",
+        probes=["crescendo:1.0"],
+        tags=["some-tag"],
+    )
+
+    assert captured["probe_ids"] == ["crescendo:1.0"]
+    assert captured["tags_filter"] == ["some-tag"]

--- a/libs/giskard-scan/tests/integrations/lidar/test_lidar_trace.py
+++ b/libs/giskard-scan/tests/integrations/lidar/test_lidar_trace.py
@@ -1,0 +1,45 @@
+import pytest
+
+# Match the garak tests: real lidar types, skip the module when lidar is absent.
+pytest.importorskip("lidar")
+
+from giskard.scan.integrations.lidar._adapter import _trace_from_messages  # noqa: E402
+from lidar.giskard_compat import make_message  # noqa: E402
+
+
+async def test_trace_pairs_user_and_assistant():
+    messages = [
+        make_message(role="user", content="hello"),
+        make_message(role="assistant", content="hi there"),
+        make_message(role="user", content="again"),
+        make_message(role="assistant", content="sure"),
+    ]
+    trace = await _trace_from_messages(messages)
+    interactions = list(trace.interactions)
+    assert len(interactions) == 2
+    assert interactions[0].inputs == "hello"
+    assert interactions[0].outputs == "hi there"
+    assert interactions[1].inputs == "again"
+    assert interactions[1].outputs == "sure"
+
+
+async def test_trace_skips_system_messages():
+    messages = [
+        make_message(role="system", content="you are a bot"),
+        make_message(role="user", content="q"),
+        make_message(role="assistant", content="a"),
+    ]
+    trace = await _trace_from_messages(messages)
+    interactions = list(trace.interactions)
+    assert len(interactions) == 1
+    assert interactions[0].inputs == "q"
+    assert interactions[0].outputs == "a"
+
+
+async def test_trace_trailing_user_has_no_output():
+    messages = [make_message(role="user", content="dangling")]
+    trace = await _trace_from_messages(messages)
+    interactions = list(trace.interactions)
+    assert len(interactions) == 1
+    assert interactions[0].inputs == "dangling"
+    assert interactions[0].outputs is None

--- a/libs/giskard-scan/tests/integrations/lidar/test_lidar_trace.py
+++ b/libs/giskard-scan/tests/integrations/lidar/test_lidar_trace.py
@@ -43,3 +43,88 @@ async def test_trace_trailing_user_has_no_output():
     assert len(interactions) == 1
     assert interactions[0].inputs == "dangling"
     assert interactions[0].outputs is None
+
+
+from dataclasses import dataclass, field  # noqa: E402
+from typing import Any  # noqa: E402
+
+from giskard.checks import Interaction  # noqa: E402
+from giskard.scan.integrations.lidar._adapter import LidarScanAdapter  # noqa: E402
+
+
+@dataclass
+class _FakeTargetCall:
+    call_id: str
+
+
+@dataclass
+class _FakeAttempt:
+    target_calls: list[Any] = field(default_factory=list)
+    messages: list[Any] = field(default_factory=list)
+
+
+class _FakeBridge:
+    def __init__(self, by_call_id):
+        self._by_call_id = by_call_id
+
+
+async def test_trace_from_target_calls_joins_in_order():
+    # Two calls; the bridge captured a typed Interaction for each. The rebuilt
+    # trace must be those exact interactions, in target_calls order.
+    i0 = Interaction(inputs="q0", outputs="a0")
+    i1 = Interaction(inputs="q1", outputs="a1")
+    bridge = _FakeBridge({"c0": i0, "c1": i1})
+    attempt = _FakeAttempt(
+        target_calls=[_FakeTargetCall("c0"), _FakeTargetCall("c1")],
+        messages=[],  # deliberately empty: proves we did NOT use messages
+    )
+    trace = await LidarScanAdapter()._trace_from_target_calls(attempt, bridge)
+    assert [it.inputs for it in trace.interactions] == ["q0", "q1"]
+    assert [it.outputs for it in trace.interactions] == ["a0", "a1"]
+
+
+async def test_trace_from_target_calls_recovers_structure_when_messages_hidden():
+    # A probe may show a sanitized transcript in messages while the real call is
+    # in target_calls; the join must recover the real structured input.
+    real = Interaction(inputs="the real payload", outputs="ok")
+    bridge = _FakeBridge({"c0": real})
+    from lidar.giskard_compat import make_message
+
+    attempt = _FakeAttempt(
+        target_calls=[_FakeTargetCall("c0")],
+        messages=[make_message(role="assistant", content="[redacted]")],
+    )
+    trace = await LidarScanAdapter()._trace_from_target_calls(attempt, bridge)
+    assert len(trace.interactions) == 1
+    assert trace.interactions[0].inputs == "the real payload"
+
+
+async def test_trace_from_target_calls_falls_back_to_messages_when_no_calls():
+    # No target_calls (probe errored before reaching the target): fall back to
+    # reconstructing from messages so partial transcripts still display.
+    from lidar.giskard_compat import make_message
+
+    bridge = _FakeBridge({})
+    attempt = _FakeAttempt(
+        target_calls=[],
+        messages=[
+            make_message(role="user", content="hello"),
+            make_message(role="assistant", content="hi"),
+        ],
+    )
+    trace = await LidarScanAdapter()._trace_from_target_calls(attempt, bridge)
+    assert len(trace.interactions) == 1
+    assert trace.interactions[0].inputs == "hello"
+    assert trace.interactions[0].outputs == "hi"
+
+
+async def test_trace_from_target_calls_skips_unknown_call_ids():
+    # A call_id the bridge never captured (should not happen, but must not crash):
+    # skip it rather than inserting a None interaction.
+    bridge = _FakeBridge({"c0": Interaction(inputs="q0", outputs="a0")})
+    attempt = _FakeAttempt(
+        target_calls=[_FakeTargetCall("c0"), _FakeTargetCall("missing")],
+        messages=[],
+    )
+    trace = await LidarScanAdapter()._trace_from_target_calls(attempt, bridge)
+    assert [it.inputs for it in trace.interactions] == ["q0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ giskard-llm = { workspace = true }
 giskard-agents = { workspace = true }
 giskard-checks = { workspace = true }
 giskard-scan = { workspace = true }
+lidar = { git = "https://github.com/Giskard-AI/lidar.git", tag = "v0.2.7" }
 
 [build-system]
 requires = ["hatchling>=1.25.0"]
@@ -108,4 +109,8 @@ dev = [
 garak-test = [
     { include-group = "test" },
     "giskard-scan[garak]",
+]
+lidar-test = [
+    { include-group = "test" },
+    "lidar",
 ]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -13,6 +13,14 @@
         "root": "libs/giskard-scan/tests/integrations/garak",
         "reportMissingImports": "none"
       },
+      {
+        "root": "libs/giskard-scan/src/giskard/scan/integrations/lidar",
+        "reportMissingImports": "none"
+      },
+      {
+        "root": "libs/giskard-scan/tests/integrations/lidar",
+        "reportMissingImports": "none"
+      },
       { "root": "libs/giskard-scan/src" },
       { "root": "libs/giskard-scan/tests" }
     ],

--- a/uv.lock
+++ b/uv.lock
@@ -686,7 +686,7 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/c1/dabe88f52c3e3760d861401bb994df08f672ec893b8f7592dc91626adcf3/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fda147a344e8eaeca0c6ff113d2851ffca8f7dfc0a6c932374ee5c47caa649c8", size = 12151019, upload-time = "2025-10-21T14:51:43.167Z" },
@@ -1182,6 +1182,13 @@ garak-test = [
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
 ]
+lidar-test = [
+    { name = "lidar" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-timeout" },
+]
 test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1219,6 +1226,13 @@ dev = [
 ]
 garak-test = [
     { name = "giskard-scan", extras = ["garak"], editable = "libs/giskard-scan" },
+    { name = "pytest", specifier = "==9.1.1" },
+    { name = "pytest-asyncio", specifier = "==1.4.0" },
+    { name = "pytest-cov", specifier = "==7.1.0" },
+    { name = "pytest-timeout", specifier = "==2.4.0" },
+]
+lidar-test = [
+    { name = "lidar", git = "https://github.com/Giskard-AI/lidar.git?tag=v0.2.7" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-asyncio", specifier = "==1.4.0" },
     { name = "pytest-cov", specifier = "==7.1.0" },
@@ -1884,6 +1898,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iso639-lang"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/5a/49bbf16d155192255e7bb37e403b2ac360144992d0d112a865afc62e457f/iso639_lang-2.6.3.tar.gz", hash = "sha256:078ddb7cd0182dcc04367691acc8022ddf7158b6cb09f08f798af823fa864265", size = 319391, upload-time = "2025-07-23T09:04:53.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/c7/f6fd3db6c33a164631c39dce2ca26a3794e3abf91b875cc99a43a5565d88/iso639_lang-2.6.3-py3-none-any.whl", hash = "sha256:a6c2fb9f739dca180dc7f48b098880f303bcce2cdf93a4ca3152ed8bbbb94fbb", size = 324990, upload-time = "2025-07-23T09:04:52.221Z" },
+]
+
+[[package]]
 name = "isort"
 version = "8.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2251,6 +2274,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl", hash = "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4", size = 120615, upload-time = "2025-07-22T11:13:31.217Z" },
+]
+
+[[package]]
+name = "lidar"
+version = "0.2.7"
+source = { git = "https://github.com/Giskard-AI/lidar.git?tag=v0.2.7#2f9a14b9f637d298750e0150c557c6714b15e56b" }
+dependencies = [
+    { name = "giskard-agents" },
+    { name = "giskard-core" },
+    { name = "giskard-llm" },
+    { name = "iso639-lang" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pydantic" },
+    { name = "relais" },
+    { name = "tenacity" },
+    { name = "tiktoken" },
+    { name = "uniseg" },
 ]
 
 [[package]]
@@ -2679,53 +2720,63 @@ wheels = [
 
 [[package]]
 name = "numpy"
-version = "2.5.0"
+version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/05/3d27272d30698dc0ecb7fdfaa41ad70303b444f81722bb99bce1d818638a/numpy-2.5.0.tar.gz", hash = "sha256:5a129578019311b6e56bdd714250f19b518f7dceeeb8d1af5490f4942d3f891c", size = 20652461, upload-time = "2026-06-21T20:57:51.95Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/0a/11486d02add7b1384dff7374d124b1cfbb0ee864dcc9f6a2c0380638cf84/numpy-2.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:489780423903667933b4ed6197b6ec3b75ea5dd17d1d8f0f38d798feb6921561", size = 16789987, upload-time = "2026-06-21T20:56:16.657Z" },
-    { url = "https://files.pythonhosted.org/packages/55/b2/285f48640a181947b4587a3766d21ec1eaa7fea833d4b49957e09da467a2/numpy-2.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ece55976ced6bca95a03ae2839e2e5ccffe8eb6a3e7022415645eb154a81e4e6", size = 11760322, upload-time = "2026-06-21T20:56:19.813Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/67/b032db1eb03ca30d16eda3b0c22aaa615338b9263c2fd559d0f29451aca4/numpy-2.5.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:c83b664b0e6eee9594fa920cf0639d8af796606d3fad6cc70180c87e4b97c7be", size = 5319605, upload-time = "2026-06-21T20:56:22.173Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/83/03fc7300c7c6b6c84c487b1dc80d322817b95fbd1f4dd57a85e23b7198de/numpy-2.5.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:bf80333980bf37f523341ddd72c783f39d6829ec7736b9eb99086388a2d52cc2", size = 6653628, upload-time = "2026-06-21T20:56:23.914Z" },
-    { url = "https://files.pythonhosted.org/packages/82/49/2ec21730bc63ccfda829323f7040a8ed4715b3852ce658689cf74ee96a8c/numpy-2.5.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1a4874217b36d5ac8fc876f52e39df56f8182c88463e9e2dceabf7ca8b7efb8", size = 15153691, upload-time = "2026-06-21T20:56:25.631Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/6b/f4a3d0637692c49da8ef99d72d52526f92e0a8d6ac4f0ca9f31441b9d9ea/numpy-2.5.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aaa760137137e8d3c920d27927748215b56014f92667dc9b6c27dfc61249255a", size = 16660066, upload-time = "2026-06-21T20:56:28.009Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/2f/c354ec86d1f3f5c19649463b0d39652e160736e5b0a4cd18dff0576715c4/numpy-2.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7174ce8265fc7f7417d171c9ea8fe905220748893ea67a2a7abe726ec331c4b0", size = 16514638, upload-time = "2026-06-21T20:56:30.26Z" },
-    { url = "https://files.pythonhosted.org/packages/06/34/43efdcb319988648580f93c11f1ae82cf7e2faa74925e98e454ae3aa95f8/numpy-2.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b8c3daaf99de52415d20b42f8e8155c78642cb04207d02f9d317a0dcf1b3fb54", size = 18419647, upload-time = "2026-06-21T20:56:32.41Z" },
-    { url = "https://files.pythonhosted.org/packages/71/e2/f5d1676b1d7fb682eb5e9a1641e7ebd2414b3216c370661d1029778908b4/numpy-2.5.0-cp312-cp312-win32.whl", hash = "sha256:6206db0af545d73d068add6d992279145f158428d1da6cc49adc4b630c5d6ee5", size = 6056688, upload-time = "2026-06-21T20:56:34.657Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/7c/48f115d1c58a34032facebcd51fdf2d02df2c51d4a46a81dd1197bb2ea6b/numpy-2.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:6f2d6873e2940c860a309d21e25b1e69af6aaffdd80aa056b04c16380db1c4f2", size = 12419237, upload-time = "2026-06-21T20:56:36.24Z" },
-    { url = "https://files.pythonhosted.org/packages/86/26/2e0882f4044d1b1a1b63e875151fb2393389032022a8b7f5657a7996d3b2/numpy-2.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:a55e1eb2bca2cfd17a16b213c99dfc8502d47b0d494224d2122277d0400935ca", size = 10339912, upload-time = "2026-06-21T20:56:38.733Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/33/07675aaad7f26ea013d5e884d9a0d784b79c6bd7566c333f5a52fa3c610b/numpy-2.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:520e6b8be0a4b65840ac8090d4f51cef4bed66e2b0894d5a520f099adc24a9b2", size = 16784890, upload-time = "2026-06-21T20:56:40.799Z" },
-    { url = "https://files.pythonhosted.org/packages/85/4b/953118a730ee3b35e28645e0eb4cf9beec5bdbb954e1ac2f5fcefba6bbc3/numpy-2.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:146b81cdd3967fdb6beca8ba25f00c58741d8f3cbd797f55af0fbe0bfec3469c", size = 11754584, upload-time = "2026-06-21T20:56:43.094Z" },
-    { url = "https://files.pythonhosted.org/packages/44/9b/56dd530c367c74ae17411027cea4135ca57e1e0583bf5594cee18bd83217/numpy-2.5.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:126b88d95e8ff9b00c9e717aa540469f21d6180162f84c0caec51b16215d49cd", size = 5313904, upload-time = "2026-06-21T20:56:45.503Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/b0/bcd672edad27ecca7da1f7bb0ce72cd1706a4f2d79ae94990afc97c13e1c/numpy-2.5.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d4313cef1594c5ce46c31b6e54e918338f63f16ee9322304e8c9114d6d81c8bd", size = 6648504, upload-time = "2026-06-21T20:56:47.567Z" },
-    { url = "https://files.pythonhosted.org/packages/80/9e/15cdfcbd30a1544a46c9e487a00df331c4672450216538705a9e51fa6710/numpy-2.5.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:750fb097caf26fa878746d9d119f6f9da12dedcbff1eea966c3e3447647c4a9e", size = 15150086, upload-time = "2026-06-21T20:56:49.352Z" },
-    { url = "https://files.pythonhosted.org/packages/32/4e/8d7656ccaab3e81e97258b8a9bc5f0c8502513a92fb4ceb0a2cbfebc17bf/numpy-2.5.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3893adc2dc7c0412ba76777db55a049215d99c9aa3113003be8f49f4f1290ab9", size = 16647250, upload-time = "2026-06-21T20:56:51.542Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/81/97060281b602ed07f21b12f4ec409eac1f75a2f91fbc829ed8b2becf3ad4/numpy-2.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:835e454dd99b238cdc5a3f63bce2371296f5ebc53ca1e0f8e6ddbb6d92a29aab", size = 16512864, upload-time = "2026-06-21T20:56:55.401Z" },
-    { url = "https://files.pythonhosted.org/packages/33/ab/4496208146911f8d8ddb54f68a972aafa6c8d44babcb2ea03b0e5cc87c9d/numpy-2.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f9836778081a0a3c02a6a21493f3e9f5b311f8d2541934f31f05583dc999ea4", size = 18408407, upload-time = "2026-06-21T20:56:57.75Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/9f/a4df67c181e4ee8b467aa3332dc2db10fd5c515136831302f3ca48bc0a01/numpy-2.5.0-cp313-cp313-win32.whl", hash = "sha256:0b525be4744b60bb0557ac872d53ef07d085b5f39622bc579c98d3809d05b988", size = 6054431, upload-time = "2026-06-21T20:57:00.016Z" },
-    { url = "https://files.pythonhosted.org/packages/30/53/491e1c47c55b62ccc6a63c1c5b8635c73fc2258dddeb9bda27cae4a0ae96/numpy-2.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:44353e2878930039db472b99dc353d749826e4010bd4d2a7f835e94a97a5c748", size = 12414420, upload-time = "2026-06-21T20:57:01.815Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/4a/25c2906f541e9d9f4c5769764db732e6627be91a13f4724fa10634d77db4/numpy-2.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:48f54b00711f83a5f796b70c518e8c2b3c5848dda03a54911f23eb68519b9b60", size = 10339533, upload-time = "2026-06-21T20:57:03.961Z" },
-    { url = "https://files.pythonhosted.org/packages/86/ad/abc44aaceaf7b17ee1edde2bbb4458da591bc79574cffff50c4bb35f00d1/numpy-2.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f27582c55ba4c750b7c58c8faf021d2cd9324a662b466229db8a417b41368af9", size = 16783807, upload-time = "2026-06-21T20:57:06.253Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/39/b72e168daf9c00fb20c9fc996d00437ccecdef3102387775d29d7a62576d/numpy-2.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:28e7137057d551e4a83c4ae414e3451f50568409db7569aacc7f9811ee06a446", size = 11765215, upload-time = "2026-06-21T20:57:08.547Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/a0/8400a9c0e3625182347593f5e1f57da9a617a534794805c8df5518154ddc/numpy-2.5.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e1da54b53e75cd9fcfc23efcc7edab2c6aecf97b6037566d8a0fe804af8ec57c", size = 5324493, upload-time = "2026-06-21T20:57:11.012Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/8c/0d104deaa0401c93395a629ec902891618a2eff76d19229139cb5a887bfc/numpy-2.5.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:694d8f74e156f7fd01179f1aa8faa2f648ab6ae0f70b6c3fe57a03249aea2303", size = 6645211, upload-time = "2026-06-21T20:57:12.919Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/d9/4a4a628c812750363786afc3d33492709a5cd64b215469c16b0f6c7bb811/numpy-2.5.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1a7569a7b53c77716f036bb28cb1c91f166a26ec7d9502cd1e4bdfe502fdec22", size = 15166004, upload-time = "2026-06-21T20:57:14.717Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/5e/2a902317d7fc4aa93236e80c932662dadfc459b323d758329e01775125e1/numpy-2.5.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39a0433bd4086ebd462960cf375e19195bb07b53dc1d87dd5fcf47ad78576f03", size = 16650797, upload-time = "2026-06-21T20:57:16.906Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/a0/a0090e6329f4ca5992c07847bb579c5259a19953dc57255bb08793142ffb/numpy-2.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:929f0c79ac38bcbd7154fe631dc907abfeddbcc5027a896bd1f7767323271e7a", size = 16524647, upload-time = "2026-06-21T20:57:19.165Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/7d/6caf27734c42b65837e7461ed0dbbd6b6fc835060c9714ec59d673bb383a/numpy-2.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cc4f247a47bbf070bfd70be53ccdcf47b800af563535e7bbe172322197c30e21", size = 18411841, upload-time = "2026-06-21T20:57:21.638Z" },
-    { url = "https://files.pythonhosted.org/packages/13/dc/26edadbd812536769a82c2e9e002234e33feb5da43061d47a044f6d309b7/numpy-2.5.0-cp314-cp314-win32.whl", hash = "sha256:5dc71423499fab3f46f7a7201155ade1669ea101f2f429d332df9e72f8161731", size = 6106361, upload-time = "2026-06-21T20:57:23.844Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/9e/4dd1459282229a72d92dece2ae9138e5cac94a72263a7ceb48f37434c925/numpy-2.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:ebb81d9d5443e0309d6c54894c3fbed74ad7da0714352a67b6d773cd189eae73", size = 12551749, upload-time = "2026-06-21T20:57:25.945Z" },
-    { url = "https://files.pythonhosted.org/packages/05/a7/6bc6384c080b86c7f6c85c5bc5b540b24f4f679cd144791d99574e90d462/numpy-2.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:3b94d0d0deceebfad3e67ae5c0e5eb87371e8f7a0581cd04a779928c2450cf1e", size = 10617072, upload-time = "2026-06-21T20:57:28.175Z" },
-    { url = "https://files.pythonhosted.org/packages/86/6b/4a2b71d66ada5608ae02b63f150dfad520f6940721cb7f029ad270befc0e/numpy-2.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:22f3d43e362d650bc39db1f17851302874a148ca95ba6981c1dfb5fa6862f35b", size = 11881067, upload-time = "2026-06-21T20:57:30.104Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/b2/d365eb40a20efb49d67e9feb90494ed8511282ee1f5fa16006675c65397d/numpy-2.5.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:243563efb4cd7528a264567e9fd206c87826457322521d06206a00bfa316c927", size = 5440290, upload-time = "2026-06-21T20:57:32.193Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/5e/e9c03188de5f9b767e46a8fe988bcfd3efad066a4a3fda8b9cb11a93f895/numpy-2.5.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:84881d825ca75249b189bbee875fcfe3238aa5c479e6100893cda566e8e86826", size = 6748371, upload-time = "2026-06-21T20:57:33.933Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/1d/68c186a38a5027bae2c4ddd5ea681fdaf8b4d30fb7301def6d8ad270390f/numpy-2.5.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cda12aa4779d42b8771180aba759c96f527d43446d8f380ab59e2b35e8489efd", size = 15214643, upload-time = "2026-06-21T20:57:35.677Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/67/73f67b7c7e20635baae9c4c3ead4ae7326a005900297a6110971abd62eb5/numpy-2.5.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c0121101093d2bd74981b10f8837d78e794a8ff57834eb27179f49e1ba11ac6", size = 16690128, upload-time = "2026-06-21T20:57:38.159Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/05/d4c1fb0c46d02a27d6b2b8b319a78c90937acec8631c1641874670b31e6f/numpy-2.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d371c92cfa09da00022f501ab67fafaea813d752eb30ac44336d45b1e5b0268a", size = 16577902, upload-time = "2026-06-21T20:57:40.447Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/1d/771c797d50fa26e4888989cccf1d50ee51f530d4e455ad2692dcb64fa711/numpy-2.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9990713e9c38154c6861e7547f1e3fc7a87e75ff09bab24ef1cc81d81c2835e9", size = 18452814, upload-time = "2026-06-21T20:57:42.875Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/46/52fc0d2a68d7643f0f149eeea5a5d8ea2a3507056ac8afa83c9212606e8b/numpy-2.5.0-cp314-cp314t-win32.whl", hash = "sha256:edadfbd4794b1086c0d822f81863e8a68fc129d132fd0bb9e31e955d7fbbbdb7", size = 6253168, upload-time = "2026-06-21T20:57:45.101Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/be/6c8d1118b5f13b2881dc095d5b345de19c6638b8959c17409b6eff84c8aa/numpy-2.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f7e5fa4382967ae6548bd2f174219afb908e294b0d5f625af01166edd5f7d9aa", size = 12736286, upload-time = "2026-06-21T20:57:46.935Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/6a/d3a169aaf8536cf228d56a09e04bcb713a2fe4410d4e2105b9419b5a9c89/numpy-2.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:016623417bb330d719d579daf2d6b9a01ddc52e41a9ed61a47f39fde46dcd865", size = 10686451, upload-time = "2026-06-21T20:57:49.313Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
 ]
 
 [[package]]
@@ -2776,7 +2827,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -2787,7 +2838,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -2814,9 +2865,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -2827,7 +2878,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -3093,7 +3144,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -4021,6 +4072,15 @@ wheels = [
 ]
 
 [[package]]
+name = "relais"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/2b/d9bb9aa75f8571fd17babd76984a79a86cb4a733e37b57da216ed9d9418c/relais-0.2.1.tar.gz", hash = "sha256:2a25876cc46f282d9df168d52bed5c7e5f61143a4cd797a2eab17aa5fcf24af4", size = 128113, upload-time = "2025-09-03T22:35:25.425Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/50/10d14257b10ee34372cdf98e7142a7a2d5477436498c20f4dae64f4a45c4/relais-0.2.1-py3-none-any.whl", hash = "sha256:853b640a7886d44f40f3c4eb29739145d697b77e6a27e56af5151aa6fcfb871b", size = 36135, upload-time = "2025-09-03T22:35:24.001Z" },
+]
+
+[[package]]
 name = "replicate"
 version = "1.0.7"
 source = { registry = "https://pypi.org/simple" }
@@ -4754,6 +4814,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "uniseg"
+version = "0.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/5e/fc5b1c370dc523a580cb214ee7753c8631a2d4be8fc51283785415b62d92/uniseg-0.10.1.tar.gz", hash = "sha256:5224267916fc01132cb2f7bf60882402dde72ab52c6977184827e4d9d6676de6", size = 8151423, upload-time = "2026-01-09T12:53:03.45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6c/9eb6d93ad8b9ac96cba13e6d2f419c316d8fdb91013e12dd478a99501699/uniseg-0.10.1-py3-none-any.whl", hash = "sha256:74fe3f7b4ee46bbd703a70ea1e5cd28e04f63eee5af9a10388d93316c554e358", size = 8179942, upload-time = "2026-01-09T12:53:00.64Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Integrates the private **lidar** security scanner into `giskard.scan` as `third_party_scan(target, tool="lidar")`, mirroring the garak integration (PR #2578, the base of this PR).

Lidar is coarse-grained: `run_scan(target=...)` runs the whole async scan and returns scored attempts. The integration bridges a Giskard scan `Target` into lidar via a `BaseGenerator` subclass, drives real (multiturn-capable) probes, and maps each lidar `Attempt` back into a scan `SuiteResult`.

## What's included

- **Dependency wiring** — lidar as a git-pinned dev dependency (`lidar-test` group, `[tool.uv.sources]` at tag `v0.2.7`) + `install-lidar-test`/`test-lidar` Makefile targets. Private-install guard raises a clear `ImportError` with the git install command.
- **Target bridge** (`ScanTargetGenerator`) — subclasses lidar's `BaseGenerator`; drives the scan `Target` through lidar's stateful `thread_id` round-trip. Stored as a pydantic `PrivateAttr` so it survives lidar's `target.model_dump(mode="json")` (a plain field crashed every scan).
- **Result mapping** — each lidar `Attempt` → one `ScenarioResult`. Polarity flip: `attempt.successful=True` (attack won) → `CheckResult.failure`. Severity → `details["severity"]` + `Metric`. Trace rebuilt from `attempt.messages`.
- **Caller-supplied target context** (this PR's key addition over the earlier lidar work) — `third_party_scan` now takes a required `description` (and optional `languages`), matching the sibling scan APIs (`catalog`/`quality`/`vulnerability`). The lidar adapter builds `TargetInfo(agent_description=description, languages=...)` and passes it to `run_scan`, so probes run for real instead of SKIPping on a missing target profile. `discover_target_info` stays `False` — context comes from the caller, not a discovery pass. Garak accepts-and-ignores these args (no `TargetInfo` concept).

## Verification

Driven end-to-end online (public entry point only, no `import lidar`, on `azure_ai/gpt-4.1-mini`):

- **deepset-injection** — 20 real verdicts, 0 SKIP; clean polarity flip (naive target → FAILURE up to `critical`; refusing target → PASS/`safe`).
- **goat (multiturn)** — 8 real verdicts, 7 with multi-interaction traces (real adversarial conversation, up to 10 turns).
- **Generator mapping** — 29/29 recorded LLM calls went to the injected Giskard generator; lidar's env-var default (`gpt-4o-mini`) never used.
- Integration suite: 41 passed / 6 skipped (key-gated), 0 failed.

## Notes

- Lidar is **private** (no PyPI, no public extra) — wired as a dev-only git dep, guarded so the package imports cleanly without lidar installed.
- Targets **PR #2578** (`feat/garak-scan-integration`); merge that first. The diff here is lidar-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
