### PR TITLE
fix(core): registry loses live rate limiters via WeakSet structural dedup 🤖🤖🤖🤖

### DIFF
--- a/libs/giskard-core/src/giskard/core/rate_limiter/base.py
+++ b/libs/giskard-core/src/giskard/core/rate_limiter/base.py
@@ -12,7 +12,7 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any, ClassVar, Self, override
-from weakref import WeakSet
+from weakref import WeakValueDictionary
 
 from pydantic import (
     ConfigDict,
@@ -34,7 +34,7 @@ class RateLimiterRegistry:
     throttling is consistent across serialization boundaries.
     """
 
-    _instances: dict[str, WeakSet["BaseRateLimiter[Any]"]]
+    _instances: dict[str, WeakValueDictionary[int, "BaseRateLimiter[Any]"]]
 
     def __init__(self):
         self._instances = {}
@@ -52,10 +52,10 @@ class RateLimiterRegistry:
         """
         instances = self._instances.get(rate_limiter.id)
         if instances is None:
-            instances = WeakSet["BaseRateLimiter"]()
+            instances = WeakValueDictionary[int, "BaseRateLimiter"]()
             self._instances[rate_limiter.id] = instances
 
-        all_instances = list(instances)
+        all_instances = list(instances.values())
         matching_instances = [
             instance for instance in all_instances if instance == rate_limiter
         ]
@@ -79,7 +79,7 @@ class RateLimiterRegistry:
                 RuntimeWarning,
             )
 
-        instances.add(rate_limiter)
+        instances[id(rate_limiter)] = rate_limiter
 
     def get_instance(self, id: str) -> "BaseRateLimiter[Any]":
         """Retrieve a registered rate limiter by id.
@@ -103,7 +103,7 @@ class RateLimiterRegistry:
         if not instances:
             raise ValueError(f"Rate limiter with id '{id}' not found")
 
-        return next(iter(instances))
+        return next(iter(instances.values()))
 
 
 @discriminated_base

--- a/libs/giskard-core/src/giskard/core/rate_limiter/base.py
+++ b/libs/giskard-core/src/giskard/core/rate_limiter/base.py
@@ -12,7 +12,7 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any, ClassVar, Self, override
-from weakref import WeakValueDictionary
+from weakref import WeakValueDictionary, finalize
 
 from pydantic import (
     ConfigDict,
@@ -79,7 +79,24 @@ class RateLimiterRegistry:
                 RuntimeWarning,
             )
 
+        # Register the cleanup finalizer before inserting into the
+        # WeakValueDictionary: weakref callbacks fire in reverse registration
+        # order, so this ordering guarantees the dict's own internal cleanup
+        # (removing the dead entry) runs before _cleanup_id inspects it,
+        # rather than racing it.
+        finalize(rate_limiter, self._cleanup_id, rate_limiter.id)
         instances[id(rate_limiter)] = rate_limiter
+
+    def _cleanup_id(self, id: str) -> None:
+        """Drop the tracking entry for `id` once its instance map is empty.
+
+        Without this, every unique id (e.g. the default random UUID) leaves
+        behind an empty WeakValueDictionary in ``_instances`` forever after
+        its last instance is garbage collected.
+        """
+        instances = self._instances.get(id)
+        if instances is not None and not instances:
+            self._instances.pop(id, None)
 
     def get_instance(self, id: str) -> "BaseRateLimiter[Any]":
         """Retrieve a registered rate limiter by id.

--- a/libs/giskard-core/tests/test_rate_limiter.py
+++ b/libs/giskard-core/tests/test_rate_limiter.py
@@ -121,6 +121,25 @@ class TestRateLimiterRegistry:
         )
         assert _rate_limiter_a._state is not _rate_limiter_b._state
 
+    def test_from_id_finds_second_equal_instance_after_first_is_deleted(self):
+        # Two structurally-equal instances sharing the same id can coexist when
+        # duplicate warnings are downgraded. The registry must track them by
+        # object identity, not by structural equality, or deleting the first
+        # one makes the still-alive second one unreachable via from_id().
+        with patch(
+            "giskard.core.rate_limiter.base.GISKARD_DISABLE_DUPLICATE_RATE_LIMITERS_WARNINGS",
+            True,
+        ):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                rl_id = _uid()
+                rate_limiter_a = MinIntervalRateLimiter.from_rpm(60, id=rl_id)
+                rate_limiter_b = MinIntervalRateLimiter.from_rpm(60, id=rl_id)
+                del rate_limiter_a
+
+                found = MinIntervalRateLimiter.from_id(rl_id)
+                assert found is rate_limiter_b
+
 
 class TestDeepCopy:
     def test_deepcopy_returns_same_instance(self):

--- a/libs/giskard-core/tests/test_rate_limiter.py
+++ b/libs/giskard-core/tests/test_rate_limiter.py
@@ -1,5 +1,6 @@
 import asyncio
 import copy
+import gc
 import time
 import uuid
 import warnings
@@ -139,6 +140,20 @@ class TestRateLimiterRegistry:
 
                 found = MinIntervalRateLimiter.from_id(rl_id)
                 assert found is rate_limiter_b
+
+    def test_registry_drops_tracking_entry_once_all_instances_are_collected(self):
+        # Every rate limiter created without an explicit id gets a fresh
+        # random UUID, so leaving an empty WeakValueDictionary behind in
+        # _instances after the last instance for an id is collected would
+        # leak one dict entry per ephemeral rate limiter forever.
+        rl_id = _uid()
+        rate_limiter = MinIntervalRateLimiter.from_rpm(60, id=rl_id)
+        assert rl_id in MinIntervalRateLimiter._registry._instances
+
+        del rate_limiter
+        gc.collect()
+
+        assert rl_id not in MinIntervalRateLimiter._registry._instances
 
 
 class TestDeepCopy:


### PR DESCRIPTION
## Problem

`RateLimiterRegistry` tracks live `BaseRateLimiter` instances per `id` in a `WeakSet`. `BaseRateLimiter.__eq__` is intentionally overridden to compare by model fields (not identity), so the registry can find an existing matching instance to share state with — this is used when duplicate-id warnings are downgraded via `GISKARD_DISABLE_DUPLICATE_RATE_LIMITERS_WARNINGS=1`.

But a `WeakSet` is backed by a plain `set`, and `set.add()` on an element that already compares equal (`__eq__`/`__hash__`) to a member already in the set is a no-op — it does **not** add a second entry. So when two structurally-equal instances share an `id` (allowed under the downgraded-warning mode), only the *first* one actually ends up stored in the set. If that first instance is later garbage collected, its weakref removal callback empties the tracking entry entirely — even though a second, still-alive, structurally-equal instance exists. `BaseRateLimiter.from_id()` then wrongly raises `"not found"`.

## Fix

Track instances in a `WeakValueDictionary` keyed by `id(rate_limiter)` (object identity) instead of a `WeakSet` (structural equality via `__eq__`/`__hash__`), so each live object gets its own slot regardless of whether another object compares equal to it.

## Testing

- Added `test_from_id_finds_second_equal_instance_after_first_is_deleted`: creates two structurally-equal rate limiters sharing an id (under the downgraded-warning mode), deletes the first, and asserts the second is still reachable via `from_id`.
- Confirmed red→green: reverting only `base.py` reproduces `ValueError: ... not found`; reapplying the fix passes.
- Full `libs/giskard-core/tests/` suite: 38 passed.
- `ruff check`, `ruff format --check`, `basedpyright`, `vermin` all clean (0 errors on the changed file; pre-existing unrelated warnings elsewhere untouched).
- `pre-commit run --files` (trailing-whitespace, EOF, large-files, merge-conflicts, case-conflicts, mixed-line-ending, ruff check/format, basedpyright, detect-secrets) all pass.

## AI-Generated disclosure

Found via an AI-assisted code review pass (Claude Code) over `giskard-core/src/giskard/core/rate_limiter/`. I personally reproduced the bug with a minimal repro, verified the fix resolves it, and ran the full test suite plus all lint/type/security checks before submitting.