### PR TITLE
fix(checks): dot-wildcard/multi-field JSONPath returns scalar vs list depending on match count

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/core/extraction.py
+++ b/libs/giskard-checks/src/giskard/checks/core/extraction.py
@@ -4,6 +4,7 @@ from jsonpath_ng import (
     Child,
     DatumInContext,
     Descendants,
+    Fields,
     Intersect,
     JSONPath,
     Slice,
@@ -74,6 +75,9 @@ def _is_list_expression(expression: JSONPath) -> bool:
 
     if isinstance(expression, Slice | Union | Intersect):
         return True
+
+    if isinstance(expression, Fields):
+        return len(expression.fields) > 1 or "*" in expression.fields
 
     return False
 

--- a/libs/giskard-checks/tests/core/test_extraction.py
+++ b/libs/giskard-checks/tests/core/test_extraction.py
@@ -1,7 +1,12 @@
 """Unit tests for JSONPath validation in extraction.py."""
 
 import pytest
-from giskard.checks.core.extraction import JSONPathStr, _validate_jsonpath_syntax
+from giskard.checks.core.extraction import (
+    JSONPathStr,
+    _validate_jsonpath_syntax,
+    resolve,
+)
+from giskard.checks.core.interaction import Interaction, Trace
 from pydantic import BaseModel, ValidationError
 
 
@@ -73,6 +78,44 @@ class TestValidateJsonpathSyntax:
     def test_valid_descendants_operator(self):
         """JSONPath descendants operator (..) should be valid."""
         assert _validate_jsonpath_syntax("trace..outputs") == "trace..outputs"
+
+
+class TestResolveDotWildcard:
+    """Tests for resolve()'s handling of dot-wildcard/multi-field JSONPath expressions.
+
+    A dot-wildcard (``trace.last.metadata.*``) or multi-field selector must always
+    resolve to a list, regardless of how many keys it actually matches -- otherwise
+    ComparisonCheck's match=any/all/none (which requires list/set/tuple) breaks
+    whenever the matched dict happens to have exactly one key.
+    """
+
+    def test_wildcard_with_single_match_returns_a_list_not_a_bare_scalar(self):
+        trace = Trace[str, str](
+            interactions=[
+                Interaction(inputs="hi", outputs="hello", metadata={"only_key": "v1"})
+            ]
+        )
+        assert resolve(trace, "trace.last.metadata.*") == ["v1"]
+
+    def test_wildcard_with_multiple_matches_returns_a_list(self):
+        trace = Trace[str, str](
+            interactions=[
+                Interaction(
+                    inputs="hi",
+                    outputs="hello",
+                    metadata={"k1": "v1", "k2": "v2"},
+                )
+            ]
+        )
+        result = resolve(trace, "trace.last.metadata.*")
+        assert isinstance(result, list)
+        assert sorted(result) == ["v1", "v2"]
+
+    def test_non_wildcard_single_field_still_returns_a_bare_scalar(self):
+        trace = Trace[str, str](
+            interactions=[Interaction(inputs="hi", outputs="hello")]
+        )
+        assert resolve(trace, "trace.last.outputs") == "hello"
 
 
 class TestJSONPathStrAnnotatedType:


### PR DESCRIPTION
## Problem

`_is_list_expression` special-cases bracket wildcards (`Slice`, `Union`, `Intersect`) to force `resolve()` to return a list, but never checks `jsonpath_ng.Fields` — what dot-wildcards like `trace.last.metadata.*` (and comma-separated multi-field selectors) actually compile to.

As a result, `resolve()` falls through to its match-count heuristic (`len(matches) > 1 or _is_list_expression(expression)`) for these expressions: a wildcard matching exactly 1 key returns a bare scalar, while 2+ matches correctly returns a list. This breaks `ComparisonCheck`'s `match=any/all/none` semantics (which require list/set/tuple) whenever the matched dict happens to have exactly one key — entirely dependent on incidental data shape, not the expression's own structure.

## Fix

Add a `Fields` branch treating any multi-field selector (`len(expression.fields) > 1`) or wildcard (`"*" in expression.fields`) as a list-expression, matching the existing bracket-wildcard handling.

## Testing

- Added `TestResolveDotWildcard` covering the single-match, multi-match, and non-wildcard-single-field cases.
- Confirmed red→green: reverting only `extraction.py` reproduces `'v1' == ['v1']` (bare scalar instead of a list) for the single-match wildcard case; reapplying passes.
- Full `libs/giskard-checks/tests/` suite: 741 passed, 4 skipped (unrelated).
- `ruff check`/`ruff format --check` and `basedpyright` — 0 errors (pre-existing unrelated warnings elsewhere in the file untouched).
- xref: no open PR touches `core/extraction.py`.

## AI-Generated disclosure

Found via an AI-assisted code review pass (Claude Code) over `giskard-checks/src/giskard/checks/core/`. I personally reproduced the match-count-dependent behavior with a minimal repro, verified the fix against single-match/multi-match/non-wildcard cases, and ran the full test suite plus lint/type checks before submitting.