### PR TITLE
chore: regenerate THIRD_PARTY_NOTICES.md

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -17,7 +17,6 @@ Find a list of packages below
 |✔|aiohappyeyeballs|
 |✔|aiohttp|
 |✔|aiosignal|
-|✔|annotated-doc|
 |✔|annotated-types|
 |✔|anthropic|
 |✔|anyio|
@@ -77,13 +76,11 @@ Find a list of packages below
 |✔|requests|
 |✔|rich|
 |✔|rpds-py|
-|✔|shellingham|
 |✔|sniffio|
 |✔|tenacity|
 |✔|tiktoken|
 |✔|tokenizers|
 |✔|tqdm|
-|✔|typer|
 |✔|typing-extensions|
 |✔|typing-inspection|
 |✔|urllib3|
@@ -110,13 +107,6 @@ Find a list of packages below
 - HomePage: https://github.com/aio-libs/aiosignal
 - Author:
 - License: Apache Software License
-- Compatible: True
-
-### annotated-doc-0.0.4
-
-- HomePage:
-- Author: =?utf-8?q?Sebasti=C3=A1n_Ram=C3=ADrez?=
-- License: MIT
 - Compatible: True
 
 ### annotated-types-0.7.0
@@ -532,13 +522,6 @@ Find a list of packages below
 - License: MIT
 - Compatible: True
 
-### shellingham-1.5.4
-
-- HomePage: https://github.com/sarugaku/shellingham
-- Author: Tzu-ping Chung
-- License: ISC License _ISCL_
-- Compatible: True
-
 ### sniffio-1.3.1
 
 - HomePage:
@@ -572,13 +555,6 @@ Find a list of packages below
 - HomePage:
 - Author:
 - License: MIT;; MPL-2.0
-- Compatible: True
-
-### typer-0.25.1
-
-- HomePage:
-- Author: Sebastián Ramírez
-- License: MIT
 - Compatible: True
 
 ### typing-extensions-4.15.0


### PR DESCRIPTION
## Summary

`THIRD_PARTY_NOTICES.md` had drifted from the resolved dependency tree. Regenerated it with `make generate-notices`.

The following packages were dropped (no longer resolved as dependencies):
- `annotated-doc`
- `shellingham`
- `typer`

## Verification

- `make check-notices` passes (the file is now byte-consistent with `make generate-notices` output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)