### PR TITLE
feat(checks): add retry/consensus voting to BaseLLMCheck

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/judges/base.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/base.py
@@ -1,4 +1,4 @@
-from typing import Any, override
+from typing import Any, Literal, override
 
 from giskard.agents import ChatWorkflow, MessageTemplate, TemplateReference
 from giskard.llm.types import ChatMessage
@@ -33,7 +33,31 @@ class BaseLLMCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignore[
     generator : BaseGenerator
         Generator for LLM evaluation. Defaults to the global
         default generator if not specified.
+    num_runs : int
+        Number of times to run the LLM evaluation. Defaults to 1 (single run,
+        identical to historical behavior). When greater than 1, the check runs
+        `num_runs` times and combines the individual results via `consensus`.
+    consensus : Literal["majority", "unanimous", "any"]
+        Rule used to combine multiple run results into a final pass/fail when
+        `num_runs > 1`. Ignored when `num_runs == 1`.
     """
+
+    num_runs: int = Field(
+        default=1,
+        ge=1,
+        description=(
+            "Number of times to run the LLM evaluation. When > 1, results are "
+            "combined using `consensus`."
+        ),
+    )
+    consensus: Literal["majority", "unanimous", "any"] = Field(
+        default="majority",
+        description=(
+            "How to combine multiple run results when `num_runs > 1`: "
+            "'majority' (more than half pass), 'unanimous' (all pass), or "
+            "'any' (at least one passes)."
+        ),
+    )
 
     @property
     def output_type(self) -> type[BaseModel] | None:
@@ -74,9 +98,28 @@ class BaseLLMCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignore[
 
         return ChatWorkflow(generator=self._generator, messages=[prompt])
 
+    async def _run_once(self, trace: TraceType) -> CheckResult:
+        """Execute a single LLM evaluation pass."""
+        workflow = await self._build_workflow(trace)
+
+        inputs = await self.get_inputs(trace)
+        workflow = workflow.with_inputs(**inputs)
+
+        if self.output_type is not None:
+            workflow = workflow.with_output(self.output_type)
+
+        chat = await workflow.run()
+
+        return await self._handle_output(chat.output, inputs, trace)
+
     @override
     async def run(self, trace: TraceType) -> CheckResult:
         """Execute the LLM-based check.
+
+        Runs the evaluation `num_runs` times (default 1, i.e. today's single-run
+        behavior) and, when `num_runs > 1`, combines the individual results into
+        a final pass/fail according to `consensus`. Individual per-run results
+        are kept in `details["runs"]` for observability.
 
         Parameters
         ----------
@@ -90,17 +133,36 @@ class BaseLLMCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignore[
         CheckResult
             The result of the check evaluation.
         """
-        workflow = await self._build_workflow(trace)
+        if self.num_runs == 1:
+            return await self._run_once(trace)
 
-        inputs = await self.get_inputs(trace)
-        workflow = workflow.with_inputs(**inputs)
+        results = [await self._run_once(trace) for _ in range(self.num_runs)]
+        passed_count = sum(1 for result in results if result.passed)
+        total = len(results)
 
-        if self.output_type is not None:
-            workflow = workflow.with_output(self.output_type)
+        if self.consensus == "unanimous":
+            passed = passed_count == total
+        elif self.consensus == "any":
+            passed = passed_count > 0
+        else:  # "majority"
+            passed = passed_count > total / 2
 
-        chat = await workflow.run()
+        message = (
+            f"{passed_count}/{total} runs passed "
+            f"(consensus={self.consensus}) -> {'PASS' if passed else 'FAIL'}"
+        )
+        details: dict[str, Any] = {
+            "num_runs": total,
+            "consensus": self.consensus,
+            "passed_count": passed_count,
+            "runs": results,
+        }
 
-        return await self._handle_output(chat.output, inputs, trace)
+        return (
+            CheckResult.success(message=message, details=details)
+            if passed
+            else CheckResult.failure(message=message, details=details)
+        )
 
     async def get_inputs(self, trace: TraceType) -> dict[str, Any]:
         """Get template inputs for the LLM prompt.

--- a/libs/giskard-checks/tests/builtin/test_judge.py
+++ b/libs/giskard-checks/tests/builtin/test_judge.py
@@ -48,6 +48,40 @@ class MockGenerator(BaseGenerator):
         )
 
 
+@BaseGenerator.register("mock_sequence")
+class SequenceMockGenerator(BaseGenerator):
+    """Mock generator returning a different passed/reason per call, cycling a sequence."""
+
+    results: list[bool] = Field(default_factory=list)
+    calls: list[Sequence[ChatMessage]] = Field(default_factory=list)
+
+    @override
+    async def _call_model(
+        self,
+        messages: Sequence[ChatMessage],
+        params: GenerationParams,
+        metadata: dict[str, Any] | None = None,
+    ) -> CompletionResponse:
+        index = len(self.calls)
+        self.calls.append(messages)
+        passed = self.results[index % len(self.results)]
+        return CompletionResponse(
+            choices=[
+                Choice(
+                    message=AssistantMessage(
+                        role="assistant",
+                        content=json.dumps(
+                            {"passed": passed, "reason": f"run {index}"}
+                        ),
+                    ),
+                    finish_reason="stop",
+                    index=0,
+                )
+            ],
+            model="mock",
+        )
+
+
 def serialization_roundtrip[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
     judge: LLMJudge[InputType, OutputType, TraceType],
 ) -> LLMJudge[InputType, OutputType, TraceType]:
@@ -175,3 +209,99 @@ async def test_validate_both_prompt_or_path() -> None:
             prompt="Evaluate the answer.",
             prompt_path="prompts/judge_prompt.j2",
         )
+
+
+# --- num_runs / consensus (#2372) ---
+
+
+async def test_num_runs_defaults_preserve_single_run_behavior() -> None:
+    """Default num_runs=1 makes exactly one call and skips the consensus wrapper."""
+    generator = MockGenerator(passed=True, reason="Looks good")
+    judge = LLMJudge(generator=generator, prompt="Evaluate the answer.")
+
+    assert judge.num_runs == 1
+    assert judge.consensus == "majority"
+
+    result = await judge.run(Trace())
+    assert result.status == CheckStatus.PASS
+    assert len(generator.calls) == 1
+    # Single-run details shape is unchanged: no "runs" wrapper key.
+    assert "runs" not in result.details
+    assert result.details["reason"] == "Looks good"
+
+
+async def test_num_runs_all_pass() -> None:
+    generator = MockGenerator(passed=True, reason="Looks good")
+    judge = LLMJudge(generator=generator, prompt="Evaluate the answer.", num_runs=3)
+
+    result = await judge.run(Trace())
+    assert result.status == CheckStatus.PASS
+    assert len(generator.calls) == 3
+    assert result.details["num_runs"] == 3
+    assert result.details["passed_count"] == 3
+    assert len(result.details["runs"]) == 3
+    assert all(r.passed for r in result.details["runs"])
+
+
+async def test_num_runs_all_fail() -> None:
+    generator = MockGenerator(passed=False, reason="Looks bad")
+    judge = LLMJudge(generator=generator, prompt="Evaluate the answer.", num_runs=3)
+
+    result = await judge.run(Trace())
+    assert result.status == CheckStatus.FAIL
+    assert len(generator.calls) == 3
+    assert result.details["passed_count"] == 0
+    assert len(result.details["runs"]) == 3
+    assert all(r.failed for r in result.details["runs"])
+
+
+async def test_consensus_majority_split_decision() -> None:
+    """2 of 3 runs pass: majority consensus passes."""
+    generator = SequenceMockGenerator(results=[True, True, False])
+    judge = LLMJudge(
+        generator=generator,
+        prompt="Evaluate the answer.",
+        num_runs=3,
+        consensus="majority",
+    )
+
+    result = await judge.run(Trace())
+    assert result.status == CheckStatus.PASS
+    assert result.details["passed_count"] == 2
+
+
+async def test_consensus_unanimous_split_decision() -> None:
+    """2 of 3 runs pass: unanimous consensus fails (not all runs passed)."""
+    generator = SequenceMockGenerator(results=[True, True, False])
+    judge = LLMJudge(
+        generator=generator,
+        prompt="Evaluate the answer.",
+        num_runs=3,
+        consensus="unanimous",
+    )
+
+    result = await judge.run(Trace())
+    assert result.status == CheckStatus.FAIL
+    assert result.details["passed_count"] == 2
+
+
+async def test_consensus_any_split_decision() -> None:
+    """1 of 3 runs pass: 'any' consensus passes (at least one passed)."""
+    generator = SequenceMockGenerator(results=[False, False, True])
+    judge = LLMJudge(
+        generator=generator,
+        prompt="Evaluate the answer.",
+        num_runs=3,
+        consensus="any",
+    )
+
+    result = await judge.run(Trace())
+    assert result.status == CheckStatus.PASS
+    assert result.details["passed_count"] == 1
+
+
+async def test_num_runs_must_be_at_least_one() -> None:
+    generator = MockGenerator(passed=True, reason=None)
+
+    with pytest.raises(ValidationError):
+        _ = LLMJudge(generator=generator, prompt="Evaluate the answer.", num_runs=0)


### PR DESCRIPTION
Closes #2372

## Problem

`BaseLLMCheck.run()` calls the underlying `ChatWorkflow` exactly once and returns that single result. LLM judges can be noisy on a single call, and there was no way to reduce that noise via repeated sampling.

## Fix

Adds two fields to `BaseLLMCheck`:
- `num_runs: int = 1` (validated `>= 1`)
- `consensus: Literal["majority", "unanimous", "any"] = "majority"`

The original single-pass body of `run()` is extracted into `_run_once()` with byte-identical logic. When `num_runs == 1`, `run()` calls `_run_once()` directly — same code path, same `details` shape, zero behavior change and zero added overhead for existing callers. When `num_runs > 1`, it runs `_run_once()` that many times, tallies pass/fail, and applies the consensus rule:
- `majority`: more than half the runs pass
- `unanimous`: all runs pass
- `any`: at least one run passes

The final `CheckResult.details` includes `num_runs`, `consensus`, `passed_count`, and `runs` (the individual per-run results) for observability.

Note: there's an existing PR (#2483) attempting this same issue, but it's been stale since June with failing CI and no response to review — this is an independent implementation, not based on that branch.

## Tests

Added to `libs/giskard-checks/tests/builtin/test_judge.py`, including a `SequenceMockGenerator` for split-decision scenarios:
- default behavior (`num_runs=1`) unchanged, no `"runs"` key in details
- all-pass / all-fail across multiple runs
- split-decision case for each of the three consensus modes
- `num_runs=0` raises a validation error

```
pytest libs/giskard-checks/tests/builtin/test_judge.py -m "not functional" -q   # 13 passed
pytest libs/giskard-checks -m "not functional" -q                              # 749 passed, 16 skipped
ruff check / ruff format --check                                               # clean
basedpyright --level error                                                     # 0 errors
```