### PR TITLE
fix(google): count Gemini thinking tokens in usage.output_tokens 🤖🤖🤖🤖

### DIFF
--- a/libs/giskard-llm/src/giskard/llm/translators/google_chat.py
+++ b/libs/giskard-llm/src/giskard/llm/translators/google_chat.py
@@ -426,11 +426,11 @@ class GoogleChatTranslator:
             # input_tokens + output_tokens == total_tokens when the model thinks.
             um = raw.usage_metadata
             usage = Usage(
-                input_tokens=(um.prompt_token_count or 0)
-                + (um.tool_use_prompt_token_count or 0),
-                output_tokens=(um.candidates_token_count or 0)
-                + (um.thoughts_token_count or 0),
-                total_tokens=um.total_token_count or 0,
+                input_tokens=(getattr(um, "prompt_token_count", 0) or 0)
+                + (getattr(um, "tool_use_prompt_token_count", 0) or 0),
+                output_tokens=(getattr(um, "candidates_token_count", 0) or 0)
+                + (getattr(um, "thoughts_token_count", 0) or 0),
+                total_tokens=getattr(um, "total_token_count", 0) or 0,
             )
 
         return CompletionResponse(choices=choices, model=model, usage=usage)

--- a/libs/giskard-llm/src/giskard/llm/translators/google_chat.py
+++ b/libs/giskard-llm/src/giskard/llm/translators/google_chat.py
@@ -419,10 +419,18 @@ class GoogleChatTranslator:
 
         usage = None
         if raw.usage_metadata:
+            # google-genai defines total_token_count as the sum of prompt,
+            # candidates, tool_use_prompt and thoughts token counts. thoughts_token_count
+            # is generated (and billed) output, so fold it into output_tokens; likewise
+            # count tool_use_prompt on the input side. This keeps
+            # input_tokens + output_tokens == total_tokens when the model thinks.
+            um = raw.usage_metadata
             usage = Usage(
-                input_tokens=raw.usage_metadata.prompt_token_count or 0,
-                output_tokens=raw.usage_metadata.candidates_token_count or 0,
-                total_tokens=raw.usage_metadata.total_token_count or 0,
+                input_tokens=(um.prompt_token_count or 0)
+                + (um.tool_use_prompt_token_count or 0),
+                output_tokens=(um.candidates_token_count or 0)
+                + (um.thoughts_token_count or 0),
+                total_tokens=um.total_token_count or 0,
             )
 
         return CompletionResponse(choices=choices, model=model, usage=usage)

--- a/libs/giskard-llm/tests/translators/test_google_chat_return.py
+++ b/libs/giskard-llm/tests/translators/test_google_chat_return.py
@@ -55,6 +55,37 @@ def test_from_google_assistant_text():
     assert ch.finish_reason == "stop"
 
 
+def test_from_google_thinking_tokens_counted_in_output():
+    """thoughts_token_count is generated output, so it belongs in output_tokens.
+
+    google-genai defines total_token_count as prompt + candidates + tool_use_prompt +
+    thoughts, so input_tokens + output_tokens must equal total_tokens even when the model
+    thinks. prompt=10, candidates=5, thoughts=20 -> total=35.
+    """
+    raw = _raw(
+        {
+            "candidates": [
+                {
+                    "content": {"parts": [{"text": "Answer."}]},
+                    "finish_reason": "STOP",
+                }
+            ],
+            "usage_metadata": {
+                "prompt_token_count": 10,
+                "candidates_token_count": 5,
+                "thoughts_token_count": 20,
+                "total_token_count": 35,
+            },
+        }
+    )
+    out = GoogleChatTranslator.from_google(raw, _MODEL, 1)
+    assert out.usage is not None
+    assert out.usage.input_tokens == 10
+    assert out.usage.output_tokens == 25
+    assert out.usage.total_tokens == 35
+    assert out.usage.input_tokens + out.usage.output_tokens == out.usage.total_tokens
+
+
 def test_from_google_multiple_text_parts_joined():
     """Multiple `text` parts are joined with newlines, matching multi-part model output."""
     raw = _raw(


### PR DESCRIPTION
## Description

`GoogleChatTranslator.from_google` builds `Usage` from Gemini's `usage_metadata`
but maps `output_tokens` to `candidates_token_count` alone:

```python
usage = Usage(
    input_tokens=raw.usage_metadata.prompt_token_count or 0,
    output_tokens=raw.usage_metadata.candidates_token_count or 0,
    total_tokens=raw.usage_metadata.total_token_count or 0,
)
```

google-genai documents `total_token_count` as the sum of `prompt_token_count`,
`candidates_token_count`, `tool_use_prompt_token_count` and `thoughts_token_count`.
`thoughts_token_count` is the model's generated (and billed) reasoning output.
When a Gemini model thinks, that count lands in `total_token_count` but in none of
`input_tokens`/`output_tokens`, so within a single `Usage` object
`input_tokens + output_tokens != total_tokens`.

**Invariant:** `input_tokens + output_tokens == total_tokens`, mapping each of
Google's four components to the correct side. The fix folds `thoughts_token_count`
into `output_tokens` (generated output) and `tool_use_prompt_token_count` into
`input_tokens` (prompt-side), so the sum matches `total_token_count` by
construction.

Scope: this touches only the `acompletion` path in `translators/google_chat.py`.
The Interactions path in `google_response.py` maps a different SDK surface
(`total_input_tokens`/`total_output_tokens`) and is not changed here.

### Verification

Reproduced at HEAD in a clean `python:3.13-slim` container (google-genai only, no
API key). A response with `prompt=10, candidates=5, thoughts=20, total=35` maps to
`input=10, output=5, total=35` on `main` (15 != 35), and to `input=10, output=25,
total=35` with the fix. The added regression test
`test_from_google_thinking_tokens_counted_in_output` fails on `main` and passes on
this branch; the existing 27 google translator tests still pass. `ruff check`,
`ruff format --check`, vermin (3.12 target) and basedpyright are clean on the
changed files.

Not verified by me: I did not make a live `gemini-3.5-flash` call (no key on the
box), so how often real responses carry a non-zero `thoughts_token_count` is not
measured here. The defect and the fix are exercised against the real google-genai
`usage_metadata` type. `tool_use_prompt_token_count` is included for formula
completeness; it is `0` in giskard's current usage, which sends only
`function_declarations`.

### Design note

`Usage` has no reasoning field, so this is the minimal change that restores the
invariant. If you would rather surface reasoning tokens separately (a new
`reasoning_tokens` field on `Usage`), that is a larger API change and I am happy to
follow that direction instead; this PR keeps to the smallest correct fix.

## Related Issue

None.

## Type of Change

- [x] 🔧 Bug fix (non-breaking change which fixes an issue)

## Coding agents

Opened by an autonomous agent per **AUTONOMOUS.md**; the title carries the required
four-robot marker.

## Checklist

- [x] I've read the `CODE_OF_CONDUCT.md` document.
- [x] I've read the `CONTRIBUTING.md` guide.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [ ] I've updated the `uv.lock` (not applicable: `pyproject.toml` unchanged).
