### PR TITLE
docs(llm): add Eden AI (OpenAI-compatible) to giskard-llm README

### DIFF
--- a/libs/giskard-llm/README.md
+++ b/libs/giskard-llm/README.md
@@ -97,6 +97,50 @@ Use `azure_ai/` for the existing Azure AI Foundry compatibility path. Do not
 use `azure_ai/` for new OpenAI v1 endpoints unless you intentionally need that
 legacy endpoint behavior.
 
+## Eden AI (OpenAI-compatible)
+
+[Eden AI](https://www.edenai.co/) exposes an OpenAI-compatible endpoint that
+routes to models from many providers (OpenAI, Anthropic, Mistral, Google, and
+more) behind a single EU-based, GDPR-compliant API key. Configure it with the
+`openai` provider and Eden AI's `base_url` (use `https://api.eu.edenai.run/v3`
+instead if you need strict EU data residency). The model name after the config
+alias is Eden AI's own `provider/model` identifier (for example
+`openai/gpt-4o-mini`), so the full model string is
+`<alias>/<eden-provider>/<eden-model>`.
+
+The `base_url` ends in `/v3` because that is Eden AI's API version (the path is
+`/v3/chat/completions`, not `/v1/...`). The key is read from the environment and
+never hard-coded:
+
+```bash
+export EDENAI_API_KEY="your-eden-ai-key"
+```
+
+```python
+from giskard.llm import LLMClient
+
+client = LLMClient()
+client.configure(
+    "edenai",
+    provider="openai",
+    api_key="os.environ/EDENAI_API_KEY", # pragma: allowlist secret
+    base_url="https://api.edenai.run/v3",
+)
+
+chat = await client.acompletion(
+    "edenai/openai/gpt-4o-mini",
+    [{"role": "user", "content": "Write one sentence."}],
+)
+embedding = await client.aembedding(
+    "edenai/openai/text-embedding-3-small",
+    ["Text to embed."],
+)
+```
+
+The same `edenai/<eden-provider>/<eden-model>` alias works for both `acompletion`
+and `aembedding`, so a single configured client covers chat and embedding models.
+Browse the available models in the [Eden AI models catalog](https://www.edenai.co/models).
+
 ## Custom transport and headers
 
 Use `http_client` to provide a caller-owned async HTTP client, for example


### PR DESCRIPTION
## Description

Adds an **Eden AI (OpenAI-compatible)** section to the `giskard-llm` README.

Eden AI exposes an OpenAI-compatible endpoint, so it works with the existing
`openai` provider plus a custom `base_url` — no new provider code is needed.
This mirrors the README's existing "Azure Foundry OpenAI v1" pattern. The new
section documents:

- configuring the client with `provider="openai"`, `base_url="https://api.edenai.run/v3"`, and the key read from `EDENAI_API_KEY`;
- the model-string convention (`<alias>/<eden-provider>/<eden-model>`, e.g. `edenai/openai/gpt-4o-mini`), since the router splits the alias off the first `/`;
- both `acompletion` and `aembedding` usage.

**Why it's useful:** Eden AI gives EU-based, GDPR-compliant access to models
from many providers (OpenAI, Anthropic, Mistral, Google, ...) behind a single
key — handy for teams that need to run Giskard evals and red-teaming on
data-sovereign, EU-hosted models without wiring up a provider per vendor.

**Verification:** the documented snippet was run end-to-end against the live
Eden AI endpoint through `giskard-llm`'s own `LLMClient` — `acompletion`
(`edenai/openai/gpt-4o-mini`) returned a valid completion and `aembedding`
(`edenai/openai/text-embedding-3-small`) returned a 1536-dim vector. The API
key was supplied via the `EDENAI_API_KEY` environment variable and never
appears in the code or docs.

## Related Issue

_None._

## Type of Change

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [x] I've read the `CODE_OF_CONDUCT.md` document.
- [x] I've read the `CONTRIBUTING.md` guide.
- [ ] I've written tests for all new methods and classes that I created. _(N/A — docs-only change; verified the example live against the Eden AI endpoint.)_
- [ ] I've written the docstring in NumPy format for all the methods and classes that I created or modified. _(N/A — no code changed.)_
- [ ] I've updated the `uv.lock` running `uv lock`. _(N/A — `pyproject.toml` not modified.)_
