### PR TITLE
chore(deps): update github-actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
       contents: read # checkout repository
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
           python-version: "3.12"
@@ -45,10 +45,10 @@ jobs:
     env:
       PACKAGE: ${{ matrix.package }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
@@ -69,10 +69,10 @@ jobs:
     env:
       PACKAGE: ${{ matrix.package }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
           python-version: "3.12"
@@ -87,10 +87,10 @@ jobs:
       contents: read # checkout repository
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
           python-version: "3.12"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -79,7 +79,7 @@ jobs:
             pytest_mark: "functional and (google or litellm)"
     name: agents / ${{ matrix.backend.name }} / ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
@@ -91,7 +91,7 @@ jobs:
           # external contributors, and the immutable head.sha pin keeps the
           # reviewed commit identical to the executed one.
           allow-unsafe-pr-checkout: true
-      - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
@@ -139,14 +139,14 @@ jobs:
       PROVIDER: ${{ matrix.provider }}
       EXTRAS: ${{ matrix.extras }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
           # Deliberate opt-in — see test-agents-functional for the full
           # rationale and compensating controls.
           allow-unsafe-pr-checkout: true
-      - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
@@ -180,14 +180,14 @@ jobs:
     env:
       PROVIDER: ${{ matrix.provider }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
           # Deliberate opt-in — see test-agents-functional for the full
           # rationale and compensating controls.
           allow-unsafe-pr-checkout: true
-      - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,14 +82,14 @@ jobs:
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: false
           python-version: "3.12"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -20,9 +20,9 @@ jobs:
       contents: read # checkout repository
       actions: read # needed for private repo analysis
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+      - uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0
         with:
           persona: pedantic

--- a/README.md
+++ b/README.md
@@ -72,12 +72,14 @@ from giskard.checks import Scenario, Groundedness
 
 client = OpenAI()
 
+
 def get_answer(inputs: str) -> str:
     response = client.chat.completions.create(
         model="gpt-5-mini",
         messages=[{"role": "user", "content": inputs}],
     )
     return response.choices[0].message.content
+
 
 scenario = (
     Scenario("test_dynamic_output")
@@ -121,12 +123,14 @@ Use Giskard Scan to:
 import asyncio
 from giskard.scan import vulnerability_scan
 
+
 async def main():
     await vulnerability_scan(
         target=my_agent,
         description="A customer support chatbot for an e-commerce platform.",
         languages=["en"],
     )
+
 
 asyncio.run(main())
 ```
@@ -147,10 +151,12 @@ Wrap your model and run the scan:
 import giskard
 import pandas as pd
 
+
 # Replace my_llm_chain with your actual LLM chain or model inference logic
 def model_predict(df: pd.DataFrame):
     """The function takes a DataFrame and must return a list of outputs (one per row)."""
     return [my_llm_chain.run({"query": question}) for question in df["question"]]
+
 
 giskard_model = giskard.Model(
     model=model_predict,
@@ -183,7 +189,7 @@ knowledge_base = KnowledgeBase.from_pandas(df, columns=["column_1", "column_2"])
 testset = generate_testset(
     knowledge_base,
     num_questions=60,
-    language='en',
+    language="en",
     agent_description="A customer support chatbot for company X",
 )
 ```

--- a/libs/giskard-agents/README.md
+++ b/libs/giskard-agents/README.md
@@ -63,8 +63,7 @@ Or add multiple messages to the workflow:
 ```python
 # The chat message role is "user" by default.
 chat = await (
-    generator
-    .chat("You are a helpful assistant.", role="system")
+    generator.chat("You are a helpful assistant.", role="system")
     .chat("Hello, how are you?")
     .chat("I'm fine, thank you!", role="assistant")
     .chat("What's your name?")
@@ -92,7 +91,9 @@ generator = agents.Generator(
 Or use the convenience method:
 
 ```python
-generator = agents.Generator(model="openai/gpt-4o-mini").with_retries(5, base_delay=2.0, max_delay=30.0)
+generator = agents.Generator(model="openai/gpt-4o-mini").with_retries(
+    5, base_delay=2.0, max_delay=30.0
+)
 ```
 
 ### Rate limiting
@@ -109,7 +110,9 @@ generator = agents.Generator(
 Or use the convenience method:
 
 ```python
-generator = generator.with_rate_limiter(MinIntervalRateLimiter.from_rpm(60, max_concurrent=5))
+generator = generator.with_rate_limiter(
+    MinIntervalRateLimiter.from_rpm(60, max_concurrent=5)
+)
 ```
 
 ## Custom middleware
@@ -124,6 +127,7 @@ from giskard.agents.generators import GenerationParams
 from giskard.agents.generators.middleware import CompletionMiddleware, NextFn
 from giskard.llm.types import ChatMessage, CompletionResponse
 
+
 @CompletionMiddleware.register("logging")
 class LoggingMiddleware(CompletionMiddleware):
     async def call(
@@ -137,6 +141,7 @@ class LoggingMiddleware(CompletionMiddleware):
         response = await next_fn(messages, params, metadata)
         logging.info(f"Got response: {response.choices[0].finish_reason}")
         return response
+
 
 generator = agents.Generator(
     model="openai/gpt-4o-mini",
@@ -154,15 +159,13 @@ each completion call:
 ```python
 from pydantic import BaseModel
 
+
 class SimpleOutput(BaseModel):
     mood: str
     greeting: str
 
-chat = await (
-    generator.chat("Hello!")
-    .with_output(SimpleOutput)
-    .run()
-)
+
+chat = await generator.chat("Hello!").with_output(SimpleOutput).run()
 
 assert isinstance(chat.output, SimpleOutput)
 assert chat.output.mood == "happy"
@@ -179,9 +182,7 @@ Here's an example:
 ```python
 # This will run a chat with the message "Hello Test Bot, how are you?"
 chat = await (
-    generator.chat(
-        "Hello {{ name_of_the_bot }}, how are you?", as_template=True
-    )
+    generator.chat("Hello {{ name_of_the_bot }}, how are you?", as_template=True)
     .with_inputs(name_of_the_bot="Test Bot")
     .run()
 )
@@ -246,7 +247,9 @@ You can then load the template as usual:
 ```python
 chat = await (
     generator.template("evaluators.scientific_theory")
-    .with_inputs(theory="Normandy is actually the center of the universe because its perfect balance of rain, cheese, and cider creates a quantum field that bends space-time, making it the most harmonious place on Earth.")
+    .with_inputs(
+        theory="Normandy is actually the center of the universe because its perfect balance of rain, cheese, and cider creates a quantum field that bends space-time, making it the most harmonious place on Earth."
+    )
     .run()
 )
 
@@ -259,10 +262,9 @@ assert score == 5
 You can run multiple chats with different inputs by passing a list of inputs to the `run_batch` method.
 
 ```python
-chats = await (
-    generator.chat("What's the weather in {{ city }}?", as_template=True)
-    .run_batch([{"city": "Paris"}, {"city": "London"}])
-)
+chats = await generator.chat(
+    "What's the weather in {{ city }}?", as_template=True
+).run_batch([{"city": "Paris"}, {"city": "London"}])
 assert len(chats) == 2
 ```
 
@@ -277,6 +279,7 @@ This can be combined with all functionalities described earlier. Here's an examp
 ```python
 from giskard import agents
 
+
 @agents.tool
 def get_weather(city: str) -> str:
     """Get the weather in a city.
@@ -290,6 +293,7 @@ def get_weather(city: str) -> str:
         return f"It's raining in {city}."
 
     return f"It's sunny in {city}."
+
 
 # Run parallel chats with tools
 chats = await (
@@ -367,10 +371,16 @@ Note: when running a single chat (`workflow.run(...)`), error policy `SKIP` beha
 from giskard.agents import ErrorPolicy
 
 # This may return fewer than 3 chats if some fail.
-chats = await generator.chat("Hello!", role="user").on_error(ErrorPolicy.SKIP).run_many(n=3)
+chats = (
+    await generator.chat("Hello!", role="user").on_error(ErrorPolicy.SKIP).run_many(n=3)
+)
 
 # This will return 3 chats, some may be in failed state.
-chats = await generator.chat("Hello!", role="user").on_error(ErrorPolicy.RETURN).run_many(n=3)
+chats = (
+    await generator.chat("Hello!", role="user")
+    .on_error(ErrorPolicy.RETURN)
+    .run_many(n=3)
+)
 
 for chat in chats:
     if chat.failed:
@@ -388,14 +398,16 @@ You can change this behavior by passing the `catch=None` on the tool decorator. 
 def get_weather(city: str) -> str:
     raise ValueError("City not found")
 
+
 result = await get_weather.run(arguments={"city": "Paris"})
-print(result) # "ERROR: City not found"
+print(result)  # "ERROR: City not found"
 
 
 # Opt out of the catch
 @agents.tool(catch=None)
 def get_weather(city: str) -> str:
     raise ValueError("City not found")
+
 
 # This will raise an exception
 result = await get_weather.run(arguments={"city": "Paris"})

--- a/libs/giskard-checks/README.md
+++ b/libs/giskard-checks/README.md
@@ -40,7 +40,7 @@ scenario = (
     Scenario("test_france_capital")
     .interact(
         inputs="What is the capital of France?",
-        outputs="The capital of France is Paris."
+        outputs="The capital of France is Paris.",
     )
     .check(
         Groundedness(
@@ -48,7 +48,7 @@ scenario = (
             answer_key="trace.last.outputs",
             context="""France is a country in Western Europe. Its capital
                        and largest city is Paris, known for the Eiffel Tower
-                       and the Louvre Museum."""
+                       and the Louvre Museum.""",
         )
     )
 )
@@ -66,6 +66,7 @@ from giskard.checks import Groundedness, Scenario
 
 client = OpenAI()
 
+
 def get_answer(inputs: str) -> str:
     response = client.chat.completions.create(
         model="gpt-5-mini",
@@ -73,17 +74,15 @@ def get_answer(inputs: str) -> str:
     )
     return response.choices[0].message.content
 
+
 scenario = (
     Scenario("test_dynamic_output")
-    .interact(
-        inputs="What is the capital of France?",
-        outputs=get_answer
-    )
+    .interact(inputs="What is the capital of France?", outputs=get_answer)
     .check(
         Groundedness(
             name="answer is grounded",
             answer_key="trace.last.outputs",
-            context="France is a country in Western Europe..."
+            context="France is a country in Western Europe...",
         )
     )
 )
@@ -94,9 +93,11 @@ The `run()` method is async. In a script, wrap it with `asyncio.run()`:
 ```python
 import asyncio
 
+
 async def main():
     result = await scenario.run()
     print(result)
+
 
 asyncio.run(main())
 ```
@@ -350,18 +351,25 @@ result = await (
     Scenario("structured-example")
     .interact(
         {"question": "What is the capital of France?"},
-        lambda inputs: {"answer": "Paris is the capital of France.", "confidence": 0.95}
+        lambda inputs: {
+            "answer": "Paris is the capital of France.",
+            "confidence": 0.95,
+        },
     )
-    .check(StringMatching(
-        name="contains_paris",
-        keyword="Paris",
-        text_key="trace.last.outputs.answer",
-    ))
-    .check(Equals(
-        name="high_confidence",
-        expected_value=0.95,
-        key="trace.last.outputs.confidence",
-    ))
+    .check(
+        StringMatching(
+            name="contains_paris",
+            keyword="Paris",
+            text_key="trace.last.outputs.answer",
+        )
+    )
+    .check(
+        Equals(
+            name="high_confidence",
+            expected_value=0.95,
+            key="trace.last.outputs.confidence",
+        )
+    )
     .run()
 )
 
@@ -381,19 +389,25 @@ result = await (
     Scenario("multi_step_conversation")
     .interact(
         "Hello, I want to apply for a job.",
-        lambda inputs: "Hi! I'd be happy to help. Please provide your email."
+        lambda inputs: "Hi! I'd be happy to help. Please provide your email.",
     )
-    .check(LLMJudge(
-        prompt="The assistant asked for the email politely: {{ trace.last.outputs }}"
-    ))
+    .check(
+        LLMJudge(
+            prompt="The assistant asked for the email politely: {{ trace.last.outputs }}"
+        )
+    )
     .interact(
         "My email is test@example.com",
-        lambda inputs: f"Thank you! I've saved your application with email: {inputs.split()[-1]}"
+        lambda inputs: (
+            f"Thank you! I've saved your application with email: {inputs.split()[-1]}"
+        ),
     )
-    .check(RegexMatching(
-        pattern="test@example.com",
-        text_key="trace.last.outputs",
-    ))
+    .check(
+        RegexMatching(
+            pattern="test@example.com",
+            text_key="trace.last.outputs",
+        )
+    )
     .run()
 )
 
@@ -421,7 +435,7 @@ result = await (
         input_generator,
         lambda inputs: {
             "response": f"Hi there! Received: {inputs['message']}",
-        }
+        },
     )
     .check(from_fn(lambda trace: True, name="noop"))
     .run()
@@ -469,18 +483,20 @@ result = await (
     Scenario("llm-example")
     .interact(
         {"question": "What is the capital of France?"},
-        lambda inputs: {"answer": "Paris is the capital of France."}
+        lambda inputs: {"answer": "Paris is the capital of France."},
     )
     .check(Conformity(name="conformity_check", rule="The agent must answer in English"))
-    .check(LLMJudge(
-        name="safety_check",
-        prompt="""Evaluate if the following response is safe and appropriate.
+    .check(
+        LLMJudge(
+            name="safety_check",
+            prompt="""Evaluate if the following response is safe and appropriate.
 
 Input: {{ trace.last.inputs }}
 Response: {{ trace.last.outputs }}
 
 Return 'passed: true' if safe, 'passed: false' if unsafe.""",
-    ))
+        )
+    )
     .run()
 )
 
@@ -544,9 +560,11 @@ For advanced use cases where you need direct control over interactions or trace 
 from giskard.checks import Interaction, TestCase, Trace
 
 # Build a Trace manually for a TestCase
-trace = Trace(interactions=[
-    Interaction(inputs="some text", outputs=process("some text")),
-])
+trace = Trace(
+    interactions=[
+        Interaction(inputs="some text", outputs=process("some text")),
+    ]
+)
 tc = TestCase(trace=trace, checks=[check1, check2], name="advanced_example")
 test_case_result = await tc.run()
 ```
@@ -556,8 +574,8 @@ For programmatic test generation or when you need fine-grained control, you can 
 ```python
 from giskard.checks import (
     Scenario,
-    Interact, # Inherits from `InteractionSpec`
-    Equals # Inherits from `Check`
+    Interact,  # Inherits from `InteractionSpec`
+    Equals,  # Inherits from `Check`
 )
 
 scenario = Scenario(name="programmatic_scenario").extend(

--- a/libs/giskard-llm/README.md
+++ b/libs/giskard-llm/README.md
@@ -38,19 +38,25 @@ from giskard.llm import LLMClient
 client = LLMClient()
 
 # Configure with explicit values or env var references
-client.configure("openai", api_key="sk-...") # pragma: allowlist secret
-client.configure("azure-prod", provider="azure",
-    api_key="os.environ/AZURE_PROD_KEY", # pragma: allowlist secret
+client.configure("openai", api_key="sk-...")  # pragma: allowlist secret
+client.configure(
+    "azure-prod",
+    provider="azure",
+    api_key="os.environ/AZURE_PROD_KEY",  # pragma: allowlist secret
     base_url="os.environ/AZURE_PROD_ENDPOINT",
     api_version="2024-02-01",
 )
-client.configure("anthropic-relaxed", provider="anthropic",
-    api_key="os.environ/ANTHROPIC_API_KEY", # pragma: allowlist secret
+client.configure(
+    "anthropic-relaxed",
+    provider="anthropic",
+    api_key="os.environ/ANTHROPIC_API_KEY",  # pragma: allowlist secret
     merge_system=True,
 )
 
 response = await client.acompletion("azure-prod/gpt-4o", messages)
-response = await client.acompletion("anthropic-relaxed/claude-3-5-haiku-latest", messages)
+response = await client.acompletion(
+    "anthropic-relaxed/claude-3-5-haiku-latest", messages
+)
 ```
 
 ## Provider reference
@@ -77,7 +83,7 @@ client = LLMClient()
 client.configure(
     "foundry-v1",
     provider="openai",
-    api_key="os.environ/AZURE_OPENAI_API_KEY", # pragma: allowlist secret
+    api_key="os.environ/AZURE_OPENAI_API_KEY",  # pragma: allowlist secret
     base_url="https://example.openai.azure.com/openai/v1/",
 )
 
@@ -113,7 +119,7 @@ client = LLMClient()
 client.configure(
     "azure-secure",
     provider="azure_ai",
-    api_key="os.environ/AZURE_AI_API_KEY", # pragma: allowlist secret
+    api_key="os.environ/AZURE_AI_API_KEY",  # pragma: allowlist secret
     base_url="os.environ/AZURE_AI_ENDPOINT",
     http_client=http_client,
     default_headers={"x-ms-useragent": "giskard-llm"},
@@ -121,7 +127,7 @@ client.configure(
 client.configure(
     "google-secure",
     provider="google",
-    api_key="os.environ/GEMINI_API_KEY", # pragma: allowlist secret
+    api_key="os.environ/GEMINI_API_KEY",  # pragma: allowlist secret
     http_client=http_client,
 )
 

--- a/libs/giskard-llm/docs/design.md
+++ b/libs/giskard-llm/docs/design.md
@@ -13,7 +13,10 @@ Input types and output types use different base classes:
 The Chat Completions API (OpenAI, Azure, Anthropic, Google via `generateContent`) uses a **nested** tool format:
 
 ```python
-{"type": "function", "function": {"name": "add", "description": "...", "parameters": {...}}}
+{
+    "type": "function",
+    "function": {"name": "add", "description": "...", "parameters": {...}},
+}
 ```
 
 The Responses API (OpenAI) and Interactions API (Google) use a **flat** tool format:


### PR DESCRIPTION
## Summary
- Same action pin updates as #2638 (`actions/checkout` v7.0.1, `astral-sh/setup-uv` v8.3.2, `zizmorcore/zizmor-action` v0.6.0)
- Also reformats Markdown Python fences so `make check` passes under the Ruff version CI installs via `uv tool install ruff` (currently 0.16.x)

## Why
#2638 failed the lint job on `make check` / `check-format` because CI's Ruff formats fenced Python in Markdown; the Renovate branch only bumped workflow pins.

## Test plan
- [x] `uvx ruff@0.16.0 format --check .` (CI-equivalent format)
- [x] `uvx ruff@0.16.0 check .`
- [x] `make check-compat` / `make security` / `make check-licenses` / `make check-notices`
- [ ] Confirm Main CI lint job is green on this PR

Supersedes #2638.