### PR TITLE
fix(core): registry loses live rate limiters via WeakSet structural dedup 

### DIFF
--- a/libs/giskard-core/src/giskard/core/rate_limiter/base.py
+++ b/libs/giskard-core/src/giskard/core/rate_limiter/base.py
@@ -12,7 +12,7 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any, ClassVar, Self, override
-from weakref import WeakSet
+from weakref import WeakValueDictionary
 
 from pydantic import (
     ConfigDict,
@@ -34,7 +34,7 @@ class RateLimiterRegistry:
     throttling is consistent across serialization boundaries.
     """
 
-    _instances: dict[str, WeakSet["BaseRateLimiter[Any]"]]
+    _instances: dict[str, WeakValueDictionary[int, "BaseRateLimiter[Any]"]]
 
     def __init__(self):
         self._instances = {}
@@ -52,10 +52,10 @@ class RateLimiterRegistry:
         """
         instances = self._instances.get(rate_limiter.id)
         if instances is None:
-            instances = WeakSet["BaseRateLimiter"]()
+            instances = WeakValueDictionary[int, "BaseRateLimiter"]()
             self._instances[rate_limiter.id] = instances
 
-        all_instances = list(instances)
+        all_instances = list(instances.values())
         matching_instances = [
             instance for instance in all_instances if instance == rate_limiter
         ]
@@ -79,7 +79,7 @@ class RateLimiterRegistry:
                 RuntimeWarning,
             )
 
-        instances.add(rate_limiter)
+        instances[id(rate_limiter)] = rate_limiter
 
     def get_instance(self, id: str) -> "BaseRateLimiter[Any]":
         """Retrieve a registered rate limiter by id.
@@ -103,7 +103,7 @@ class RateLimiterRegistry:
         if not instances:
             raise ValueError(f"Rate limiter with id '{id}' not found")
 
-        return next(iter(instances))
+        return next(iter(instances.values()))
 
 
 @discriminated_base

--- a/libs/giskard-core/src/giskard/core/rate_limiter/base.py
+++ b/libs/giskard-core/src/giskard/core/rate_limiter/base.py
@@ -12,7 +12,7 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any, ClassVar, Self, override
-from weakref import WeakValueDictionary
+from weakref import WeakValueDictionary, finalize
 
 from pydantic import (
     ConfigDict,
@@ -79,7 +79,24 @@ class RateLimiterRegistry:
                 RuntimeWarning,
             )
 
+        # Register the cleanup finalizer before inserting into the
+        # WeakValueDictionary: weakref callbacks fire in reverse registration
+        # order, so this ordering guarantees the dict's own internal cleanup
+        # (removing the dead entry) runs before _cleanup_id inspects it,
+        # rather than racing it.
+        finalize(rate_limiter, self._cleanup_id, rate_limiter.id)
         instances[id(rate_limiter)] = rate_limiter
+
+    def _cleanup_id(self, id: str) -> None:
+        """Drop the tracking entry for `id` once its instance map is empty.
+
+        Without this, every unique id (e.g. the default random UUID) leaves
+        behind an empty WeakValueDictionary in ``_instances`` forever after
+        its last instance is garbage collected.
+        """
+        instances = self._instances.get(id)
+        if instances is not None and not instances:
+            self._instances.pop(id, None)
 
     def get_instance(self, id: str) -> "BaseRateLimiter[Any]":
         """Retrieve a registered rate limiter by id.

--- a/libs/giskard-core/tests/test_rate_limiter.py
+++ b/libs/giskard-core/tests/test_rate_limiter.py
@@ -121,6 +121,25 @@ class TestRateLimiterRegistry:
         )
         assert _rate_limiter_a._state is not _rate_limiter_b._state
 
+    def test_from_id_finds_second_equal_instance_after_first_is_deleted(self):
+        # Two structurally-equal instances sharing the same id can coexist when
+        # duplicate warnings are downgraded. The registry must track them by
+        # object identity, not by structural equality, or deleting the first
+        # one makes the still-alive second one unreachable via from_id().
+        with patch(
+            "giskard.core.rate_limiter.base.GISKARD_DISABLE_DUPLICATE_RATE_LIMITERS_WARNINGS",
+            True,
+        ):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                rl_id = _uid()
+                rate_limiter_a = MinIntervalRateLimiter.from_rpm(60, id=rl_id)
+                rate_limiter_b = MinIntervalRateLimiter.from_rpm(60, id=rl_id)
+                del rate_limiter_a
+
+                found = MinIntervalRateLimiter.from_id(rl_id)
+                assert found is rate_limiter_b
+
 
 class TestDeepCopy:
     def test_deepcopy_returns_same_instance(self):

--- a/libs/giskard-core/tests/test_rate_limiter.py
+++ b/libs/giskard-core/tests/test_rate_limiter.py
@@ -1,5 +1,6 @@
 import asyncio
 import copy
+import gc
 import time
 import uuid
 import warnings
@@ -139,6 +140,20 @@ class TestRateLimiterRegistry:
 
                 found = MinIntervalRateLimiter.from_id(rl_id)
                 assert found is rate_limiter_b
+
+    def test_registry_drops_tracking_entry_once_all_instances_are_collected(self):
+        # Every rate limiter created without an explicit id gets a fresh
+        # random UUID, so leaving an empty WeakValueDictionary behind in
+        # _instances after the last instance for an id is collected would
+        # leak one dict entry per ephemeral rate limiter forever.
+        rl_id = _uid()
+        rate_limiter = MinIntervalRateLimiter.from_rpm(60, id=rl_id)
+        assert rl_id in MinIntervalRateLimiter._registry._instances
+
+        del rate_limiter
+        gc.collect()
+
+        assert rl_id not in MinIntervalRateLimiter._registry._instances
 
 
 class TestDeepCopy:


### PR DESCRIPTION
## Summary
Formatted follow-up of https://github.com/Giskard-AI/giskard-oss/pull/2603 (@chuenchen309).

Same change as #2603, plus ruff format (markdown fences + any Python the newer CI ruff touches) so `check-format` passes.

## Why
#2603 had `safe for build` but lint failed on:
```
uv run ruff format --check .
make: *** [Makefile:101: check-format] Error 1
```

## Supersedes
Please close https://github.com/Giskard-AI/giskard-oss/pull/2603 in favor of this PR once CI is green.

## Test plan
- [ ] lint / check-format green
- [ ] Functional diff matches #2603; extra commits are format-only