### PR TITLE
docs(giskard-llm): OpenAI-compatible multi-model gateway example (DaoXE)

### DIFF
--- a/libs/giskard-llm/README.md
+++ b/libs/giskard-llm/README.md
@@ -97,6 +97,36 @@ Use `azure_ai/` for the existing Azure AI Foundry compatibility path. Do not
 use `azure_ai/` for new OpenAI v1 endpoints unless you intentionally need that
 legacy endpoint behavior.
 
+## OpenAI-compatible multi-model gateways
+
+Any OpenAI-compatible Chat Completions host can use the `openai` provider with
+a custom `base_url`. Example with [DaoXE](https://daoxe.com)
+(`https://daoxe.com/v1`):
+
+```python
+from giskard.llm import LLMClient
+
+client = LLMClient()
+client.configure(
+    "daoxe",
+    provider="openai",
+    api_key="os.environ/DAOXE_API_KEY",  # pragma: allowlist secret
+    base_url="https://daoxe.com/v1",
+)
+
+response = await client.acompletion(
+    "daoxe/your-account-model-id",  # exact ID from GET /v1/models or dashboard
+    [{"role": "user", "content": "Write one sentence."}],
+)
+```
+
+Notes:
+
+- Model IDs are account-scoped; do not hardcode a static public catalog.
+- Chat Completions path only on this snippet.
+- DaoXE is not available in mainland China.
+- Contributor disclosure: this example was contributed by a DaoXE affiliate.
+
 ## Custom transport and headers
 
 Use `http_client` to provide a caller-owned async HTTP client, for example

--- a/libs/giskard-llm/README.md
+++ b/libs/giskard-llm/README.md
@@ -123,7 +123,7 @@ response = await client.acompletion(
 Notes:
 
 - Model IDs are account-scoped; do not hardcode a static public catalog.
-- Chat Completions path only on this snippet.
+- This snippet only demonstrates the Chat Completions path.
 - DaoXE is not available in mainland China.
 - Contributor disclosure: this example was contributed by a DaoXE affiliate.
 


### PR DESCRIPTION
## Summary

Adds a short example to `libs/giskard-llm/README.md` showing how to point `LLMClient` at an OpenAI-compatible multi-model gateway via `provider=\"openai\"` + custom `base_url`.

Example uses [DaoXE](https://daoxe.com) (`https://daoxe.com/v1`).

- Docs only
- Same pattern as Azure Foundry OpenAI v1 (`openai` provider + `base_url`)

### Notes

- Account-scoped model IDs
- Chat Completions path
- DaoXE not available in mainland China
- Contributor is affiliated with DaoXE

## Test plan

- [ ] README section renders
- [ ] Optional: `LLMClient.configure(\"daoxe\", provider=\"openai\", base_url=\"https://daoxe.com/v1\")` with a real key