### PR TITLE
feat(checks): add ContainsAny and ContainsAll checks

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/__init__.py
@@ -9,6 +9,8 @@ from . import builtin, judges
 from .builtin import (
     AllOf,
     AnyOf,
+    ContainsAll,
+    ContainsAny,
     Equals,
     FnCheck,
     GreaterEquals,
@@ -135,6 +137,8 @@ __all__ = [
     "Toxicity",
     "StringMatching",
     "RegexMatching",
+    "ContainsAll",
+    "ContainsAny",
     # Exceptions
     "InputGenerationException",
     # LLM-based generators

--- a/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
@@ -30,7 +30,7 @@ from .json_valid import JsonValid
 from .nlp_metrics import Readability
 from .rego_policy import RegoPolicy
 from .semantic_similarity import SemanticSimilarity
-from .text_matching import RegexMatching, StringMatching
+from .text_matching import ContainsAll, ContainsAny, RegexMatching, StringMatching
 
 __all__ = [
     "AllOf",
@@ -43,6 +43,8 @@ __all__ = [
     "RegoPolicy",
     "StringMatching",
     "RegexMatching",
+    "ContainsAny",
+    "ContainsAll",
     "Equals",
     "NotEquals",
     "LessThan",

--- a/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
@@ -3,6 +3,8 @@
 This module provides checks for text matching:
 - StringMatching: Literal substring matching with normalization
 - RegexMatching: Regular expression pattern matching
+- ContainsAny: Validates if at least one value from a list appears within a text string
+- ContainsAll: Validates if all values from a list appear within a text string
 """
 
 from abc import ABC, abstractmethod
@@ -470,5 +472,365 @@ class RegexMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignore
             )
         return CheckResult.failure(
             message=f"Text does not match the regex pattern '{pattern}'.",
+            details=details,
+        )
+
+
+class ListTextBasedCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
+    Check[InputType, OutputType, TraceType], ABC
+):
+    """Base class for checks that validate text against a list of target values.
+
+    This abstract class handles the common pattern of:
+    1. Extracting text from a trace or direct value
+    2. Extracting a target list of values from trace or direct value
+    3. Validating both exist and have correct types
+    4. Delegating to subclass for specific matching logic
+
+    Attributes
+    ----------
+    text : str | MISSING
+        The text string to search within. If omitted, extracted from
+        trace using ``text_key``.
+    text_key : JSONPathStr
+        JSONPath expression to extract the text from the trace. Defaults to
+        "trace.last.outputs" which extracts the last interaction's outputs.
+    values : list[str] | MISSING
+        The list of values to search for. Either this or ``values_key`` must be provided.
+    values_key : JSONPathStr | MISSING
+        JSONPath expression to extract the values from the trace. Either this or ``values`` must be provided.
+    normalization_form : NormalizationForm | None
+        Unicode normalization form to apply before matching. Options:
+        - "NFC": Canonical Composition
+        - "NFD": Canonical Decomposition
+        - "NFKC": Compatibility Composition (default)
+        - "NFKD": Compatibility Decomposition
+        If None, no normalization is applied. Defaults to "NFKC".
+    case_sensitive : bool
+        If True, matching is case-sensitive. If False, both text and values
+        are converted to lowercase before comparison. Defaults to False.
+    """
+
+    text: str | MISSING = Field(
+        default=MISSING,
+        description="The text string to search within.",
+    )
+    text_key: JSONPathStr = Field(
+        default="trace.last.outputs",
+        description="JSONPath expression to extract text from trace.",
+    )
+    values: list[str] | MISSING = Field(
+        default=MISSING,
+        description="The list of values to search for.",
+    )
+    values_key: JSONPathStr | MISSING = Field(
+        default=MISSING,
+        description="JSONPath expression to extract the values from the trace.",
+    )
+    normalization_form: NormalizationForm | None = Field(
+        default="NFKC",
+        description="Unicode normalization form to apply (NFC, NFD, NFKC, NFKD). Defaults to NFKC.",
+    )
+    case_sensitive: bool = Field(
+        default=False,
+        description="If True, matching is case-sensitive. If False, strings are lowercased before comparison.",
+    )
+
+    @model_validator(mode="after")
+    def validate_values_or_values_key(self) -> Self:
+        """Validate that exactly one of values or values_key is provided.
+
+        Returns
+        -------
+        Self
+            The validated instance.
+
+        Raises
+        ------
+        ValueError
+            If neither or both values and values_key are provided.
+        """
+        if (self.values is MISSING) == (self.values_key is MISSING):
+            raise ValueError(
+                "Exactly one of 'values' or 'values_key' must be provided, not both or neither."
+            )
+        return self
+
+    def _extract_and_validate(
+        self,
+        trace: TraceType,
+    ) -> tuple[str, list[str], dict[str, Any]] | tuple[None, None, CheckResult]:
+        """Extract and validate text and target values from trace or direct values.
+
+        Parameters
+        ----------
+        trace : TraceType
+            The trace to extract values from.
+
+        Returns
+        -------
+        tuple[str, list[str], dict] | tuple[None, None, CheckResult]
+            Either (text, values, details) on success, or (None, None, error_result) on failure.
+        """
+        text = provided_or_resolve(trace, key=self.text_key, value=self.text)
+        target = provided_or_resolve(
+            trace,
+            key=self.values_key,
+            value=self.values,
+        )
+
+        details = {"text": text, "values": target}
+
+        if isinstance(target, NoMatch):
+            return (
+                None,
+                None,
+                CheckResult.failure(
+                    message=f"No value found for values key '{self.values_key}'.",
+                    details=details,
+                ),
+            )
+
+        if not isinstance(target, list) or not all(isinstance(x, str) for x in target):
+            return (
+                None,
+                None,
+                CheckResult.failure(
+                    message="Value for values must be a list of strings.",
+                    details=details,
+                ),
+            )
+
+        if isinstance(text, NoMatch):
+            return (
+                None,
+                None,
+                CheckResult.failure(
+                    message=f"No value found for text key '{self.text_key}'.",
+                    details=details,
+                ),
+            )
+
+        if not isinstance(text, str):
+            return (
+                None,
+                None,
+                CheckResult.failure(
+                    message=f"Value for text is not a string, expected string but got {type(text).__name__}.",
+                    details=details,
+                ),
+            )
+
+        return text, target, details
+
+    def _format_str(self, value: str) -> str:
+        """Format a string for matching by applying normalization and case handling.
+
+        This method:
+        1. Applies Unicode normalization if specified
+        2. Converts to lowercase if case-insensitive matching is enabled
+
+        Parameters
+        ----------
+        value : str
+            The string to format.
+
+        Returns
+        -------
+        str
+            The formatted string ready for comparison.
+        """
+        value = normalize_string(value, self.normalization_form)
+        if not self.case_sensitive:
+            value = value.lower()
+        return value
+
+
+@Check.register("contains_any")
+class ContainsAny[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
+    ListTextBasedCheck[InputType, OutputType, TraceType]
+):
+    """Check that validates if at least one value appears within a text string.
+
+    This check performs substring matching between a list of values and text, with
+    support for Unicode normalization and case sensitivity control. Both the
+    text and values can be provided directly or extracted from a trace using
+    JSONPath expressions.
+
+    Attributes
+    ----------
+    text : str | MISSING
+        The text string to search within. If omitted, extracted from
+        trace using ``text_key``.
+    text_key : JSONPathStr
+        JSONPath expression to extract the text from the trace. Defaults to
+        "trace.last.outputs" which extracts the last interaction's outputs.
+    values : list[str] | MISSING
+        The list of values to search for. Either this or ``values_key`` must be provided.
+    values_key : JSONPathStr | MISSING
+        JSONPath expression to extract the values from the trace. Either this or ``values`` must be provided.
+    normalization_form : NormalizationForm | None
+        Unicode normalization form to apply before matching. Options:
+        - "NFC": Canonical Composition
+        - "NFD": Canonical Decomposition
+        - "NFKC": Compatibility Composition (default)
+        - "NFKD": Compatibility Decomposition
+        If None, no normalization is applied. Defaults to "NFKC".
+    case_sensitive : bool
+        If True, matching is case-sensitive. If False, both text and values
+        are converted to lowercase before comparison. Defaults to False.
+
+    Examples
+    --------
+    Direct text and values::
+
+        check = ContainsAny(
+            text="Hello World",
+            values=["world", "java"],
+            case_sensitive=False
+        )
+
+    Extract both from trace::
+
+        check = ContainsAny(
+            text_key="trace.last.outputs.answer",
+            values_key="trace.last.inputs.expected_keywords"
+        )
+    """
+
+    @override
+    async def run(self, trace: TraceType) -> CheckResult:
+        """Execute the ContainsAny check.
+
+        Parameters
+        ----------
+        trace : TraceType
+            The trace to evaluate.
+
+        Returns
+        -------
+        CheckResult
+            The result of the check execution.
+        """
+        result = self._extract_and_validate(trace)
+        if result[0] is None:
+            return result[2]  # type: ignore[return-value]
+
+        text, values, details = result[0], result[1], result[2]
+        details["normalization_form"] = self.normalization_form
+        details["case_sensitive"] = self.case_sensitive
+
+        formatted_text = self._format_str(text)
+        formatted_values = [self._format_str(v) for v in values]
+
+        matched_values = [
+            v for v, fv in zip(values, formatted_values) if fv in formatted_text
+        ]
+
+        details["matched_values"] = matched_values
+
+        if matched_values:
+            return CheckResult.success(
+                message=f"The text contains at least one of the values: {', '.join(matched_values)}.",
+                details=details,
+            )
+
+        return CheckResult.failure(
+            message="The text does not contain any of the provided values.",
+            details=details,
+        )
+
+
+@Check.register("contains_all")
+class ContainsAll[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
+    ListTextBasedCheck[InputType, OutputType, TraceType]
+):
+    """Check that validates if all values appear within a text string.
+
+    This check performs substring matching between a list of values and text, with
+    support for Unicode normalization and case sensitivity control. Both the
+    text and values can be provided directly or extracted from a trace using
+    JSONPath expressions.
+
+    Attributes
+    ----------
+    text : str | MISSING
+        The text string to search within. If omitted, extracted from
+        trace using ``text_key``.
+    text_key : JSONPathStr
+        JSONPath expression to extract the text from the trace. Defaults to
+        "trace.last.outputs" which extracts the last interaction's outputs.
+    values : list[str] | MISSING
+        The list of values to search for. Either this or ``values_key`` must be provided.
+    values_key : JSONPathStr | MISSING
+        JSONPath expression to extract the values from the trace. Either this or ``values`` must be provided.
+    normalization_form : NormalizationForm | None
+        Unicode normalization form to apply before matching. Options:
+        - "NFC": Canonical Composition
+        - "NFD": Canonical Decomposition
+        - "NFKC": Compatibility Composition (default)
+        - "NFKD": Compatibility Decomposition
+        If None, no normalization is applied. Defaults to "NFKC".
+    case_sensitive : bool
+        If True, matching is case-sensitive. If False, both text and values
+        are converted to lowercase before comparison. Defaults to False.
+
+    Examples
+    --------
+    Direct text and values::
+
+        check = ContainsAll(
+            text="Hello World",
+            values=["hello", "world"],
+            case_sensitive=False
+        )
+
+    Extract both from trace::
+
+        check = ContainsAll(
+            text_key="trace.last.outputs.answer",
+            values_key="trace.last.inputs.all_keywords"
+        )
+    """
+
+    @override
+    async def run(self, trace: TraceType) -> CheckResult:
+        """Execute the ContainsAll check.
+
+        Parameters
+        ----------
+        trace : TraceType
+            The trace to evaluate.
+
+        Returns
+        -------
+        CheckResult
+            The result of the check execution.
+        """
+        result = self._extract_and_validate(trace)
+        if result[0] is None:
+            return result[2]  # type: ignore[return-value]
+
+        text, values, details = result[0], result[1], result[2]
+        details["normalization_form"] = self.normalization_form
+        details["case_sensitive"] = self.case_sensitive
+
+        formatted_text = self._format_str(text)
+        formatted_values = [self._format_str(v) for v in values]
+
+        missing_values = [
+            v for v, fv in zip(values, formatted_values) if fv not in formatted_text
+        ]
+
+        details["missing_values"] = missing_values
+
+        if not missing_values:
+            return CheckResult.success(
+                message="The text contains all of the provided values.",
+                details=details,
+            )
+
+        return CheckResult.failure(
+            message=f"The text is missing the following values: {', '.join(missing_values)}.",
             details=details,
         )

--- a/libs/giskard-checks/tests/builtin/test_contains.py
+++ b/libs/giskard-checks/tests/builtin/test_contains.py
@@ -1,0 +1,123 @@
+"""Tests for the ContainsAny and ContainsAll checks."""
+
+import pytest
+from giskard.checks import CheckStatus, ContainsAll, ContainsAny, Interaction, Trace
+
+
+async def test_contains_any_success() -> None:
+    """Test that ContainsAny passes when at least one value is found."""
+    check = ContainsAny(
+        text="Hello World Python", values=["world", "java"], case_sensitive=False
+    )
+    result = await check.run(Trace())
+    assert result.status == CheckStatus.PASS
+    assert result.message is not None
+    assert "at least one of the values" in result.message
+    assert "world" in result.details["matched_values"]
+
+
+async def test_contains_any_failure() -> None:
+    """Test that ContainsAny fails when no values are found."""
+    check = ContainsAny(
+        text="Hello World", values=["python", "java"], case_sensitive=False
+    )
+    result = await check.run(Trace())
+    assert result.status == CheckStatus.FAIL
+    assert result.message is not None
+    assert "does not contain any of the provided values" in result.message
+
+
+async def test_contains_all_success() -> None:
+    """Test that ContainsAll passes when all values are found."""
+    check = ContainsAll(
+        text="Hello World Python", values=["world", "python"], case_sensitive=False
+    )
+    result = await check.run(Trace())
+    assert result.status == CheckStatus.PASS
+    assert result.message is not None
+    assert "contains all of the provided values" in result.message
+    assert len(result.details["missing_values"]) == 0
+
+
+async def test_contains_all_failure() -> None:
+    """Test that ContainsAll fails when some values are missing."""
+    check = ContainsAll(
+        text="Hello World Python", values=["world", "java"], case_sensitive=False
+    )
+    result = await check.run(Trace())
+    assert result.status == CheckStatus.FAIL
+    assert result.message is not None
+    assert "is missing the following values: java" in result.message
+    assert "java" in result.details["missing_values"]
+
+
+async def test_case_sensitive_matching() -> None:
+    """Test case-sensitive matching behavior."""
+    # Case-sensitive: should fail
+    check_sensitive = ContainsAny(
+        text="Hello World", values=["world"], case_sensitive=True
+    )
+    result = await check_sensitive.run(Trace())
+    assert result.status == CheckStatus.FAIL
+
+    # Case-insensitive: should pass
+    check_insensitive = ContainsAny(
+        text="Hello World", values=["world"], case_sensitive=False
+    )
+    result = await check_insensitive.run(Trace())
+    assert result.status == CheckStatus.PASS
+
+
+async def test_extraction_from_trace() -> None:
+    """Test extracting both text and values from trace."""
+    check = ContainsAll(
+        text_key="trace.last.outputs.response",
+        values_key="trace.last.inputs.topics",
+    )
+    interaction = Interaction(
+        inputs={"topics": ["Paris", "France"]},
+        outputs={"response": "The capital of France is Paris."},
+    )
+    result = await check.run(Trace(interactions=[interaction]))
+    assert result.status == CheckStatus.PASS
+    assert result.details["text"] == "The capital of France is Paris."
+    assert result.details["values"] == ["Paris", "France"]
+
+
+async def test_invalid_values_type() -> None:
+    """Test behavior when values is not a list of strings."""
+    check = ContainsAny(
+        text="Hello 123",
+        values_key="trace.last.inputs.topics",
+    )
+    interaction = Interaction(
+        inputs={"topics": "not a list"},
+        outputs={"response": "response"},
+    )
+    result = await check.run(Trace(interactions=[interaction]))
+    assert result.status == CheckStatus.FAIL
+    assert result.message is not None
+    assert "must be a list of strings" in result.message
+
+
+async def test_unicode_normalization() -> None:
+    """Test that Unicode normalization works correctly."""
+    # Using NFKC normalization (default)
+    check = ContainsAny(
+        text="Hello Ａ World",
+        values=["A", "B"],
+        normalization_form="NFKC",
+        case_sensitive=False,
+    )
+    result = await check.run(Trace())
+    assert result.status == CheckStatus.PASS
+
+
+async def test_cannot_provide_both_values_and_values_key() -> None:
+    """Test that providing both values and values_key raises an error."""
+    with pytest.raises(ValueError, match="Exactly one"):
+        ContainsAny(
+            text="Hello World",
+            values=["hello"],
+            values_key="trace.last.inputs.topics",
+        )


### PR DESCRIPTION
## Description

Adds built-in `ContainsAny` and `ContainsAll` checks for validating text against a list of target strings.

- **`ContainsAny`**: Passes if at least one value from the list is found in the text.
- **`ContainsAll`**: Passes if all values from the list are found in the text.
- Both support `case_sensitive`, `normalization_form` (NFC/NFD/NFKC/NFKD), and JSONPath trace extraction via `text_key` / `values_key`.
- Built on a new `ListTextBasedCheck` base class that mirrors the existing `TextBasedCheck` pattern.

**Files changed:**
- `libs/giskard-checks/src/giskard/checks/builtin/text_matching.py` — `ListTextBasedCheck`, `ContainsAny`, `ContainsAll` implementation
- `libs/giskard-checks/src/giskard/checks/builtin/__init__.py` — export
- `libs/giskard-checks/src/giskard/checks/__init__.py` — export
- `libs/giskard-checks/tests/builtin/test_contains.py` — 9 async unit tests

**Validation:**
- `ruff format` + `ruff check`: clean
- `basedpyright --level error`: 0 errors
- Full `giskard-checks` unit suite: **766 passed, 4 skipped** (no regressions)

## Related Issue

Closes #2361

## Type of Change

- [x] 🚀 New feature (non-breaking change which adds functionality)

## Checklist

- [x] I've read the `CODE_OF_CONDUCT.md` document.
- [x] I've read the `CONTRIBUTING.md` guide.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [ ] I've updated the `uv.lock` running `uv lock` (N/A — no `pyproject.toml` changes)
