### PR TITLE
fix(google): map Gemini finish_reason via enum value, not str()

### DIFF
--- a/libs/giskard-llm/src/giskard/llm/translators/google_chat.py
+++ b/libs/giskard-llm/src/giskard/llm/translators/google_chat.py
@@ -284,7 +284,6 @@ REFUSAL_REASONS = frozenset(
 FINISH_REASON_MAP = {
     "STOP": "stop",
     "MAX_TOKENS": "length",
-    "SAFETY": "content_filter",
 } | {reason: "refusal" for reason in REFUSAL_REASONS}
 
 
@@ -372,23 +371,24 @@ class GoogleChatTranslator:
         if not raw.candidates:
             return CompletionResponse(choices=[], model=model)
 
+        # ``candidate.finish_reason`` is a ``FinishReason`` enum whose ``str()`` is
+        # ``"FinishReason.SAFETY"`` (etc.), not the bare ``"SAFETY"`` the map is keyed
+        # on -- so read ``.value``. The SDK is an optional dep imported by the caller,
+        # so ``FinishReason`` is resolved lazily here (never at module load).
+        from google.genai.types import FinishReason
+
         for i, candidate in enumerate(raw.candidates):
             finish_reason = "stop"
 
-            # ``candidate.finish_reason`` is a ``FinishReason`` enum whose ``str()``
-            # is ``"FinishReason.SAFETY"`` (etc.), not the bare ``"SAFETY"`` the map
-            # is keyed on. Use ``.value`` so the lookup actually hits; fall back to
-            # ``str()`` for the plain-string case (e.g. dict-validated test inputs).
-            raw_finish_reason = getattr(
-                candidate.finish_reason, "value", candidate.finish_reason
+            fr = candidate.finish_reason
+            raw_finish_reason = (
+                fr.value if isinstance(fr, FinishReason) else str(fr or "")
             )
-            if candidate.finish_reason:
-                finish_reason = FINISH_REASON_MAP.get(
-                    str(raw_finish_reason), "stop"
-                )
+            if fr:
+                finish_reason = FINISH_REASON_MAP.get(raw_finish_reason, "stop")
 
             refusal_out = (
-                (candidate.finish_message or str(raw_finish_reason))
+                (candidate.finish_message or raw_finish_reason)
                 if finish_reason == "refusal"
                 else None
             )

--- a/libs/giskard-llm/src/giskard/llm/translators/google_chat.py
+++ b/libs/giskard-llm/src/giskard/llm/translators/google_chat.py
@@ -375,13 +375,20 @@ class GoogleChatTranslator:
         for i, candidate in enumerate(raw.candidates):
             finish_reason = "stop"
 
+            # ``candidate.finish_reason`` is a ``FinishReason`` enum whose ``str()``
+            # is ``"FinishReason.SAFETY"`` (etc.), not the bare ``"SAFETY"`` the map
+            # is keyed on. Use ``.value`` so the lookup actually hits; fall back to
+            # ``str()`` for the plain-string case (e.g. dict-validated test inputs).
+            raw_finish_reason = getattr(
+                candidate.finish_reason, "value", candidate.finish_reason
+            )
             if candidate.finish_reason:
                 finish_reason = FINISH_REASON_MAP.get(
-                    str(candidate.finish_reason), "stop"
+                    str(raw_finish_reason), "stop"
                 )
 
             refusal_out = (
-                (candidate.finish_message or candidate.finish_reason)
+                (candidate.finish_message or str(raw_finish_reason))
                 if finish_reason == "refusal"
                 else None
             )

--- a/libs/giskard-llm/tests/translators/test_google_chat_return.py
+++ b/libs/giskard-llm/tests/translators/test_google_chat_return.py
@@ -197,3 +197,43 @@ def test_from_google_empty_candidates():
     out = GoogleChatTranslator.from_google(raw, _MODEL, 1)
     assert out.choices == []
     assert out.model == _MODEL
+
+
+def test_from_google_max_tokens_maps_to_length():
+    """A ``MAX_TOKENS`` finish reason maps to ``length``.
+
+    Regression: ``candidate.finish_reason`` round-trips through
+    ``model_validate`` as a ``FinishReason`` enum whose ``str()`` is
+    ``"FinishReason.MAX_TOKENS"``. Keying the map on ``str(enum)`` silently
+    missed and collapsed every non-STOP reason to ``"stop"``.
+    """
+    raw = _raw(
+        {
+            "candidates": [
+                {
+                    "content": {"parts": [{"text": "truncated"}]},
+                    "finish_reason": "MAX_TOKENS",
+                }
+            ],
+        }
+    )
+    out = GoogleChatTranslator.from_google(raw, _MODEL, 1)
+    assert out.choices[0].finish_reason == "length"
+
+
+def test_from_google_safety_maps_to_refusal():
+    """A ``SAFETY`` finish reason maps to ``refusal`` (not the default ``stop``)."""
+    raw = _raw(
+        {
+            "candidates": [
+                {
+                    "content": {"parts": [{"text": "blocked"}]},
+                    "finish_reason": "SAFETY",
+                }
+            ],
+        }
+    )
+    out = GoogleChatTranslator.from_google(raw, _MODEL, 1)
+    assert out.choices[0].finish_reason == "refusal"
+    # The refusal text must be a clean reason string, never "FinishReason.SAFETY".
+    assert out.choices[0].message.refusal == "SAFETY"

--- a/libs/giskard-llm/tests/translators/test_google_chat_return.py
+++ b/libs/giskard-llm/tests/translators/test_google_chat_return.py
@@ -237,3 +237,25 @@ def test_from_google_safety_maps_to_refusal():
     assert out.choices[0].finish_reason == "refusal"
     # The refusal text must be a clean reason string, never "FinishReason.SAFETY".
     assert out.choices[0].message.refusal == "SAFETY"
+
+
+def test_from_google_refusal_uses_finish_message_when_present():
+    """When Gemini supplies a ``finish_message``, it becomes the refusal text.
+
+    The reason code (``SAFETY``) is only the fallback; the human-readable
+    ``finish_message`` takes precedence so callers surface Gemini's explanation.
+    """
+    raw = _raw(
+        {
+            "candidates": [
+                {
+                    "content": {"parts": [{"text": "blocked"}]},
+                    "finish_reason": "SAFETY",
+                    "finish_message": "Blocked for safety.",
+                }
+            ],
+        }
+    )
+    out = GoogleChatTranslator.from_google(raw, _MODEL, 1)
+    assert out.choices[0].finish_reason == "refusal"
+    assert out.choices[0].message.refusal == "Blocked for safety."


### PR DESCRIPTION
### problem
in the Gemini -> giskard translator (`llm/translators/google_chat.py`), the finish reason is looked up with `str(candidate.finish_reason)`:

```python
finish_reason = FINISH_REASON_MAP.get(str(candidate.finish_reason), "stop")
```

but `candidate.finish_reason` is a `google.genai` `FinishReason` enum, and `str(FinishReason.MAX_TOKENS)` is `"FinishReason.MAX_TOKENS"`, not `"MAX_TOKENS"`. `FINISH_REASON_MAP` is keyed on the bare names (`"MAX_TOKENS"`, `"SAFETY"`, ...), so every non-STOP reason misses the map and falls back to `"stop"`. `STOP` only "works" by accident because the fallback is also `"stop"`.

net effect: Gemini truncations are reported as normal completions (`length` lost) and, more importantly for a safety tool, **SAFETY blocks / refusals are never surfaced as refusals**.

### repro (real google-genai SDK)
```python
from google.genai.types import FinishReason
str(FinishReason.MAX_TOKENS)          # 'FinishReason.MAX_TOKENS'  (not 'MAX_TOKENS')
FINISH_REASON_MAP.get(str(FinishReason.MAX_TOKENS), "stop")  # 'stop'  -> should be 'length'
```

### fix
look up via the enum's `.value` (`getattr(finish_reason, "value", finish_reason)`, robust to both the real enum and the plain-string form used in dict-validated inputs). also fixed the `refusal_out` line so refusal text is a clean reason string rather than `"FinishReason.SAFETY"`.

### test
added `test_from_google_max_tokens_maps_to_length` and `test_from_google_safety_maps_to_refusal` mirroring the file's existing tests. before: `2 failed` (`assert 'stop' == 'length'`, `assert 'stop' == 'refusal'`); after: pass. the existing translator tests only covered `STOP`, which is indistinguishable from the fallback, so the bug went unnoticed. ruff clean.

found by reading the translator.
