### PR TITLE
fix(checks): SemanticSimilarity embeds the repr of a list-valued key

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/builtin/semantic_similarity.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/semantic_similarity.py
@@ -154,6 +154,30 @@ class SemanticSimilarity[InputType, OutputType, TraceType: Trace](  # pyright: i
                 },
             )
 
+        # A list-valued key (a wildcard, `..`, or a multi-match path) would
+        # otherwise reach str() below and be embedded as its Python repr --
+        # brackets, quotes and all -- yielding a similarity score computed on
+        # text no one wrote. Reject it instead, the way Readability rejects a
+        # value it cannot score. Scalars still stringify as before.
+        resolved: list[tuple[str, str, object]] = [
+            ("reference text", self.reference_text_key, reference_text),
+            ("actual answer", self.actual_answer_key, actual_answer),
+        ]
+        for label, key, value in resolved:
+            if isinstance(value, (list, tuple, set, dict)):
+                return CheckResult.failure(
+                    message=(
+                        f"Value for {label} key '{key}' must be a single value, but "
+                        f"found {type(value).__name__}. Use a key that resolves to "
+                        "one value."
+                    ),
+                    details={
+                        "reference_text_key": self.reference_text_key,
+                        "actual_answer_key": self.actual_answer_key,
+                        "value": str(value),
+                    },
+                )
+
         actual_answer = str(actual_answer)
         reference_text = str(reference_text)
 

--- a/libs/giskard-checks/tests/builtin/test_semantic_similarity.py
+++ b/libs/giskard-checks/tests/builtin/test_semantic_similarity.py
@@ -623,3 +623,59 @@ async def test_similarity_at_exact_threshold() -> None:
     # Should pass when similarity >= threshold
     assert result.status == CheckStatus.PASS
     assert result.details["similarity"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_list_valued_key_is_rejected_instead_of_embedding_its_repr():
+    """A key resolving to several values must not be embedded as `str(list)`.
+
+    Without this guard the check embeds "['a', 'b']" -- brackets and quotes
+    included -- and reports an ordinary pass/fail on a score computed from
+    text no one wrote.
+    """
+    embedded: list[list[str]] = []
+
+    @BaseEmbeddingModel.register("recording")
+    class RecordingEmbeddingModel(BaseEmbeddingModel):
+        async def _embed(
+            self, texts: list[str], params: EmbeddingParams | None = None
+        ) -> list[np.ndarray]:
+            embedded.append(list(texts))
+            return [np.array([1.0, 0.0, 0.0]) for _ in texts]
+
+    trace = Trace[str, str](
+        interactions=[
+            Interaction(inputs="q1", outputs="a1", metadata={"ref": "first"}),
+            Interaction(inputs="q2", outputs="a2", metadata={"ref": "second"}),
+        ]
+    )
+    check = SemanticSimilarity(
+        actual_answer_key="trace.last.outputs",
+        reference_text_key="trace.interactions[*].metadata.ref",
+        threshold=0.5,
+        embedding_model=RecordingEmbeddingModel(),
+    )
+
+    result = await check.run(trace)
+
+    assert not result.passed
+    assert "must be a single value" in (result.message or "")
+    assert embedded == [], "nothing should have been sent to the embedding model"
+
+
+@pytest.mark.asyncio
+async def test_scalar_key_still_stringifies():
+    """Non-string scalars keep working; only collections are rejected."""
+    trace = Trace[str, str](
+        interactions=[Interaction(inputs="q", outputs="42", metadata={"ref": 42})]
+    )
+    check = SemanticSimilarity(
+        actual_answer_key="trace.last.outputs",
+        reference_text_key="trace.last.metadata.ref",
+        threshold=0.5,
+        embedding_model=MockEmbeddingModel(embeddings={}),
+    )
+
+    result = await check.run(trace)
+
+    assert result.passed


### PR DESCRIPTION
Fixes #2635.

## Problem

`run()` calls `str()` on whatever `reference_text_key` and `actual_answer_key` resolve to. A key resolving to several values — a bracket wildcard, `..`, or any multi-match path — reaches the embedding model as its Python repr:

```
reference_text_key="trace.interactions[*].metadata.ref"

sent to the embedding model:
    'Berlin is the capital of Germany'
    "['Paris is the capital', 'Berlin is the capital']"
result: pass | The cosine similarity with the reference answer is 1.00 which is greater than the threshold 0.50
```

The check reports a normal pass on a score computed from a string no one wrote, and nothing in the result flags the value as unusable. `Readability` already guards the equivalent case in `builtin/nlp_metrics.py`; `SemanticSimilarity` did not.

## Fix

Reject `list`/`tuple`/`set`/`dict` before embedding, naming the offending key. Scalars still stringify exactly as before, so a numeric metadata value such as `{"ref": 42}` keeps working.

I chose this over a strict `isinstance(value, str)` — which would match `Readability` exactly — because the strict form would newly reject numbers that stringify sensibly today. Say the word and I'll switch it; the test for the scalar path documents whichever way you prefer.

## Verification

- `uv run pytest libs/giskard-checks -m "not functional"` → **759 passed, 4 skipped** (757 on `main`; the 2 added tests are the difference).
- TDD red→green: reverting only `semantic_similarity.py` fails `test_list_valued_key_is_rejected_instead_of_embedding_its_repr`; reapplying passes. `test_scalar_key_still_stringifies` passes both before and after, which is the point — it pins behavior this change must not alter.
- `ruff check` / `ruff format --check` on both files: clean.
- `basedpyright` on `semantic_similarity.py`: 0 errors, 11 warnings vs 9 on `main`. The two extra are `reportAny`/partially-unknown on the resolved values, the same class already reported elsewhere in this file; `failOnWarnings` is false for this package. I annotated the loop as `list[tuple[str, str, object]]` to keep it to two rather than five — tell me if you would rather I chase them to zero.

Python 3.13.
