### PR TITLE
fix(llm): use .text not .content in _validate_messages to avoid AttributeError on list content

### DIFF
--- a/libs/giskard-llm/src/giskard/llm/providers/anthropic.py
+++ b/libs/giskard-llm/src/giskard/llm/providers/anthropic.py
@@ -224,7 +224,7 @@ class AnthropicProvider:
                 raise BadRequestError(
                     400, "Tool messages must have a tool_call_id.", PROVIDER
                 )
-            if m.role in _ANTHROPIC_INSTRUCTION_ROLES and not (m.content or "").strip():
+            if m.role in _ANTHROPIC_INSTRUCTION_ROLES and not (m.text or "").strip():
                 raise BadRequestError(
                     400,
                     "System and developer messages must have non-empty content.",

--- a/libs/giskard-llm/src/giskard/llm/providers/google.py
+++ b/libs/giskard-llm/src/giskard/llm/providers/google.py
@@ -331,7 +331,7 @@ class GoogleProvider:
                 raise BadRequestError(
                     400, "Tool messages must have a tool_call_id.", PROVIDER
                 )
-            if m.role in _INSTRUCTION_ROLES and not (m.content or "").strip():
+            if m.role in _INSTRUCTION_ROLES and not (m.text or "").strip():
                 raise BadRequestError(
                     400, "System messages must have non-empty content.", PROVIDER
                 )

--- a/libs/giskard-llm/src/giskard/llm/providers/openai.py
+++ b/libs/giskard-llm/src/giskard/llm/providers/openai.py
@@ -222,7 +222,7 @@ class OpenAIProvider:
                 raise BadRequestError(
                     400, "Tool messages must have a tool_call_id.", self._PROVIDER
                 )
-            if m.role in _INSTRUCTION_ROLES and not (m.content or "").strip():
+            if m.role in _INSTRUCTION_ROLES and not (m.text or "").strip():
                 raise BadRequestError(
                     400, "System messages must have non-empty content.", self._PROVIDER
                 )

--- a/libs/giskard-llm/tests/test_providers.py
+++ b/libs/giskard-llm/tests/test_providers.py
@@ -598,6 +598,27 @@ async def test_openai_validate_empty_system_content(mock_import):
 
 @patch("giskard.llm.providers.openai._import_openai")
 @pytest.mark.openai
+async def test_openai_validate_developer_content_as_content_blocks(mock_import):
+    """Developer ``content`` typed as a list of ``TextContent`` blocks (the SDK-native
+    shape, reachable via plain-dict validation) must be normalized through ``.text``,
+    not crash with ``AttributeError`` from calling ``.strip()`` on a list."""
+    mock_import.return_value = MagicMock()
+    provider = _make_openai_provider()
+    provider._client.chat.completions.create = AsyncMock(
+        return_value=_make_openai_response("Hello")
+    )
+    resp = await provider.complete(
+        "gpt-4o",
+        [
+            {"role": "developer", "content": [{"type": "text", "text": "Be helpful"}]},
+            {"role": "user", "content": "Hi"},
+        ],
+    )
+    assert resp.choices[0].message.content == "Hello"
+
+
+@patch("giskard.llm.providers.openai._import_openai")
+@pytest.mark.openai
 async def test_openai_multiple_system_works(mock_import):
     """OpenAI supports multiple system messages natively."""
     mock_import.return_value = MagicMock()
@@ -720,6 +741,31 @@ async def test_anthropic_validate_empty_developer_content(mock_import):
 
 
 @patch("giskard.llm.providers.anthropic._import_anthropic")
+async def test_anthropic_validate_developer_content_as_content_blocks(mock_import):
+    """Developer ``content`` typed as a list of ``TextContent`` blocks must be
+    normalized through ``.text``, not crash with ``AttributeError`` from calling
+    ``.strip()`` on a list."""
+    mock_import.return_value = MagicMock()
+    provider = _make_anthropic_provider()
+
+    mock_raw = MagicMock()
+    mock_raw.content = [SimpleNamespace(type="text", text="Hello")]
+    mock_raw.stop_reason = "end_turn"
+    mock_raw.model = "claude-3"
+    mock_raw.usage = SimpleNamespace(input_tokens=10, output_tokens=5)
+    provider._client.messages.create = AsyncMock(return_value=mock_raw)
+
+    resp = await provider.complete(
+        "claude-3",
+        [
+            {"role": "developer", "content": [{"type": "text", "text": "Be helpful"}]},
+            {"role": "user", "content": "Hi"},
+        ],
+    )
+    assert resp.choices[0].message.content == [TextContent(text="Hello")]
+
+
+@patch("giskard.llm.providers.anthropic._import_anthropic")
 async def test_anthropic_validate_alternation(mock_import):
     mock_import.return_value = MagicMock()
     provider = _make_anthropic_provider()
@@ -732,6 +778,47 @@ async def test_anthropic_validate_alternation(mock_import):
                 {"role": "user", "content": "Hello again"},
             ],
         )
+
+
+# -- Google message validation --------------------------------------------------
+
+
+@patch("giskard.llm.providers.google._import_genai_errors")
+@pytest.mark.google
+async def test_google_validate_developer_content_as_content_blocks(mock_errors):
+    """Developer ``content`` typed as a list of ``TextContent`` blocks must be
+    normalized through ``.text``, not crash with ``AttributeError`` from calling
+    ``.strip()`` on a list."""
+    genai_types = pytest.importorskip("google.genai.types")
+    mock_errors.return_value = MagicMock()
+    provider = _make_google_provider()
+    provider._client.aio = MagicMock()
+    provider._client.aio.models = MagicMock()
+    raw = genai_types.GenerateContentResponse.model_validate(
+        {
+            "candidates": [
+                {
+                    "content": {"parts": [{"text": "Hello"}]},
+                    "finish_reason": "STOP",
+                }
+            ],
+            "usage_metadata": {
+                "prompt_token_count": 3,
+                "candidates_token_count": 4,
+                "total_token_count": 7,
+            },
+        }
+    )
+    provider._client.aio.models.generate_content = AsyncMock(return_value=raw)
+
+    resp = await provider.complete(
+        "gemini-3.5-flash",
+        [
+            {"role": "developer", "content": [{"type": "text", "text": "Be helpful"}]},
+            {"role": "user", "content": "Hi"},
+        ],
+    )
+    assert resp.choices[0].message.content == [TextContent(text="Hello")]
 
 
 # -- OpenAI Responses API (respond) -------------------------------------------


### PR DESCRIPTION
## What

`_validate_messages` in the OpenAI, Anthropic, and Google providers raises `AttributeError: 'list' object has no attribute 'strip'` when a system/developer message carries **list-typed content** instead of a plain string.

Each provider guards empty instruction messages with:

```python
if m.role in _INSTRUCTION_ROLES and not (m.content or "").strip():
    raise BadRequestError(...)
```

But `SystemMessage.content` / `DeveloperMessage.content` is typed `str | Sequence[TextContent]`. When it's a non-empty list (a legitimate, reachable input via plain-dict validation), `(m.content or "")` returns the list and `.strip()` blows up with `AttributeError` — instead of the intended `BadRequestError` (or passing validation for non-empty content).

## Fix

Use the `.text` property already defined on these message models (built for exactly this normalization) instead of the raw `.content`:

```python
if m.role in _INSTRUCTION_ROLES and not (m.text or "").strip():
```

Three-line change, one per provider (`openai.py`, `anthropic.py`, `google.py`).

## Testing

Added a regression test per provider in `libs/giskard-llm/tests/test_providers.py` — a developer/system-role message with list-typed content. All three reproduce the identical `AttributeError` before the fix (TDD red confirmed by reverting the 3 source files) and pass after. Full `libs/giskard-llm/tests/test_providers.py` suite: 47 passed. `ruff check` + `ruff format --check` clean.

xref: no open PR or issue touches these three files or `_validate_messages`.

---
Disclosure: this PR was drafted with AI assistance (Claude); I reviewed, tested, and take responsibility for the change.
