### PR TITLE
fix(checks): descendants JSONPath returns scalar vs list depending on match count

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/core/extraction.py
+++ b/libs/giskard-checks/src/giskard/checks/core/extraction.py
@@ -65,7 +65,15 @@ class NoMatch(BaseModel):
 
 
 def _is_list_expression(expression: JSONPath) -> bool:
-    if isinstance(expression, Child | Descendants):
+    # `..` searches a whole subtree, so how many values it finds is a property
+    # of the data, not of the expression. Treat it as a list-expression the way
+    # bracket wildcards are, or resolve() falls back to its match-count
+    # heuristic and returns a bare scalar whenever the data happens to hold one
+    # match.
+    if isinstance(expression, Descendants):
+        return True
+
+    if isinstance(expression, Child):
         return _is_list_expression(expression.right) or _is_list_expression(
             expression.left
         )

--- a/libs/giskard-checks/tests/core/test_extraction.py
+++ b/libs/giskard-checks/tests/core/test_extraction.py
@@ -157,3 +157,42 @@ class TestJSONPathStrAnnotatedType:
 
         with pytest.raises(ValidationError, match="Invalid JSONPath expression"):
             Model(key="trace.last.outputs[")
+
+
+class TestResolveDescendants:
+    """Tests for resolve()'s handling of the descendants operator (``..``).
+
+    ``trace..ctx`` searches the whole trace, so the number of values it finds
+    depends on the data, not on the expression. It must always resolve to a
+    list -- otherwise ComparisonCheck's match=any/all/none rejects the value
+    with a type error whenever exactly one interaction happens to carry the
+    field.
+    """
+
+    @staticmethod
+    def _trace(*metadata: dict[str, str]) -> Trace[str, str]:
+        return Trace[str, str](
+            interactions=[
+                Interaction(inputs=f"q{i}", outputs=f"a{i}", metadata=m)
+                for i, m in enumerate(metadata)
+            ]
+        )
+
+    def test_descendants_with_single_match_returns_a_list_not_a_bare_scalar(self):
+        trace = self._trace({"ctx": "doc-1"}, {})
+        assert resolve(trace, "trace..ctx") == ["doc-1"]
+
+    def test_descendants_with_multiple_matches_returns_a_list(self):
+        trace = self._trace({"ctx": "doc-1"}, {"ctx": "doc-2"}, {})
+        result = resolve(trace, "trace..ctx")
+        assert isinstance(result, list)
+        assert sorted(result) == ["doc-1", "doc-2"]
+
+    def test_descendants_with_no_match_returns_an_empty_list(self):
+        """Consistent with `*`, which already returns [] rather than NoMatch."""
+        trace = self._trace({})
+        assert resolve(trace, "trace..missing") == []
+
+    def test_child_expression_without_wildcard_still_returns_a_bare_scalar(self):
+        trace = self._trace({})
+        assert resolve(trace, "trace.last.outputs") == "a0"


### PR DESCRIPTION
Fixes #2633.

## Problem

`_is_list_expression` handles `Descendants` in the same recursive branch as `Child`:

```python
if isinstance(expression, Child | Descendants):
    return _is_list_expression(expression.right) or _is_list_expression(expression.left)
```

For `trace..ctx` both children are single-field `Fields`, so this returns `False` and `resolve()` falls back to its match-count heuristic (`len(matches) > 1 or _is_list_expression(expression)`). A `..` expression then yields a bare scalar when the data holds exactly one match and a list when it holds two or more.

This is the defect #2605 fixed for dot-wildcards and multi-field selectors. That fix added a `Fields` branch; `..` compiles to `Descendants` and was not covered. `..` is a supported expression — `test_extraction.py` already asserts `trace..outputs` validates.

It breaks `ComparisonCheck`'s `match=any/all/none`, which requires a list/set/tuple:

```
Equals(key="trace..ctx", expected_value="doc-1", match="any")

one interaction carries ctx : FAIL | Expected a list, set, or tuple at key 'trace..ctx'
                                     when match is 'any', but got str.
two interactions carry ctx  : PASS | At least one value in ['doc-1', 'doc-2'] is equal to 'doc-1'.
```

Identical check configuration; the outcome depends on incidental data shape.

## Fix

Give `Descendants` its own branch returning `True`, and leave `Child` recursing. A `..` searches a whole subtree, so its match count is a property of the data, not of the expression — the same reasoning the bracket-wildcard and `Fields` branches already encode.

## Behavior change worth flagging

`trace..missing` now returns `[]` instead of `NoMatch`. That matches how list-expressions already behave — `trace.last.metadata.*` on empty metadata returns `[]` today — while ordinary paths such as `trace.last.nope` keep returning `NoMatch`. Covered by a test.

## Verification

- `uv run pytest libs/giskard-checks -m "not functional"` → **761 passed, 4 skipped** (757 passed, 4 skipped on `main` before this change; the 4 added tests are the difference).
- TDD red→green: reverting only `extraction.py` reproduces `'doc-1' == ['doc-1']` (bare scalar) and fails 2 of the new tests; reapplying passes all 5 in the class.
- `ruff check` / `ruff format --check` on both changed files: clean.
- `basedpyright` on `extraction.py`: 0 errors, 28 warnings — byte-identical to the count on `main`, so nothing new was introduced.

Python 3.13, `jsonpath-ng` from the pinned range.

## Separate observation, not addressed here

`Trace.model_dump()` includes a `last` key duplicating the final interaction, so `trace..outputs` on a single-interaction trace returns `['hello', 'hello']`. Different problem, different blast radius — noted in #2633 and left alone.
