### PR TITLE
fix(agents): guard on chat.messages not chat.last to avoid IndexError in _run_tools

### DIFF
--- a/libs/giskard-agents/src/giskard/agents/workflow.py
+++ b/libs/giskard-agents/src/giskard/agents/workflow.py
@@ -166,7 +166,7 @@ class _StepRunner:
 
     async def _run_tools(self, chat: Chat[Any]) -> AsyncGenerator[ToolMessage, None]:
         if (
-            not chat.last
+            not chat.messages
             or not isinstance(chat.last, AssistantMessage)
             or not chat.last.tool_calls
         ):

--- a/libs/giskard-agents/tests/test_workflow_steps.py
+++ b/libs/giskard-agents/tests/test_workflow_steps.py
@@ -120,3 +120,29 @@ async def test_run_returns_successful_chat():
 
     assert not chat.failed
     assert chat.last.content == "World!"
+
+
+async def test_run_with_no_messages_does_not_raise_indexerror():
+    """A ChatWorkflow with no messages added must not crash with IndexError.
+
+    ``_run_tools``'s guard checks ``not chat.last`` before checking whether
+    there is anything to process, but ``Chat.last`` indexes ``messages[-1]``,
+    which raises ``IndexError`` on an empty list instead of behaving falsy.
+    """
+    gen = MagicMock(spec=BaseGenerator)
+    gen.complete = AsyncMock(
+        return_value=CompletionResponse(
+            choices=[
+                Choice(
+                    message=AssistantMessage(content="Hello!"),
+                    finish_reason="stop",
+                    index=0,
+                )
+            ]
+        )
+    )
+
+    chat = await ChatWorkflow(generator=gen).run()
+
+    assert not chat.failed
+    assert chat.last.content == "Hello!"


### PR DESCRIPTION
## What

`ChatWorkflow(...).run()` with no messages added crashes with `IndexError` instead of the intended no-op.

The "no tool calls" guard in `_run_tools` (`libs/giskard-agents/src/giskard/agents/workflow.py`) starts with:

```python
if not chat.last or ...:
    return
```

But `Chat.last` is `self.messages[-1]`, which raises `IndexError: list index out of range` on an empty `messages` list rather than returning something falsy. Since `messages` defaults to `[]`, a workflow that runs before any `.chat()` call hits this — the `IndexError` propagates and `run()` (default RAISE error policy) wraps it in `WorkflowError("Step processing failed")` instead of the intended early return.

## Fix

Guard on `chat.messages` (the list) instead of `chat.last` (which indexes into it):

```python
if not chat.messages or ...:
    return
```

One-line change in `workflow.py`.

## Testing

Added `test_run_with_no_messages_does_not_raise_indexerror` to `libs/giskard-agents/tests/test_workflow_steps.py` (mocked `BaseGenerator`, no real API calls). TDD red confirmed against the unfixed guard (raises `WorkflowError` wrapping the `IndexError`), green after the fix. `libs/giskard-agents/tests/test_workflow_steps.py` (non-functional): 4 passed. `ruff check` + `ruff format --check` clean.

xref: no open PR or issue touches `workflow.py`, `_run_tools`, `Chat.last`, or `ChatWorkflow`.

---
Disclosure: this PR was drafted with AI assistance (Claude); I reviewed, tested, and take responsibility for the change.
