### PR TITLE
fix(scan): GOAT/Crescendo generators crash on empty languages list

### DIFF
--- a/libs/giskard-scan/src/giskard/scan/generators/crescendo.py
+++ b/libs/giskard-scan/src/giskard/scan/generators/crescendo.py
@@ -88,6 +88,7 @@ class CrescendoAttackScenarioGenerator(ScenarioGenerator):
         assignments = list(DEFAULT_CRESCENDO_OBJECTIVES.items())
         selected_assignments: list[tuple[str, str]]
         rng = rng or np.random.default_rng()
+        languages = languages or ["en"]
 
         if max_scenarios is None or max_scenarios >= len(assignments):
             selected_assignments = assignments

--- a/libs/giskard-scan/src/giskard/scan/generators/goat.py
+++ b/libs/giskard-scan/src/giskard/scan/generators/goat.py
@@ -177,6 +177,7 @@ class GOATAttackScenarioGenerator(ScenarioGenerator):
         assignments = list(DEFAULT_GOAT_OBJECTIVES.items())
         selected_assignments: list[tuple[str, str]]
         rng = rng or np.random.default_rng()
+        languages = languages or ["en"]
 
         if max_scenarios is None or max_scenarios >= len(assignments):
             selected_assignments = assignments

--- a/libs/giskard-scan/tests/generators/test_crescendo.py
+++ b/libs/giskard-scan/tests/generators/test_crescendo.py
@@ -93,3 +93,16 @@ async def test_crescendo_multiturn_still_returns_scenarios():
         target_mode="multiturn",
     )
     assert len(scenarios) == len(DEFAULT_CRESCENDO_OBJECTIVES)
+
+
+async def test_crescendo_generator_falls_back_to_english_with_empty_languages():
+    """An empty `languages` list should fall back to English, mirroring
+    KnowledgeBaseScenarioGenerator._sample_languages, instead of crashing in
+    `rng.integers(0)`."""
+    gen = CrescendoAttackScenarioGenerator()
+    scenarios = await gen.generate_scenario(
+        ScenarioContext(description="A safety chatbot", languages=[])
+    )
+
+    assert len(scenarios) == len(DEFAULT_CRESCENDO_OBJECTIVES)
+    assert all(scenario.annotations["language"] == "en" for scenario in scenarios)

--- a/libs/giskard-scan/tests/generators/test_goat.py
+++ b/libs/giskard-scan/tests/generators/test_goat.py
@@ -92,3 +92,16 @@ async def test_goat_multiturn_still_returns_scenarios():
         target_mode="multiturn",
     )
     assert len(scenarios) == len(DEFAULT_GOAT_OBJECTIVES)
+
+
+async def test_goat_generator_falls_back_to_english_with_empty_languages():
+    """An empty `languages` list should fall back to English, mirroring
+    KnowledgeBaseScenarioGenerator._sample_languages, instead of crashing in
+    `rng.integers(0)`."""
+    gen = GOATAttackScenarioGenerator()
+    scenarios = await gen.generate_scenario(
+        ScenarioContext(description="A safety chatbot", languages=[])
+    )
+
+    assert len(scenarios) == len(DEFAULT_GOAT_OBJECTIVES)
+    assert all(scenario.annotations["language"] == "en" for scenario in scenarios)


### PR DESCRIPTION
## What

Both `GOATAttackScenarioGenerator._select_objectives` and `CrescendoAttackScenarioGenerator._select_objectives` pick a random language via `languages[int(rng.integers(len(languages)))]`, with no guard for an empty `languages` list. `vulnerability_scan()` accepts `languages: list[str]` with no validation, so an empty list is easy to hit (e.g. a caller building the list programmatically), and raises `ValueError: high <= 0` from numpy instead of producing scenarios.

The sibling `KnowledgeBaseScenarioGenerator._sample_languages` already handles this exact case correctly:
```python
if not languages:
    return ["en"] * scenario_count
```
GOAT and Crescendo look like copy-pasted siblings (same objectives-dict structure, same `_select_objectives` body) that never received this guard.

**Repro:**
```python
await GOATAttackScenarioGenerator().generate_scenario(
    ScenarioContext(description="A safety chatbot", languages=[])
)
# ValueError: high <= 0
```

## Fix

`languages = languages or ["en"]` in both generators, mirroring the existing correct fallback in `KnowledgeBaseScenarioGenerator`.

## Test plan

- Added a regression test to both `test_goat.py` and `test_crescendo.py` asserting `languages=[]` falls back to `"en"` instead of raising.
- Verified red/green: reverted the fix locally, confirmed both new tests fail with `ValueError: high <= 0`; restored the fix, confirmed all 14 tests in both files pass.
- Ran the full `giskard-scan` package test suite (155 tests) — all pass.
- `make format` / `make lint` / pre-commit (ruff, basedpyright, detect-secrets) — all clean.

## AI-Generated disclosure

Found and fixed with AI-assisted code review (Claude Code), used with a human in the loop per this repo's `AGENTS.md`. I personally reproduced the crash, verified the fix against the sibling generator's existing correct pattern, and reviewed the diff before opening this PR.