### PR TITLE
fix(checks): last_interaction_index wrongly attributes results when a step adds zero new interactions 🤖🤖🤖🤖

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
@@ -133,9 +133,12 @@ class ScenarioRunner:
         )
 
         for step in steps:
+            interactions_before = len(trace.interactions)
             trace = await trace.with_interactions(*step.interacts)
             last_interaction_index = (
-                len(trace.interactions) - 1 if trace.interactions else None
+                len(trace.interactions) - 1
+                if len(trace.interactions) > interactions_before
+                else None
             )
 
             test_case = TestCase(

--- a/libs/giskard-checks/tests/core/test_scenario.py
+++ b/libs/giskard-checks/tests/core/test_scenario.py
@@ -569,6 +569,32 @@ class TestScenarioEdgeCases:
         assert len(result.final_trace.interactions) == 0
         assert result.passed
 
+    async def test_last_interaction_index_is_none_when_step_adds_no_new_interactions(
+        self,
+    ):
+        """A step whose interaction spec yields zero interactions must report
+        last_interaction_index=None for that step, even when an earlier step
+        already populated the trace -- it must not point at a prior step's
+        interaction."""
+        interaction1 = Interaction(inputs="in1", outputs="out1")
+        spec_with_interaction = MockInteractionSpec(interactions=[interaction1])
+        spec_with_no_interactions = MockInteractionSpec(interactions=[])
+        check1 = MockCheck(result=CheckResult.success(message="c1"))
+        check2 = MockCheck(result=CheckResult.success(message="c2"))
+
+        result = await (
+            Scenario("last_interaction_index_repro")
+            .add_interaction(spec_with_interaction)
+            .check(check1)
+            .add_interaction(spec_with_no_interactions)
+            .check(check2)
+            .run()
+        )
+
+        assert len(result.steps) == 2
+        assert result.steps[0].last_interaction_index == 0
+        assert result.steps[1].last_interaction_index is None
+
     async def test_scenario_with_multiple_consecutive_interactions(self):
         """Test scenario with multiple consecutive interaction specs."""
         mock_interactions: list[InteractionSpec[str, str, Trace[str, str]]] = [


### PR DESCRIPTION
Fixes #2736

## Problem

`ScenarioRunner._run_once` computed each step's `last_interaction_index` as `len(trace.interactions) - 1 if trace.interactions else None` — i.e. `None` only when the **whole cumulative trace** is empty, not when **this step's** `interacts` added zero new interactions. A step whose interaction spec yields nothing (e.g. a conditional interaction generator that sometimes produces no interaction) after an earlier step already populated the trace gets wrongly attributed to the prior step's last interaction instead of `None`, contradicting the field's own documented contract ("`None` when the step added no interactions").

`TestCaseResult.last_interaction_index`'s docstring explicitly documents consumers (e.g. the Giskard Hub upload flow) using this field to attribute check results to a specific interaction — a wrong index here means a check result gets attributed to the wrong interaction in that downstream flow.

## Fix

Track `interactions_before = len(trace.interactions)` before running the step's `interacts`, then compare against the count after — only report an index when interactions actually grew for this step.

## Testing

- Added `test_last_interaction_index_is_none_when_step_adds_no_new_interactions`, using an interaction spec that generates zero interactions after an earlier step already added one, asserting the second step correctly reports `None` (not the first step's index).
- Confirmed red→green: reverting only `runner.py` reproduces `assert 0 is None` (wrongly attributed to the prior step); reapplying passes.
- Full `libs/giskard-checks/tests/` suite: 739 passed, 4 skipped (unrelated).
- `ruff check`/`ruff format --check` and `basedpyright` — 0 errors (pre-existing unrelated warnings elsewhere in the file untouched).
- `pre-commit run --files` — all hooks pass.

**Note on overlap**: #2599 ("fix(checks): record input generation errors") also touches this function and adds a new except-block that reproduces the same unfixed `len(trace.interactions) - 1 if trace.interactions else None` pattern in a different code path (input-generation-failure handling). This PR doesn't touch that new block, so it's not a duplicate, but merging both may need a small rebase depending on order — happy to reconcile once I know which lands first.

## AI-Generated disclosure

Found via an AI-assisted code review pass (Claude Code) over `giskard-checks/src/giskard/checks/scenarios/`. I personally traced the per-step vs whole-trace distinction against the field's documented contract, reproduced the wrong attribution, verified the fix, and ran the full test suite plus lint/type checks before submitting.