### PR TITLE
fix(llm): set message.refusal for every Anthropic refusal, not only when stop_details.explanation is present 🤖🤖🤖🤖

### DIFF
--- a/libs/giskard-llm/src/giskard/llm/translators/anthropic.py
+++ b/libs/giskard-llm/src/giskard/llm/translators/anthropic.py
@@ -313,9 +313,17 @@ class AnthropicChatTranslator:
         )
 
         refusal_out: str | None = None
-        if raw.stop_reason == "refusal" and raw.stop_details is not None:
+        if raw.stop_reason == "refusal":
+            # stop_details and both of its fields are optional, so a refusal may carry
+            # its reason in the structured category, or carry no detail at all. Fall
+            # back to the bare stop reason rather than None so the refusal stays
+            # detectable, the way google_chat falls back when finish_message is absent.
             # stop_details.explanation is a beta Anthropic API attribute; use getattr for safety
-            refusal_out = getattr(raw.stop_details, "explanation", None)
+            refusal_out = (
+                getattr(raw.stop_details, "explanation", None)
+                or getattr(raw.stop_details, "category", None)
+                or raw.stop_reason
+            )
 
         message = AssistantMessage(
             role="assistant",

--- a/libs/giskard-llm/tests/translators/test_anthropic_chat_return.py
+++ b/libs/giskard-llm/tests/translators/test_anthropic_chat_return.py
@@ -71,6 +71,66 @@ def test_from_anthropic_refusal_stop():
     assert ch.finish_reason == "stop"
     assert ch.message.content is None
     assert ch.message.refusal == "Policy decline."
+    assert ch.message.is_refusal
+
+
+def test_from_anthropic_refusal_without_stop_details():
+    """A refusal with no ``stop_details`` falls back to the bare stop reason."""
+    raw = _message(
+        {
+            "content": [{"type": "text", "text": "I can't help with that."}],
+            "stop_reason": "refusal",
+        }
+    )
+    out = AnthropicChatTranslator.from_anthropic(raw)
+    ch = out.choices[0]
+    assert ch.message.refusal == "refusal"
+    assert ch.message.is_refusal
+
+
+def test_from_anthropic_refusal_falls_back_to_category():
+    """Without ``explanation``, the structured ``category`` carries the reason."""
+    raw = _message(
+        {
+            "content": [],
+            "stop_reason": "refusal",
+            "stop_details": {"type": "refusal", "category": "bio"},
+        }
+    )
+    out = AnthropicChatTranslator.from_anthropic(raw)
+    ch = out.choices[0]
+    assert ch.message.refusal == "bio"
+    assert ch.message.is_refusal
+
+
+def test_from_anthropic_refusal_prefers_explanation_over_category():
+    """``explanation`` stays preferred when both fields are populated."""
+    raw = _message(
+        {
+            "content": [],
+            "stop_reason": "refusal",
+            "stop_details": {
+                "type": "refusal",
+                "category": "bio",
+                "explanation": "Policy decline.",
+            },
+        }
+    )
+    out = AnthropicChatTranslator.from_anthropic(raw)
+    assert out.choices[0].message.refusal == "Policy decline."
+
+
+def test_from_anthropic_non_refusal_stop_reason_sets_no_refusal():
+    """A normal completion is never marked as a refusal."""
+    raw = _message(
+        {
+            "content": [{"type": "text", "text": "Hello from Claude."}],
+            "stop_reason": "end_turn",
+        }
+    )
+    ch = AnthropicChatTranslator.from_anthropic(raw).choices[0]
+    assert ch.message.refusal is None
+    assert not ch.message.is_refusal
 
 
 def test_from_anthropic_multiple_text_blocks_joined():


### PR DESCRIPTION
## Description

`from_anthropic` only populated `message.refusal` when the optional `stop_details.explanation` happened to be present:

```python
if raw.stop_reason == "refusal" and raw.stop_details is not None:
    refusal_out = getattr(raw.stop_details, "explanation", None)
```

`stop_details` is `Optional[RefusalStopDetails]` and defaults to `None`, and inside it `explanation` is `Optional[str]` while `category` is the structured reason field. So a refusal that carries its reason only in `category`, or that carries no detail at all, produced `refusal=None`.

`FINISH_REASON_MAP` maps `"refusal"` to `"stop"`, which is correct (the OpenAI path does the same), so `message.refusal` is the only refusal signal left on this path. With it unset, the consumer's rule at `workflow.py:233` (`choice.finish_reason == "refusal" or choice.message.is_refusal`) does not fire, and the response falls through to `workflow.py:238` `output_model.model_validate_json(choice.message.text or "")`. A refused generation then surfaces as a pydantic `ValidationError` on the apology text instead of `ModelRefusalError`.

**Invariant:** when `stop_reason == "refusal"`, `from_anthropic` leaves the message in a state `workflow.py:233` recognises as a refusal, whatever the optional `stop_details` fields contain.

## Fix

Fall back `explanation` -> `category` -> the bare stop reason. This mirrors the existing precedent in `google_chat.py:390`, which already falls back to the bare reason code when the free-text `finish_message` is absent:

```python
refusal_out = (candidate.finish_message or raw_finish_reason) if finish_reason == "refusal" else None
```

`FINISH_REASON_MAP` needs no change, so there is no behaviour change for any non-refusal stop reason.

## Verification

Run in a clean `python:3.12-slim` container against this branch, anthropic SDK 0.117.0.

Three-way differential across the providers, applying the `workflow.py:233` rule verbatim. Before:

```
OPENAI    finish_reason='stop'    refusal="I can't help with that."  DETECTED=True
GOOGLE    finish_reason='refusal' refusal='SAFETY'                   DETECTED=True

ANTHROPIC stop_details=None (SDK default)              refusal=None  DETECTED=False
ANTHROPIC stop_details category='bio', no explanation  refusal=None  DETECTED=False
ANTHROPIC stop_details explanation='Policy decline.'   refusal='Policy decline.'  DETECTED=True
```

After, all three Anthropic shapes report `DETECTED=True`, with `refusal` set to `'refusal'`, `'bio'` and `'Policy decline.'` respectively.

Four tests added to `test_anthropic_chat_return.py`, alongside the existing `test_from_anthropic_refusal_stop` (which covered only the passing shape). The two that pin the bug fail on `main` with `assert None == 'refusal'` and `assert None == 'bio'`, and pass here.

Gates run locally, matching the `lint` and `test-unit` jobs:

- `ruff check`, `ruff format --check`, `vermin --target=3.12-`, `basedpyright --level error`: all clean on both changed files.
- `pytest libs/giskard-llm -m "not functional"` on 3.12, 3.13 and 3.14: 215 passed, 7 skipped.
- `pytest libs/giskard-agents -m "not functional"`: 117 passed, 2 skipped.

I also enumerated every writer of `AssistantMessage.refusal` in `libs/` by parsing the AST, to check nothing downstream overwrites it: `anthropic.py:320` (this line), `google_chat.py:409`, and `openai_chat.py:99` via bulk `CompletionResponse.model_validate`. The two `.refusal =` assignments in `workflow_errors.py` are `ModelRefusalError`'s own attribute, a different type. On the Anthropic path this line is the only writer.

## What I did not verify

The inputs are constructed SDK fixtures, built the same way the existing translator tests build them. I did not call the live Anthropic API, so I am making no claim about which of these shapes production emits, or how often. The claim is only about what `from_anthropic` does with each SDK-valid shape.

## Related Issue

Fixes #2615

## Type of Change

- [x] 🔧 Bug fix (non-breaking change which fixes an issue)

## Coding agents

This PR was opened by an autonomous agent with no human in the loop, per [AUTONOMOUS.md](https://github.com/Giskard-AI/giskard-oss/blob/main/AUTONOMOUS.md). The title carries the required `🤖🤖🤖🤖` marker.

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [x] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in NumPy format for all the methods and classes that I created or modified. The new tests carry one-line docstrings matching the surrounding file's style; `from_anthropic`'s own docstring is unchanged.
- [ ] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been modified). Not applicable, `pyproject.toml` is unchanged.
