### PR TITLE
fix(checks): skip regorus extra on Windows

### DIFF
--- a/libs/giskard-checks/pyproject.toml
+++ b/libs/giskard-checks/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 readability = [
     "textstat>=0.7.0",
 ]
-regorus = ["celine-regorus>=0.9.1"]
+regorus = ["celine-regorus>=0.9.1; sys_platform != 'win32'"]
 all = ["giskard-checks[regorus]"] # Install all optional dependencies
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -967,18 +967,18 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
-    { name = "celine-regorus" },
+    { name = "celine-regorus", marker = "sys_platform != 'win32'" },
 ]
 readability = [
     { name = "textstat" },
 ]
 regorus = [
-    { name = "celine-regorus" },
+    { name = "celine-regorus", marker = "sys_platform != 'win32'" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "celine-regorus", marker = "extra == 'regorus'", specifier = ">=0.9.1" },
+    { name = "celine-regorus", marker = "sys_platform != 'win32' and extra == 'regorus'", specifier = ">=0.9.1" },
     { name = "giskard-agents", editable = "libs/giskard-agents" },
     { name = "giskard-checks", extras = ["regorus"], marker = "extra == 'all'", editable = "libs/giskard-checks" },
     { name = "giskard-core", editable = "libs/giskard-core" },


### PR DESCRIPTION
Closses #2627

 ## Summary
  - Guard `celine-regorus` with `sys_platform != "win32"` because it has no Windows wheel/source distribution.
  - Update `uv.lock` so Windows users can resolve/export the `regorus` extra without install failures.
  - Keep `regorus` available on supported Linux/macOS platforms.

  ## Testing
  - `uv lock`
  - `uv export --no-dev --extra regorus --format requirements-txt`
  - `ruff format --check libs/giskard-checks/pyproject.toml`
  - `ruff check libs/giskard-checks/pyproject.toml`
  - `git diff --check`