### PR TITLE
ci: opt in to fork PR checkout for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -83,6 +83,14 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
+          # Deliberate opt-in: this job installs and executes fork-authored
+          # code (make install, pytest) with live provider API keys in scope.
+          # Compensating controls: the `ci` environment requires a reviewer to
+          # approve each run before secrets are injected (server-enforced,
+          # per-run), the authorize job requires a fresh `labeled` event for
+          # external contributors, and the immutable head.sha pin keeps the
+          # reviewed commit identical to the executed one.
+          allow-unsafe-pr-checkout: true
       - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
           enable-cache: true
@@ -135,6 +143,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
+          # Deliberate opt-in — see test-agents-functional for the full
+          # rationale and compensating controls.
+          allow-unsafe-pr-checkout: true
       - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
           enable-cache: true
@@ -173,6 +184,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
+          # Deliberate opt-in — see test-agents-functional for the full
+          # rationale and compensating controls.
+          allow-unsafe-pr-checkout: true
       - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
           enable-cache: true


### PR DESCRIPTION
## Problem

Integration tests fail at the **checkout step** on every external contributor's PR (e.g. #2599), before any code runs:

> `##[error]Refusing to check out fork pull request code from a 'pull_request_target' workflow. [...] To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.`

`actions/checkout` [v7.0.0](https://github.com/actions/checkout/pull/2454) added a hard refusal to check out fork PR code under `pull_request_target`. It was backported as **[BREAKING]** to v6.1.0, v5.1.0 and v4.4.0, so pinning backwards is not an escape. Nothing in our workflow changed — the action's behaviour did. See GitHub's [changelog](https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/).

## Why we opt in rather than restructure

The standard safe alternative is the [two-workflow `workflow_run` pattern](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/): build untrusted code sandboxed under `pull_request`, then do privileged work in a separate `workflow_run`. That doesn't fit here — our secrets are provider API keys needed *during* the test run to call live LLM endpoints, so they can't be deferred to a second phase.

This is a genuine "pwn request" surface and worth naming plainly: `make install` resolves a fork-controlled lockfile and `pytest` collects fork-controlled `conftest.py`, both with `OPENAI_API_KEY`, `GEMINI_API_KEY`, `ANTHROPIC_API_KEY` and `AZURE_*` in scope.

## Compensating controls

GitHub Security Lab considers label gating alone a *temporary* mitigation, so the primary gate is now server-side:

- **Required reviewers on the `CI` environment** (configured in repo settings, not in this diff) — runs pause and secrets are **not injected** until the `open-source-maintainers` team approves. Enforced by GitHub per-run, and bound to a specific run rather than to mutable PR state.
- **`authorize` job** — external contributors need a fresh `labeled` event; it checks the *event action*, never the PR's current label set, so a stale label can't authorize a later push.
- **Immutable `head.sha` pin** — the reviewed commit is the executed commit; a later push can't retarget an in-flight run.
- **`reset-safe-for-build-label.yml`** strips the label on `synchronize`, forcing visible re-review.

The label gate is now defence in depth rather than the primary control; simplifying it is worth a follow-up but is deliberately out of scope here.

## Note on merge order

`pull_request_target` runs the workflow from the **base** branch, so merging this to `main` unblocks #2599 and every other fork PR without touching contributor branches.

## Testing

- `yaml.safe_load` parses the workflow; flag confirmed present on all three checkout steps (`test-agents-functional`, `test-llm-functional`, `test-checks-functional`) and absent from `authorize`, which does no checkout.
- Environment protection verified via API: `CI` now returns a `required_reviewers` rule for the `open-source-maintainers` team (previously `[]`).
- End-to-end behaviour can only be confirmed by a real fork-PR run after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)