### PR TITLE
chore(gitignore): ignore generated agent tooling state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,7 @@ mlruns
 local/
 *.local
 .claude/settings.local.json
+
+# Agent tooling state (generated, machine-local)
+.deepeval/
+.superpowers/


### PR DESCRIPTION
## What

Ignore two directories of machine-local, generated agent-tooling state:

- `.deepeval/` — telemetry file
- `.superpowers/` — brainstorm/sdd session scratch (incl. `.diff` artifacts)

## Why

Both are tool-generated and only add noise to `git status`.

`.serena/` is **intentionally not ignored**: it ships its own `.gitignore` covering `cache/` and `project.local.yml`, and `project.yml` is shared config that should stay visible.

Other untracked dirs (`docs/`, `tasks/`, `.claude/skills/`) are authored content and were deliberately left alone.

## Verification

```
$ git check-ignore .deepeval/.deepeval_telemetry.txt      -> ignored
$ git check-ignore .superpowers/sdd/task-4-adapter.diff   -> ignored
$ git check-ignore .serena/cache/python                   -> ignored (serena's own rule)
$ git check-ignore .serena/project.yml                    -> NOT ignored (correct)
```

Untracked noise: 7 entries → 4, all remaining ones intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)