### PR TITLE
fix(llm): warn on unknown Anthropic params; detect bare refusals

### DIFF
--- a/libs/giskard-llm/src/giskard/llm/translators/anthropic.py
+++ b/libs/giskard-llm/src/giskard/llm/translators/anthropic.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any, Literal, Required, TypedDict, cast
 
@@ -45,6 +46,24 @@ else:
     httpxTimeout = Any
 
 _PROVIDER = "anthropic/chat"
+PROVIDER = "anthropic"
+logger = logging.getLogger(__name__)
+
+# Params accepted by AnthropicChatConfigParams / to_anthropic (plus tools which
+# is a dedicated keyword arg). Anything else is dropped by pydantic extra=ignore
+# — warn so callers notice, matching OpenAI/Google translators (#2613).
+KNOWN_COMPLETION_PARAMS = frozenset(
+    {
+        "max_tokens",
+        "temperature",
+        "timeout",
+        "tools",
+        "system",
+        "output_config",
+        "response_format",
+    }
+)
+
 
 
 @ToolDef.register_serializer(_PROVIDER)
@@ -249,6 +268,14 @@ class AnthropicChatTranslator:
         tools: Sequence[ToolDef] | None = None,
         **params: Any,
     ) -> "CompletionCreateParams":
+        unknown = set(params) - KNOWN_COMPLETION_PARAMS
+        if unknown:
+            logger.warning(
+                "%s provider: ignoring unknown completion params: %s",
+                PROVIDER,
+                sorted(unknown),
+            )
+
         anthropic_params = AnthropicChatConfigParams(
             model=model,
             messages=messages,
@@ -313,9 +340,14 @@ class AnthropicChatTranslator:
         )
 
         refusal_out: str | None = None
-        if raw.stop_reason == "refusal" and raw.stop_details is not None:
-            # stop_details.explanation is a beta Anthropic API attribute; use getattr for safety
-            refusal_out = getattr(raw.stop_details, "explanation", None)
+        if raw.stop_reason == "refusal":
+            # Prefer free-text explanation; fall back to structured category or a
+            # bare "refusal" marker so message.is_refusal still fires when
+            # stop_details / explanation are absent (#2615).
+            details = getattr(raw, "stop_details", None)
+            explanation = getattr(details, "explanation", None) if details is not None else None
+            category = getattr(details, "category", None) if details is not None else None
+            refusal_out = explanation or category or "refusal"
 
         message = AssistantMessage(
             role="assistant",

--- a/libs/giskard-llm/tests/translators/test_anthropic_chat.py
+++ b/libs/giskard-llm/tests/translators/test_anthropic_chat.py
@@ -401,3 +401,20 @@ def test_function_message_raises():
     ]
     with pytest.raises(ValueError, match="Unsupported message role"):
         AnthropicChatTranslator.to_anthropic(_MODEL, messages)
+
+
+def test_unknown_completion_params_warn(caplog):
+    """Unsupported kwargs are dropped but callers get a warning (#2613)."""
+    import logging
+
+    msg = UserMessage(content="Hello.")
+    with caplog.at_level(logging.WARNING):
+        payload = AnthropicChatTranslator.to_anthropic(
+            _MODEL, [msg], top_p=0.5, stop_sequences=["STOP"], temperature=0.2
+        )
+    assert payload["temperature"] == 0.2
+    assert "top_p" not in payload
+    assert "stop_sequences" not in payload
+    joined = " ".join(r.message for r in caplog.records)
+    assert "top_p" in joined
+    assert "stop_sequences" in joined

--- a/libs/giskard-llm/tests/translators/test_anthropic_chat_return.py
+++ b/libs/giskard-llm/tests/translators/test_anthropic_chat_return.py
@@ -139,3 +139,26 @@ def test_from_anthropic_tool_use_only():
     assert msg.tool_calls is not None
     assert msg.tool_calls[0].function.name == "add"
     assert msg.tool_calls[0].function.arguments == {"a": 1, "b": 2}
+
+
+def test_from_anthropic_refusal_without_details():
+    """Refusal with no stop_details still populates message.refusal (#2615)."""
+    raw = _message({"content": [], "stop_reason": "refusal", "stop_details": None})
+    out = AnthropicChatTranslator.from_anthropic(raw)
+    ch = out.choices[0]
+    assert ch.finish_reason == "stop"
+    assert ch.message.refusal == "refusal"
+    assert ch.message.is_refusal
+
+
+def test_from_anthropic_refusal_category_only():
+    """Category without explanation is used as the refusal text (#2615)."""
+    raw = _message(
+        {
+            "content": [{"type": "text", "text": "I can't help with that."}],
+            "stop_reason": "refusal",
+            "stop_details": {"type": "refusal", "category": "bio"},
+        }
+    )
+    out = AnthropicChatTranslator.from_anthropic(raw)
+    assert out.choices[0].message.refusal == "bio"


### PR DESCRIPTION
## Summary
Two Anthropic translator gaps, fixed together:

1. **Unknown completion params were dropped silently** (`top_p`, `stop_sequences`, …) because `AnthropicChatConfigParams` uses pydantic `extra="ignore"`. OpenAI/Google already `logger.warning` in that situation.
2. **Refusals without `stop_details.explanation` left `message.refusal=None`**, so workflow refusal detection failed and the apology text fell through to pydantic validation.

## Change
- Warn on unknown kwargs in `AnthropicChatTranslator.to_anthropic` (same pattern as OpenAI/Google)
- On `stop_reason == "refusal"`, set `refusal` to `explanation` → `category` → `"refusal"`

## Test plan
- [x] `test_unknown_completion_params_warn`
- [x] `test_from_anthropic_refusal_without_details`
- [x] `test_from_anthropic_refusal_category_only`

Fixes #2613  
Fixes #2620  
Fixes #2615
