### PR TITLE
fix(scan): serialize garak detector construction before parallel run

### DIFF
--- a/libs/giskard-scan/src/giskard/scan/integrations/garak/_adapter.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/garak/_adapter.py
@@ -1,6 +1,7 @@
 """Adapter that runs garak through Giskard scan scenarios."""
 
 import asyncio
+import concurrent.futures
 import logging
 import time
 from collections import defaultdict
@@ -140,16 +141,7 @@ def _resolve_detectors(
     loop: "asyncio.AbstractEventLoop | None",
     cache: "dict[str, Detector] | None" = None,
 ) -> "tuple[list[tuple[str, Detector]], list[_SkipMarker]]":
-    """Resolve a probe's detectors, reusing any already in ``cache``.
-
-    Detectors download at construction time — ``HFDetector.__init__`` pulls model
-    weights from the Hub — so building the same detector once per probe both
-    re-downloads and, when probes run in parallel, races on the HF cache. A shared
-    ``cache`` keyed by detector name builds each distinct detector exactly once and
-    lets every probe reuse the instance. Both plain and judge detectors go through
-    the cache (garak's own ``PluginProvider`` dedups plain detectors by class but
-    not judge detectors, which we build out-of-band).
-    """
+    """Resolve a probe's detectors, reusing any already in ``cache``."""
     from garak._plugins import load_plugin
     from garak.detectors.judge import ModelAsJudge
     from garak.exception import APIKeyMissingError, GarakException
@@ -391,20 +383,35 @@ class GarakScanAdapter:
                 continue
             resolved.append((probe, detectors, skipped))
 
-        async with asyncio.TaskGroup() as task_group:
-            tasks = [
-                task_group.create_task(
-                    asyncio.to_thread(
-                        self._run_probe_isolated,
-                        probe,
-                        target,
-                        loop,
-                        detectors,
-                        skipped,
+        async def _run_on_executor(
+            executor: concurrent.futures.ThreadPoolExecutor,
+            probe: "Probe",
+            detectors: "list[tuple[str, Detector]]",
+            skipped: "list[_SkipMarker]",
+        ) -> list[ScenarioResult[TraceType]]:
+            return await loop.run_in_executor(
+                executor,
+                self._run_probe_isolated,
+                probe,
+                target,
+                loop,
+                detectors,
+                skipped,
+            )
+
+        probe_executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=max(len(resolved), 1)
+        )
+        try:
+            async with asyncio.TaskGroup() as task_group:
+                tasks = [
+                    task_group.create_task(
+                        _run_on_executor(probe_executor, probe, detectors, skipped)
                     )
-                )
-                for probe, detectors, skipped in resolved
-            ]
+                    for probe, detectors, skipped in resolved
+                ]
+        finally:
+            probe_executor.shutdown(wait=False)
 
         # Results are only available once the TaskGroup has exited and every
         # task has completed; reading task.result() inside the block would hit

--- a/libs/giskard-scan/src/giskard/scan/integrations/garak/_adapter.py
+++ b/libs/giskard-scan/src/giskard/scan/integrations/garak/_adapter.py
@@ -136,8 +136,20 @@ def _detector_class(name: str) -> "type[Detector] | None":
 
 
 def _resolve_detectors(
-    probe: "Probe", loop: "asyncio.AbstractEventLoop | None"
+    probe: "Probe",
+    loop: "asyncio.AbstractEventLoop | None",
+    cache: "dict[str, Detector] | None" = None,
 ) -> "tuple[list[tuple[str, Detector]], list[_SkipMarker]]":
+    """Resolve a probe's detectors, reusing any already in ``cache``.
+
+    Detectors download at construction time — ``HFDetector.__init__`` pulls model
+    weights from the Hub — so building the same detector once per probe both
+    re-downloads and, when probes run in parallel, races on the HF cache. A shared
+    ``cache`` keyed by detector name builds each distinct detector exactly once and
+    lets every probe reuse the instance. Both plain and judge detectors go through
+    the cache (garak's own ``PluginProvider`` dedups plain detectors by class but
+    not judge detectors, which we build out-of-band).
+    """
     from garak._plugins import load_plugin
     from garak.detectors.judge import ModelAsJudge
     from garak.exception import APIKeyMissingError, GarakException
@@ -151,26 +163,29 @@ def _resolve_detectors(
     detectors: list[tuple[str, Detector]] = []
     skipped: list[_SkipMarker] = []
     for name in detector_names:
+        if cache is not None and name in cache:
+            detectors.append((name, cache[name]))
+            continue
+
         full_name = f"detectors.{name}"
         detector_cls = _detector_class(name)
 
         # Judge detectors: install the Giskard generator so no judge key is needed.
         if detector_cls is not None and issubclass(detector_cls, ModelAsJudge):
-            detectors.append(
-                (
-                    name,
-                    cast(
-                        "Detector",
-                        make_judge_detector(
-                            detector_cls, get_default_generator(), loop
-                        ),
-                    ),
-                )
+            judge = cast(
+                "Detector",
+                make_judge_detector(detector_cls, get_default_generator(), loop),
             )
+            if cache is not None:
+                cache[name] = judge
+            detectors.append((name, judge))
             continue
 
         try:
-            detectors.append((name, cast("Detector", load_plugin(full_name))))
+            detector = cast("Detector", load_plugin(full_name))
+            if cache is not None:
+                cache[name] = detector
+            detectors.append((name, detector))
         except GarakException as exc:
             cause = exc.__cause__
             if isinstance(cause, APIKeyMissingError):
@@ -293,11 +308,12 @@ class GarakScanAdapter:
         probe: "Probe",
         target: Target[InputType, OutputType, TraceType],
         loop: asyncio.AbstractEventLoop,
+        detectors: "list[tuple[str, Detector]]",
+        skipped_detectors: "list[_SkipMarker]",
     ) -> list[ScenarioResult[TraceType]]:
         from ._generator import TargetGenerator
 
         generator = TargetGenerator(target=target, loop=loop)
-        detectors, skipped_detectors = _resolve_detectors(probe, loop)
 
         attempts = probe.probe(generator)
         scenario_results = []
@@ -325,9 +341,11 @@ class GarakScanAdapter:
         probe: "Probe",
         target: Target[InputType, OutputType, TraceType],
         loop: asyncio.AbstractEventLoop,
+        detectors: "list[tuple[str, Detector]]",
+        skipped_detectors: "list[_SkipMarker]",
     ) -> list[ScenarioResult[TraceType]]:
         try:
-            return self._run_probe(probe, target, loop)
+            return self._run_probe(probe, target, loop, detectors, skipped_detectors)
         except Exception as exc:  # noqa: BLE001 — probe errors are ignored per spec
             logger.warning("Probe %s raised: %s", probe.probename, exc)
             return []
@@ -355,12 +373,37 @@ class GarakScanAdapter:
 
         loop = asyncio.get_running_loop()
         start_time = time.perf_counter()
+
+        # Resolve every probe's detectors sequentially, before the parallel run.
+        # Detectors download at construction (HFDetector.__init__ pulls model
+        # weights); building them from the parallel probe threads races on the HF
+        # cache and can hang. The shared cache also builds each distinct detector
+        # once and reuses the instance across probes.
+        detector_cache: dict[str, Detector] = {}
+        resolved: list[tuple[Probe, list[tuple[str, Detector]], list[_SkipMarker]]] = []
+        for probe in probes:
+            try:
+                detectors, skipped = _resolve_detectors(probe, loop, detector_cache)
+            except Exception as exc:  # noqa: BLE001 — one bad probe must not abort the scan
+                logger.warning(
+                    "Resolving detectors for probe %s raised: %s", probe.probename, exc
+                )
+                continue
+            resolved.append((probe, detectors, skipped))
+
         async with asyncio.TaskGroup() as task_group:
             tasks = [
                 task_group.create_task(
-                    asyncio.to_thread(self._run_probe_isolated, probe, target, loop)
+                    asyncio.to_thread(
+                        self._run_probe_isolated,
+                        probe,
+                        target,
+                        loop,
+                        detectors,
+                        skipped,
+                    )
                 )
-                for probe in probes
+                for probe, detectors, skipped in resolved
             ]
 
         # Results are only available once the TaskGroup has exited and every

--- a/libs/giskard-scan/tests/integrations/garak/test_garak_run.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_garak_run.py
@@ -29,7 +29,7 @@ def _patch_resolvers(monkeypatch: pytest.MonkeyPatch, probes, detectors):
 
     monkeypatch.setattr(_adapter, "_resolve_probes", lambda probes_arg: probes)
     monkeypatch.setattr(
-        _adapter, "_resolve_detectors", lambda probe, loop: (detectors, [])
+        _adapter, "_resolve_detectors", lambda probe, loop, cache=None: (detectors, [])
     )
     return _adapter.GarakScanAdapter
 
@@ -279,6 +279,91 @@ async def test_run_marks_missing_detector_scores_as_skip(
         result.results[1].steps[0].results[0].message
         == "no detector score for this conversation"
     )
+
+
+class _RecordingProbe:
+    """Probe that logs a (phase, name) event when its .probe() runs."""
+
+    tags: list[str] = []
+
+    def __init__(self, name: str, log: list[tuple[str, str]]) -> None:
+        self.probename = name
+        self._log = log
+
+    def probe(self, generator: object) -> list[Attempt]:
+        self._log.append(("probe", self.probename))
+        return [_attempt(self.probename)]
+
+
+async def test_run_resolves_all_detectors_before_running_any_probe(
+    monkeypatch: pytest.MonkeyPatch, target
+) -> None:
+    """Detector construction is serialized before the parallel probe run.
+
+    HF-backed detectors download at construction time; doing that from the
+    parallel probe threads races on the HF cache. So every probe's detectors
+    must be resolved before the first probe's .probe() executes.
+    """
+    from giskard.scan.integrations.garak import _adapter
+
+    log: list[tuple[str, str]] = []
+
+    def fake_resolve(probe, loop, cache=None):
+        log.append(("resolve", probe.probename))
+        return ([("fake.Detector", _FakeDetector(score=0.1))], [])
+
+    monkeypatch.setattr(
+        _adapter, "_resolve_probes", lambda probes_arg: probes_arg or []
+    )
+    monkeypatch.setattr(_adapter, "_resolve_detectors", fake_resolve)
+
+    probes = [_RecordingProbe(f"p{i}", log) for i in range(3)]
+    await _adapter.GarakScanAdapter().run(target=target, probes=probes)
+
+    resolve_count = sum(1 for phase, _ in log if phase == "resolve")
+    first_probe_at = next(i for i, (phase, _) in enumerate(log) if phase == "probe")
+    resolves_before_first_probe = sum(
+        1 for phase, _ in log[:first_probe_at] if phase == "resolve"
+    )
+    assert resolve_count == 3
+    assert resolves_before_first_probe == 3, (
+        f"expected all 3 detector resolutions before the first probe ran, "
+        f"got {resolves_before_first_probe}; log={log}"
+    )
+
+
+def test_resolve_detectors_reuses_shared_cache() -> None:
+    """A detector name already in the shared cache is not rebuilt.
+
+    Reusing one instance across probes avoids re-downloading the same HF model
+    (HFDetector.__init__ pulls weights from the Hub) per probe.
+    """
+    from giskard.scan.integrations.garak import _adapter
+
+    build_calls: list[str] = []
+
+    def fake_load_plugin(full_name: str):
+        build_calls.append(full_name)
+        return _FakeDetector(score=0.1)
+
+    class _Probe:
+        primary_detector = "shared.Detector"
+        extended_detectors: list[str] = []
+
+    cache: dict[str, object] = {}
+    import garak._plugins as garak_plugins
+
+    original = garak_plugins.load_plugin
+    garak_plugins.load_plugin = fake_load_plugin
+    try:
+        first, _ = _adapter._resolve_detectors(_Probe(), None, cache=cache)
+        second, _ = _adapter._resolve_detectors(_Probe(), None, cache=cache)
+    finally:
+        garak_plugins.load_plugin = original
+
+    # Built once, reused the second time; both probes get the same instance.
+    assert build_calls == ["detectors.shared.Detector"]
+    assert first[0][1] is second[0][1]
 
 
 async def test_run_warns_and_drops_extra_detector_scores(

--- a/libs/giskard-scan/tests/integrations/garak/test_garak_structured_input.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_garak_structured_input.py
@@ -179,7 +179,7 @@ def _patch_resolvers(monkeypatch: pytest.MonkeyPatch, probes, detectors):
 
     monkeypatch.setattr(_adapter, "_resolve_probes", lambda probes_arg: probes)
     monkeypatch.setattr(
-        _adapter, "_resolve_detectors", lambda probe, loop: (detectors, [])
+        _adapter, "_resolve_detectors", lambda probe, loop, cache=None: (detectors, [])
     )
     return _adapter.GarakScanAdapter
 


### PR DESCRIPTION
## Description

Garak's HFDetector downloads its classifier model at construction time (HFDetector.__init__ -> from_pretrained). Detectors were resolved inside _run_probe, which runs on each asyncio.to_thread worker, so parallel probes built the same detector concurrently -> concurrent from_pretrained writes racing on the HF cache, which can hang the download at 0%.

Resolve every probe's detectors sequentially before the TaskGroup, backed by a shared name-keyed cache so each distinct detector (plain or judge) is built exactly once and reused across probes. Probe .probe() calls still run in parallel; only the contended construction is serialized.


<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Coding agents

Autonomous agents with no human in the loop must read **[AUTONOMOUS.md](https://github.com/Giskard-AI/giskard-oss/blob/main/AUTONOMOUS.md)** before opening a PR.

**PR title:** agent-opened PRs **must** end the title with **`🤖🤖🤖🤖`** (exactly four robot emojis). Do not omit — that suffix is how the expedited agent PR workflow picks up the PR.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [ ] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been
  modified)
