### PR TITLE
fix(checks): join list[str] context in Groundedness/Contradiction judges instead of str()-ing it 🤖🤖🤖🤖

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/judges/base.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/base.py
@@ -19,6 +19,24 @@ class LLMCheckResult(BaseModel):
     passed: bool = Field(..., description="Whether the check passed or failed")
 
 
+def format_prompt_text(value: Any) -> str:
+    """Render a resolved trace/input value as plain text for an LLM prompt.
+
+    Several judge inputs (e.g. ``context``) accept either a single string or a
+    list of strings (multiple context documents). A bare ``str(value)`` on a
+    list renders Python's ``repr`` -- brackets, comma separators, and quoted
+    (sometimes escaped) items -- which leaks implementation syntax into the
+    prompt instead of the actual text. Join list values into a single
+    newline-separated block instead, matching the ``"\\n".join(...)``
+    convention used elsewhere in this codebase for combining text fragments.
+    Any other value (a plain string, ``NoMatch``, or arbitrary trace payload)
+    is stringified as before.
+    """
+    if isinstance(value, list):
+        return "\n".join(str(item) for item in value)
+    return str(value)
+
+
 class BaseLLMCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
     Check[InputType, OutputType, TraceType], WithGeneratorMixin
 ):

--- a/libs/giskard-checks/src/giskard/checks/judges/contradiction.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/contradiction.py
@@ -7,7 +7,7 @@ from pydantic.experimental.missing_sentinel import MISSING
 from ..core import Trace
 from ..core.check import Check
 from ..core.extraction import JSONPathStr, provided_or_resolve
-from .base import BaseLLMCheck
+from .base import BaseLLMCheck, format_prompt_text
 
 
 @Check.register("contradiction")
@@ -49,7 +49,7 @@ class Contradiction[InputType, OutputType, TraceType: Trace](  # pyright: ignore
             "answer": str(
                 provided_or_resolve(trace, key=self.answer_key, value=self.answer)
             ),
-            "context": str(
+            "context": format_prompt_text(
                 provided_or_resolve(trace, key=self.context_key, value=self.context)
             ),
         }

--- a/libs/giskard-checks/src/giskard/checks/judges/groundedness.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/groundedness.py
@@ -7,7 +7,7 @@ from pydantic.experimental.missing_sentinel import MISSING
 from ..core import Trace
 from ..core.check import Check
 from ..core.extraction import JSONPathStr, provided_or_resolve
-from .base import BaseLLMCheck
+from .base import BaseLLMCheck, format_prompt_text
 
 
 @Check.register("groundedness")
@@ -91,7 +91,7 @@ class Groundedness[InputType, OutputType, TraceType: Trace](  # pyright: ignore[
                     value=self.answer,
                 )
             ),
-            "context": str(
+            "context": format_prompt_text(
                 provided_or_resolve(
                     trace,
                     key=self.context_key,

--- a/libs/giskard-checks/tests/builtin/test_contradiction.py
+++ b/libs/giskard-checks/tests/builtin/test_contradiction.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from giskard.checks import CheckStatus, Contradiction, Interaction, Trace
 
 from ..testing_utils import MockJudgeGenerator as MockGenerator
@@ -58,7 +60,7 @@ async def test_direct_answer_and_context_are_passed_to_judge() -> None:
 
     assert result.status == CheckStatus.PASS
     assert result.details["inputs"]["answer"] == "Direct answer"
-    assert result.details["inputs"]["context"] == "['Context 1', 'Context 2']"
+    assert result.details["inputs"]["context"] == "Context 1\nContext 2"
     assert len(generator.calls) == 1
 
 
@@ -129,7 +131,7 @@ async def test_custom_answer_and_context_keys() -> None:
 
     assert result.status == CheckStatus.PASS
     assert result.details["inputs"]["answer"] == "The Eiffel Tower is in Paris."
-    assert result.details["inputs"]["context"] == "['The Eiffel Tower is in Paris.']"
+    assert result.details["inputs"]["context"] == "The Eiffel Tower is in Paris."
 
 
 async def test_direct_values_take_priority_over_trace() -> None:
@@ -149,7 +151,36 @@ async def test_direct_values_take_priority_over_trace() -> None:
 
     assert result.status == CheckStatus.PASS
     assert result.details["inputs"]["answer"] == "Direct answer"
-    assert result.details["inputs"]["context"] == "['Direct context']"
+    assert result.details["inputs"]["context"] == "Direct context"
+
+
+async def test_list_context_is_joined_without_python_repr_artifacts() -> None:
+    """A list[str] context must reach the judge prompt as readable text.
+
+    Regression test for the bug where get_inputs() rendered a list context via
+    bare str(), producing the Python repr (e.g. "['doc 1', 'doc 2']") instead of
+    the documents themselves. Documents containing apostrophes are especially
+    revealing: str(repr) mixes quote styles and escapes the apostrophe, which
+    should never appear in the actual prompt text.
+    """
+    generator = MockGenerator(passed=True, reason=None)
+    contradiction = Contradiction(
+        generator=generator,
+        answer="The Eiffel Tower is in Paris, and it's a landmark.",
+        context=[
+            "Paris is the capital of France.",
+            "It's located in Europe.",
+        ],
+    )
+
+    result = await contradiction.run(Trace())
+
+    context_str = cast(str, result.details["inputs"]["context"])
+    assert context_str == "Paris is the capital of France.\nIt's located in Europe."
+    assert "[" not in context_str
+    assert "]" not in context_str
+    assert '\\"' not in context_str
+    assert "\\'" not in context_str
 
 
 async def test_missing_trace_values_are_passed_to_judge_as_no_match() -> None:

--- a/libs/giskard-checks/tests/builtin/test_groundedness.py
+++ b/libs/giskard-checks/tests/builtin/test_groundedness.py
@@ -167,7 +167,7 @@ async def test_context_priority_over_trace() -> None:
     result = await groundedness.run(Trace(interactions=[interaction]))
 
     assert result.status == CheckStatus.PASS
-    assert result.details["inputs"]["context"] == "['Direct context']"
+    assert result.details["inputs"]["context"] == "Direct context"
 
 
 async def test_empty_string_context_is_preserved() -> None:
@@ -200,7 +200,35 @@ async def test_empty_context() -> None:
     result = await groundedness.run(Trace())
 
     assert result.status == CheckStatus.FAIL
-    assert result.details["inputs"]["context"] == "[]"
+    assert result.details["inputs"]["context"] == ""
+
+
+async def test_list_context_is_joined_without_python_repr_artifacts() -> None:
+    """A list[str] context must reach the judge prompt as readable text.
+
+    Regression test for the bug where get_inputs() rendered a list context via
+    bare str(), producing the Python repr (e.g. "['doc 1', 'doc 2']") instead of
+    the documents themselves. Documents containing apostrophes are especially
+    revealing: str(repr) mixes quote styles and escapes the apostrophe, which
+    should never appear in the actual prompt text.
+    """
+    generator = MockGenerator(passed=True, reason=None)
+    groundedness = Groundedness(
+        generator=generator,
+        answer="The Eiffel Tower is in Paris, and it's a landmark.",
+        context=[
+            "Paris is the capital of France.",
+            "It's located in Europe.",
+        ],
+    )
+    result = await groundedness.run(Trace())
+
+    context_str = cast(str, result.details["inputs"]["context"])
+    assert context_str == "Paris is the capital of France.\nIt's located in Europe."
+    assert "[" not in context_str
+    assert "]" not in context_str
+    assert '\\"' not in context_str
+    assert "\\'" not in context_str
 
 
 async def test_missing_answer_in_trace() -> None:


### PR DESCRIPTION
`Groundedness` and `Contradiction` both accept `context` as `str | list[str] | MISSING` — passing a list of source documents is the documented way to use them (see the `Groundedness` docstring example: `context=["Paris is the capital of France.", "It's located in Europe."]`). The problem was in `get_inputs()`: whatever `context` resolved to just got passed through `str(...)`. For a plain string that's a no-op, but for a list, `str()` gives you Python's `repr` — square brackets, comma separators, and quotes around each item, with the quote character flipping per item whenever one contains an apostrophe (that's just how `repr` avoids having to escape it). That repr gets dropped straight into the `{{ context }}` slot of `judges/groundedness.j2` / `judges/contradiction.j2`, so the judge model was reading something like:

```
['Paris is the capital of France.', "It's located in Europe."]
```

instead of the actual context text. An empty list came through as the literal string `"[]"`.

This wasn't some obscure edge case — it was the tested, asserted behavior. Existing tests had lines like `assert result.details["inputs"]["context"] == "['Direct context']"`, so the repr leak had effectively been locked in as "correct" output.

Root cause: `get_inputs()` declares the type as `str | list[str]` but never actually branches on it — every value falls through to the same `str()` call regardless of which half of the union it is.

```mermaid
flowchart LR
    A["context resolves to list[str]<br/>e.g. two context documents, one with an apostrophe"] --> B{"get_inputs()"}
    B -->|"before: str(value)"| C["Python repr string:<br/>brackets + comma-separated + quoted items<br/>(quote char flips per item)"]
    B -->|"after: format_prompt_text(value)"| D["items joined with '\\n':<br/>plain readable text, no syntax"]
    C --> E["rendered into {{ context }} in<br/>groundedness.j2 / contradiction.j2"]
    D --> E
    E -->|before| F["judge model sees list/repr syntax<br/>mixed into the prompt"]
    E -->|after| G["judge model sees the actual<br/>context documents"]
```

Fix is a small `format_prompt_text()` helper in `judges/base.py`: joins list values with `\n` (matching the `"\n".join(...)` convention already used elsewhere in this codebase, e.g. `llm/translators/google_response.py`, `checks/export/junit.py`), and falls back to plain `str(value)` for anything that isn't a list — strings, `NoMatch`, arbitrary trace payloads, all of which were already rendering correctly. Wired it into the `context` field of both `Groundedness.get_inputs` and `Contradiction.get_inputs`. Went looking for other built-in checks with the same `str | list[str]` context pattern; these two are the only ones, so the fix doesn't need to go any further.

No issue filed for this — ran into it while going through the judge prompt templates and the rendered context just looked wrong.

**Testing**

- Added a regression test per check, using a context list where one item has an apostrophe — that's the case that most clearly exposes the bug, since it's exactly what makes `repr` mix quote styles. Confirmed both fail against unmodified `judges/*.py` (actual output was the bracketed repr string), and pass after the fix.
- Updated the 4 existing assertions that had the buggy repr baked in as expected output (`test_context_priority_over_trace` in both files, `test_direct_answer_and_context_are_passed_to_judge`, `test_custom_answer_and_context_keys`).
- Full `giskard-checks` suite: 759 passed, 4 skipped. `giskard-core`, `giskard-llm`, `giskard-agents`, `giskard-scan` all green individually — untouched by this change.
- `ruff format --check` / `ruff check` clean on touched files; `basedpyright --level error` (what `make typecheck` runs per `giskard-checks/pyproject.toml`) reports 0 errors on touched files.

## Coding agents

I've read [AUTONOMOUS.md](https://github.com/Giskard-AI/giskard-oss/blob/main/AUTONOMOUS.md).

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [ ] I've updated the `uv.lock` running `uv lock` (not applicable — no `pyproject.toml` changes)
