### PR TITLE
feat(checks): opt-in progress logging for scenario/check execution (#…

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
@@ -147,17 +147,18 @@ class ScenarioRunner:
                 len(trace.interactions) - 1 if trace.interactions else None
             )
 
-            check_names = (
-                ", ".join(str(check.name or check.kind) for check in step.checks)
-                or "<none>"
-            )
-            logger.info(
-                "Scenario %r: running step %d/%d (checks: %s)",
-                scenario.name,
-                step_index,
-                total_steps,
-                check_names,
-            )
+            if logger.isEnabledFor(logging.INFO):
+                check_names = (
+                    ", ".join(str(check.name or check.kind) for check in step.checks)
+                    or "<none>"
+                )
+                logger.info(
+                    "Scenario %r: running step %d/%d (checks: %s)",
+                    scenario.name,
+                    step_index,
+                    total_steps,
+                    check_names,
+                )
 
             test_case = TestCase(
                 trace=trace,

--- a/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
@@ -170,13 +170,14 @@ class ScenarioRunner:
             )
             steps_results.append(step_result)
 
-            logger.info(
-                "Scenario %r: step %d/%d %s",
-                scenario.name,
-                step_index,
-                total_steps,
-                "passed" if step_result.passed else "failed",
-            )
+            if logger.isEnabledFor(logging.INFO):
+                logger.info(
+                    "Scenario %r: step %d/%d %s",
+                    scenario.name,
+                    step_index,
+                    total_steps,
+                    "passed" if step_result.passed else "failed",
+                )
 
             # Stop on first failure
             if not step_result.passed:

--- a/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
@@ -5,6 +5,7 @@ pattern, where components yield Interactions or CheckResults and receive
 updated Trace objects via the async generator protocol.
 """
 
+import logging
 import time
 from typing import Any, cast
 
@@ -23,6 +24,13 @@ from ..core.scenario import Scenario, Step
 from ..core.testcase import TestCase
 from ..core.types import Target
 from ..utils.inference import _infer_trace_type
+
+# Progress logging is opt-in via the standard logging hierarchy, e.g.
+# ``logging.getLogger("giskard").setLevel(logging.INFO)``. It stays silent at
+# the default WARNING level, so existing behavior is unchanged. Each record
+# carries the scenario name so output remains readable when scenarios run
+# concurrently under ``Suite.run(parallel=True)``.
+logger = logging.getLogger(__name__)
 
 
 def _validate_multiple_runs(value: int | None) -> int | None:
@@ -132,10 +140,23 @@ class ScenarioRunner:
             properties=shape_props,
         )
 
-        for step in steps:
+        total_steps = len(steps)
+        for step_index, step in enumerate(steps, start=1):
             trace = await trace.with_interactions(*step.interacts)
             last_interaction_index = (
                 len(trace.interactions) - 1 if trace.interactions else None
+            )
+
+            check_names = (
+                ", ".join(str(check.name or check.kind) for check in step.checks)
+                or "<none>"
+            )
+            logger.info(
+                "Scenario %r: running step %d/%d (checks: %s)",
+                scenario.name,
+                step_index,
+                total_steps,
+                check_names,
             )
 
             test_case = TestCase(
@@ -147,6 +168,14 @@ class ScenarioRunner:
                 update={"last_interaction_index": last_interaction_index}
             )
             steps_results.append(step_result)
+
+            logger.info(
+                "Scenario %r: step %d/%d %s",
+                scenario.name,
+                step_index,
+                total_steps,
+                "passed" if step_result.passed else "failed",
+            )
 
             # Stop on first failure
             if not step_result.passed:

--- a/libs/giskard-checks/tests/scenarios/test_runner_logging.py
+++ b/libs/giskard-checks/tests/scenarios/test_runner_logging.py
@@ -1,0 +1,61 @@
+"""Opt-in progress logging in the scenario runner (issue #2421).
+
+The runner emits INFO-level progress via the standard ``logging`` hierarchy,
+so callers can surface per-step / per-check progress in CI, scripts, and
+notebooks without the rich progress bar. It stays silent by default.
+"""
+
+import logging
+from typing import Any
+
+import pytest
+from giskard.checks import Equals, Scenario, Suite
+
+
+def _identity(inputs: Any) -> Any:
+    return inputs
+
+
+def _demo_suite() -> Suite[Any, Any]:
+    suite = Suite(name="demo", target=_identity)
+    suite.append(
+        Scenario("scenario_1")
+        .interact("hello")
+        .checks(Equals(expected_value="hello", key="trace.last.outputs"))
+    )
+    return suite
+
+
+@pytest.mark.asyncio
+async def test_runner_logs_step_progress_at_info(caplog):
+    """At INFO, running a suite surfaces scenario + check identity (start & end)."""
+    with caplog.at_level(logging.INFO, logger="giskard"):
+        result = await _demo_suite().run()
+
+    assert result.pass_rate == 1.0
+
+    messages = [r.getMessage() for r in caplog.records if r.name.startswith("giskard")]
+    joined = "\n".join(messages)
+
+    # Scenario identity is present so interleaved parallel output stays readable.
+    assert "scenario_1" in joined
+    # Check identity is surfaced (name falls back to kind, e.g. "equals").
+    assert "equals" in joined
+    # Both the start and the completion of the step are logged.
+    assert any("running step" in m for m in messages)
+    assert any("passed" in m for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_runner_quiet_by_default(caplog):
+    """At the default level the runner emits no INFO progress logs (backward-compatible)."""
+    caplog.set_level(logging.WARNING, logger="giskard")
+
+    await _demo_suite().run()
+
+    below_warning = [
+        r
+        for r in caplog.records
+        if r.name.startswith("giskard") and r.levelno < logging.WARNING
+    ]
+    assert below_warning == []


### PR DESCRIPTION
…2421)

## Description

Adds opt-in, per-step progress logging to the scenario runner so long `Suite.run()`
executions surface which scenario and checks are running — useful in CI, scripts, and
notebooks where the rich progress bar doesn't render.

`Suite.run()` already exposes a `verbose` flag + `_SuiteProgress` bar for scenario-level
progress; this closes the check-level gap, where `ScenarioRunner._run_once` previously
emitted nothing.

**Changes**
- `scenarios/runner.py`: module logger; INFO logs at step start (scenario name + step
  index + check identities) and completion (pass/fail). `check.name` falls back to
  `check.kind` when unset.
- `tests/scenarios/test_runner_logging.py`: covers logs-at-INFO and quiet-by-default.

**Design**
- Opt-in via standard logging levels — silent by default; enable with
  `logging.getLogger("giskard").setLevel(logging.INFO)`. No new API, backward-compatible
  (uses the Python-logging option suggested in the issue).
- Async-safe — every log line includes the scenario name, so interleaved output under
  `parallel=True` stays readable.
- Scenario-level rich bar left untouched.

**Testing** — full `giskard-checks` suite (754 passed), whole monorepo (1,268 passed,
0 failed), serial + `parallel=True` verified manually, `make check` clean.

_Developed with AI assistance (human-in-the-loop; I reviewed and verified all changes)._


<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Coding agents

Autonomous agents with no human in the loop must read **[AUTONOMOUS.md](https://github.com/Giskard-AI/giskard-oss/blob/main/AUTONOMOUS.md)** before opening a PR.

**PR title:** agent-opened PRs **must** end the title with **`🤖🤖🤖🤖`** (exactly four robot emojis). Do not omit — that suffix is how the expedited agent PR workflow picks up the PR.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ x] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [ x] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [ x] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [ ] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been
  modified)
