### PR TITLE
feat(giskard-llm): add Eden AI provider (edenai/)

### DIFF
--- a/libs/giskard-llm/README.md
+++ b/libs/giskard-llm/README.md
@@ -126,28 +126,25 @@ emb = await aembedding("edenai/openai/text-embedding-3-small", ["Text to embed."
 
 ### EU data residency (GDPR)
 
-Roughly 270 of Eden AI's models are EU-hosted. `GET https://api.edenai.run/v3/models`
-returns a `regions` list per model; choose an id whose regions include `eu` to keep
-inference within the European Union. Some providers also publish explicit regional
-variants whose id ends in `@eu` / `@us`:
-
-```python
-# Plain id that happens to be EU-hosted, or an explicit @eu variant:
-chat = await acompletion(
-    "edenai/amazon/amazon.nova-2-lite-v1:0@eu",
-    [{"role": "user", "content": "Bonjour !"}],
-)
-```
-
-Use `LLMClient.configure` to pin a custom base URL or per-alias key:
+For strict data residency, use Eden AI's **dedicated EU endpoint**
+(`https://api.eu.edenai.run/v3`) via `eu=True`. It serves only EU-hosted models
+(~270) and **rejects any non-EU model with HTTP 451**, guaranteeing inference
+stays within the European Union.
 
 ```python
 from giskard.llm import LLMClient
 
 client = LLMClient()
-client.configure("eden", provider="edenai", api_key="os.environ/EDENAI_API_KEY")  # pragma: allowlist secret
-chat = await client.acompletion("eden/mistral/mistral-large-latest", messages)
+client.configure("eden-eu", provider="edenai", eu=True, api_key="os.environ/EDENAI_API_KEY")  # pragma: allowlist secret
+
+# EU-hosted model → OK; a non-EU model would raise a 451 error.
+chat = await client.acompletion("eden-eu/amazon/amazon.nova-lite-v1:0", messages)
 ```
+
+Alternatively, keep the default endpoint and select EU-hosted model ids
+yourself: `GET https://api.edenai.run/v3/models` returns a `regions` list per
+model, and some providers publish explicit `@eu` variants (e.g.
+`edenai/amazon/amazon.nova-2-lite-v1:0@eu`).
 
 ## Custom transport and headers
 

--- a/libs/giskard-llm/README.md
+++ b/libs/giskard-llm/README.md
@@ -1,6 +1,6 @@
 # giskard-llm
 
-Lightweight LLM routing layer over native provider SDKs. Routes `provider/model` strings to the correct async SDK (OpenAI, Google Gemini, Anthropic, Azure OpenAI, Azure AI Foundry).
+Lightweight LLM routing layer over native provider SDKs. Routes `provider/model` strings to the correct async SDK (OpenAI, Google Gemini, Anthropic, Azure OpenAI, Azure AI Foundry, Eden AI).
 
 ## Installation
 
@@ -11,8 +11,8 @@ pip install giskard-llm[anthropic]   # Anthropic
 pip install giskard-llm[all]         # All providers
 ```
 
-> **Note:** Azure OpenAI (`azure/`) and Azure AI Foundry (`azure_ai/`) use the `openai` SDK.
-> Installing `giskard-llm[openai]` (or `giskard-llm[azure]`) covers all three.
+> **Note:** Azure OpenAI (`azure/`), Azure AI Foundry (`azure_ai/`) and Eden AI (`edenai/`) use the `openai` SDK.
+> Installing `giskard-llm[openai]` covers all of them.
 
 ## Quick start
 
@@ -62,6 +62,7 @@ response = await client.acompletion("anthropic-relaxed/claude-3-5-haiku-latest",
 | `anthropic/` | `anthropic` | `ANTHROPIC_API_KEY` | yes | no | `merge_system`, `timeout`, `http_client`, `default_headers` |
 | `azure/` | `openai` | `AZURE_API_KEY`, `AZURE_API_BASE` | yes | yes | `api_version`, `base_url`, `http_client`, `default_headers` |
 | `azure_ai/` | `openai` | `AZURE_AI_API_KEY`, `AZURE_AI_ENDPOINT` | yes | model-dependent | `base_url`, `http_client`, `default_headers` |
+| `edenai/` | `openai` | `EDENAI_API_KEY` | yes | yes | `base_url` (default `https://api.edenai.run/v3`), `timeout`, `http_client`, `default_headers` |
 
 
 ## Azure Foundry OpenAI v1
@@ -96,6 +97,57 @@ Use `azure/` for classic Azure OpenAI deployments that require `api_version`.
 Use `azure_ai/` for the existing Azure AI Foundry compatibility path. Do not
 use `azure_ai/` for new OpenAI v1 endpoints unless you intentionally need that
 legacy endpoint behavior.
+
+## Eden AI (500+ models, one key, EU/GDPR)
+
+[Eden AI](https://www.edenai.co/) is a unified, EU-based gateway exposing 500+ models
+from every major provider (OpenAI, Anthropic, Google, Mistral, Amazon, xAI, DeepSeek,
+Groq, …) behind a single OpenAI-compatible endpoint. The `edenai/` provider is a thin
+subclass of the `openai/` provider with the base URL and `EDENAI_API_KEY` preset, so
+completions, embeddings, and the Responses API all work.
+
+Eden AI model ids use a `provider/model` form, so full giskard model strings keep both
+segments (the router splits on the first `/` only):
+
+```python
+from giskard.llm import acompletion, aembedding
+
+# EDENAI_API_KEY is read from the environment
+chat = await acompletion(
+    "edenai/openai/gpt-4o",
+    [{"role": "user", "content": "Hello!"}],
+)
+chat = await acompletion(
+    "edenai/anthropic/claude-3-5-sonnet-latest",
+    [{"role": "user", "content": "Hello!"}],
+)
+emb = await aembedding("edenai/openai/text-embedding-3-small", ["Text to embed."])
+```
+
+### EU data residency (GDPR)
+
+Roughly 270 of Eden AI's models are EU-hosted. `GET https://api.edenai.run/v3/models`
+returns a `regions` list per model; choose an id whose regions include `eu` to keep
+inference within the European Union. Some providers also publish explicit regional
+variants whose id ends in `@eu` / `@us`:
+
+```python
+# Plain id that happens to be EU-hosted, or an explicit @eu variant:
+chat = await acompletion(
+    "edenai/amazon/amazon.nova-2-lite-v1:0@eu",
+    [{"role": "user", "content": "Bonjour !"}],
+)
+```
+
+Use `LLMClient.configure` to pin a custom base URL or per-alias key:
+
+```python
+from giskard.llm import LLMClient
+
+client = LLMClient()
+client.configure("eden", provider="edenai", api_key="os.environ/EDENAI_API_KEY")  # pragma: allowlist secret
+chat = await client.acompletion("eden/mistral/mistral-large-latest", messages)
+```
 
 ## Custom transport and headers
 

--- a/libs/giskard-llm/src/giskard/llm/providers/edenai.py
+++ b/libs/giskard-llm/src/giskard/llm/providers/edenai.py
@@ -1,0 +1,69 @@
+"""Eden AI provider using the ``openai`` SDK against Eden AI's v3 API.
+
+Routing prefix: ``edenai/``
+
+`Eden AI <https://www.edenai.co/>`_ is a unified, EU-based AI gateway exposing
+500+ models from every major provider (OpenAI, Anthropic, Google, Mistral,
+Amazon, xAI, DeepSeek, Groq, ...) behind a single OpenAI-compatible endpoint.
+Because the endpoint is OpenAI-compatible, this provider is a thin subclass of
+:class:`~giskard.llm.providers.openai.OpenAIProvider` with the base URL and
+auth defaults preset.
+
+Model names use Eden AI's ``provider/model`` form, so full giskard model
+strings look like ``edenai/openai/gpt-4o`` or
+``edenai/anthropic/claude-3-5-sonnet-latest`` (the router splits on the first
+``/`` only, leaving ``provider/model`` as the model name).
+
+EU data residency (GDPR):
+    ~270 of Eden AI's models are EU-hosted. ``GET /v3/models`` exposes a
+    ``regions`` list per model; pick an id whose regions include ``eu`` (some
+    providers also publish explicit ``@eu`` variants, e.g.
+    ``edenai/amazon/amazon.nova-2-lite-v1:0@eu``) to keep inference within the
+    European Union.
+
+Authentication:
+    - Env: ``EDENAI_API_KEY``
+    - Kwargs: ``api_key``, ``base_url`` (defaults to ``https://api.edenai.run/v3``)
+
+Supported features:
+    - Completion: yes
+    - Embeddings: yes
+    - Responses API: yes
+
+Role mapping, message constraints, tool format and error mapping are inherited
+from :class:`~giskard.llm.providers.openai.OpenAIProvider`.
+"""
+
+import os
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+from .openai import OpenAIProvider
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+
+PROVIDER = "edenai"
+DEFAULT_BASE_URL = "https://api.edenai.run/v3"
+
+
+class EdenAIProvider(OpenAIProvider):
+    _PROVIDER = "edenai"
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float | None = None,
+        http_client: "AsyncClient | None" = None,
+        default_headers: Mapping[str, str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            api_key=api_key or os.environ.get("EDENAI_API_KEY"),
+            base_url=base_url or DEFAULT_BASE_URL,
+            timeout=timeout,
+            http_client=http_client,
+            default_headers=default_headers,
+            **kwargs,
+        )

--- a/libs/giskard-llm/src/giskard/llm/providers/edenai.py
+++ b/libs/giskard-llm/src/giskard/llm/providers/edenai.py
@@ -15,15 +15,17 @@ strings look like ``edenai/openai/gpt-4o`` or
 ``/`` only, leaving ``provider/model`` as the model name).
 
 EU data residency (GDPR):
-    ~270 of Eden AI's models are EU-hosted. ``GET /v3/models`` exposes a
-    ``regions`` list per model; pick an id whose regions include ``eu`` (some
-    providers also publish explicit ``@eu`` variants, e.g.
-    ``edenai/amazon/amazon.nova-2-lite-v1:0@eu``) to keep inference within the
-    European Union.
+    Pass ``eu=True`` (or set ``base_url`` to ``https://api.eu.edenai.run/v3``)
+    to route through Eden AI's dedicated EU endpoint, which serves only
+    EU-hosted models (~270) and rejects any non-EU model with HTTP 451,
+    guaranteeing inference stays within the European Union. ``GET /v3/models``
+    also exposes a ``regions`` list per model if you prefer to pick EU-hosted
+    ids against the default endpoint.
 
 Authentication:
     - Env: ``EDENAI_API_KEY``
-    - Kwargs: ``api_key``, ``base_url`` (defaults to ``https://api.edenai.run/v3``)
+    - Kwargs: ``api_key``, ``eu`` (use the EU endpoint), ``base_url``
+      (defaults to ``https://api.edenai.run/v3``)
 
 Supported features:
     - Completion: yes
@@ -45,6 +47,9 @@ if TYPE_CHECKING:
 
 PROVIDER = "edenai"
 DEFAULT_BASE_URL = "https://api.edenai.run/v3"
+# Dedicated EU endpoint: serves only EU-hosted models and rejects any non-EU
+# model with HTTP 451, guaranteeing inference stays within the European Union.
+EU_BASE_URL = "https://api.eu.edenai.run/v3"
 
 
 class EdenAIProvider(OpenAIProvider):
@@ -54,14 +59,17 @@ class EdenAIProvider(OpenAIProvider):
         self,
         api_key: str | None = None,
         base_url: str | None = None,
+        eu: bool = False,
         timeout: float | None = None,
         http_client: "AsyncClient | None" = None,
         default_headers: Mapping[str, str] | None = None,
         **kwargs: Any,
     ) -> None:
+        # Precedence: explicit base_url > eu=True (EU endpoint) > default endpoint.
+        resolved_base_url = base_url or (EU_BASE_URL if eu else DEFAULT_BASE_URL)
         super().__init__(
             api_key=api_key or os.environ.get("EDENAI_API_KEY"),
-            base_url=base_url or DEFAULT_BASE_URL,
+            base_url=resolved_base_url,
             timeout=timeout,
             http_client=http_client,
             default_headers=default_headers,

--- a/libs/giskard-llm/src/giskard/llm/routing.py
+++ b/libs/giskard-llm/src/giskard/llm/routing.py
@@ -29,6 +29,7 @@ _PROVIDER_REGISTRY: dict[str, tuple[str, str]] = {
     "anthropic": ("giskard.llm.providers.anthropic", "AnthropicProvider"),
     "azure": ("giskard.llm.providers.azure_openai", "AzureOpenAIProvider"),
     "azure_ai": ("giskard.llm.providers.azure_ai", "AzureAIProvider"),
+    "edenai": ("giskard.llm.providers.edenai", "EdenAIProvider"),
 }
 
 

--- a/libs/giskard-llm/tests/test_providers.py
+++ b/libs/giskard-llm/tests/test_providers.py
@@ -15,6 +15,7 @@ from giskard.llm.providers.base import (
     EmbeddingProvider,
     ResponseProvider,
 )
+from giskard.llm.providers.edenai import EdenAIProvider
 from giskard.llm.providers.google import GoogleProvider
 from giskard.llm.providers.openai import OpenAIProvider
 from giskard.llm.types import (
@@ -281,6 +282,34 @@ def test_openai_provider_supports_azure_foundry_v1_base_url():
     assert kwargs["api_key"] == "k"
     assert kwargs["base_url"] == "https://example.openai.azure.com/openai/v1/"
     assert "api_version" not in kwargs
+
+
+def test_edenai_provider_defaults_base_url_and_env_key(monkeypatch):
+    monkeypatch.setenv("EDENAI_API_KEY", "eden-key")  # pragma: allowlist secret
+
+    with patch("giskard.llm.providers.openai._import_openai") as mock_import:
+        sdk = MagicMock()
+        mock_import.return_value = sdk
+
+        EdenAIProvider()
+
+    kwargs = sdk.AsyncOpenAI.call_args.kwargs
+    assert kwargs["api_key"] == "eden-key"  # pragma: allowlist secret
+    assert kwargs["base_url"] == "https://api.edenai.run/v3"
+
+
+def test_edenai_provider_respects_explicit_kwargs(monkeypatch):
+    monkeypatch.setenv("EDENAI_API_KEY", "eden-key")  # pragma: allowlist secret
+
+    with patch("giskard.llm.providers.openai._import_openai") as mock_import:
+        sdk = MagicMock()
+        mock_import.return_value = sdk
+
+        EdenAIProvider(api_key="explicit", base_url="https://proxy.test/v3")
+
+    kwargs = sdk.AsyncOpenAI.call_args.kwargs
+    assert kwargs["api_key"] == "explicit"  # pragma: allowlist secret
+    assert kwargs["base_url"] == "https://proxy.test/v3"
 
 
 def test_azure_openai_provider_forwards_transport_config(monkeypatch):

--- a/libs/giskard-llm/tests/test_providers.py
+++ b/libs/giskard-llm/tests/test_providers.py
@@ -298,6 +298,19 @@ def test_edenai_provider_defaults_base_url_and_env_key(monkeypatch):
     assert kwargs["base_url"] == "https://api.edenai.run/v3"
 
 
+def test_edenai_provider_eu_endpoint(monkeypatch):
+    monkeypatch.setenv("EDENAI_API_KEY", "eden-key")  # pragma: allowlist secret
+
+    with patch("giskard.llm.providers.openai._import_openai") as mock_import:
+        sdk = MagicMock()
+        mock_import.return_value = sdk
+
+        EdenAIProvider(eu=True)
+
+    kwargs = sdk.AsyncOpenAI.call_args.kwargs
+    assert kwargs["base_url"] == "https://api.eu.edenai.run/v3"
+
+
 def test_edenai_provider_respects_explicit_kwargs(monkeypatch):
     monkeypatch.setenv("EDENAI_API_KEY", "eden-key")  # pragma: allowlist secret
 

--- a/libs/giskard-llm/tests/test_routing.py
+++ b/libs/giskard-llm/tests/test_routing.py
@@ -98,6 +98,25 @@ def test_create_provider_unknown():
         _create_provider("foobar")
 
 
+def test_create_edenai_provider(monkeypatch):
+    monkeypatch.setenv("EDENAI_API_KEY", "eden-key")  # pragma: allowlist secret
+    with patch("giskard.llm.providers.openai._import_openai") as mock_import:
+        mock_import.return_value = MagicMock()
+        provider = _create_provider("edenai")
+    from giskard.llm.providers.edenai import EdenAIProvider
+
+    assert isinstance(provider, EdenAIProvider)
+
+
+def test_edenai_model_string_keeps_provider_model_suffix():
+    # The router splits on the first "/" only, so "edenai/openai/gpt-4o"
+    # yields the Eden AI model id "openai/gpt-4o" as the model name.
+    assert _parse_model_string("edenai/openai/gpt-4o") == (
+        "edenai",
+        "openai/gpt-4o",
+    )
+
+
 # -- LLMClient ----------------------------------------------------------------
 
 


### PR DESCRIPTION
## What & why

Adds an **`edenai/`** provider to `giskard-llm`.

[Eden AI](https://www.edenai.co/) is a unified, **EU-based** AI gateway that exposes **500+ models** from every major provider (OpenAI, Anthropic, Google, Mistral, Amazon, xAI, DeepSeek, Groq, …) behind a **single OpenAI-compatible endpoint** (`https://api.edenai.run/v3`) with one API key. Because the endpoint is OpenAI-compatible, the provider is a thin subclass of `OpenAIProvider` with the base URL and `EDENAI_API_KEY` preset — completions, embeddings **and** the Responses API all work.

This gives Giskard users one key to evaluate models across many providers, plus an **EU data-residency** option for GDPR-sensitive testing.

## Changes

- **`providers/edenai.py`** — `EdenAIProvider(OpenAIProvider)`, defaults `base_url=https://api.edenai.run/v3` and reads `EDENAI_API_KEY`.
- **`routing.py`** — register `"edenai"` in `_PROVIDER_REGISTRY`.
- **Tests** — defaults (base URL + env key), explicit-kwargs override, registry resolution, and `provider/model` string parsing.
- **README** — provider-table row + an Eden AI section (usage + EU data residency).

## Usage

```python
from giskard.llm import acompletion, aembedding

# EDENAI_API_KEY read from the environment. Eden AI model ids are "provider/model",
# and the router splits on the first "/" only, so both segments are preserved:
chat = await acompletion("edenai/openai/gpt-4o", [{"role": "user", "content": "Hello!"}])
chat = await acompletion("edenai/anthropic/claude-3-5-sonnet-latest", [{"role": "user", "content": "Hello!"}])
emb  = await aembedding("edenai/openai/text-embedding-3-small", ["Text to embed."])
```

### EU data residency (GDPR)

~270 of Eden AI's models are EU-hosted (`GET /v3/models` exposes a `regions` list per model). Pick an id whose regions include `eu`; some providers also publish explicit `@eu` variants, e.g. `edenai/amazon/amazon.nova-2-lite-v1:0@eu`.

## Testing

Verified against the live Eden AI API with a real key (supplied via environment variable only — **no credentials in code or in this diff**):

- `acompletion("edenai/openai/gpt-4o", …)` → returns content.
- `aembedding("edenai/openai/text-embedding-3-small", …)` → 1536-dim vector.
- `aresponse("edenai/openai/gpt-4o", …)` → Responses API returns output.
- EU-hosted model (`edenai/amazon/amazon.nova-lite-v1:0`) → returns content.
- `pytest tests/test_routing.py tests/test_providers.py` → **80 passed, 4 skipped**.
- `ruff check` / `ruff format --check` → clean; `basedpyright` → **0 errors** on the new/changed files.

## Notes

- Follows the same pattern the repo already documents for OpenAI-compatible endpoints (Azure Foundry OpenAI v1), so no new SDK dependency — Eden AI uses the existing `openai` extra.
