### PR TITLE
feat(checks): add retry/consensus voting to BaseLLMCheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,14 @@ from giskard.checks import Scenario, Groundedness
 
 client = OpenAI()
 
+
 def get_answer(inputs: str) -> str:
     response = client.chat.completions.create(
         model="gpt-5-mini",
         messages=[{"role": "user", "content": inputs}],
     )
     return response.choices[0].message.content
+
 
 scenario = (
     Scenario("test_dynamic_output")
@@ -121,12 +123,14 @@ Use Giskard Scan to:
 import asyncio
 from giskard.scan import vulnerability_scan
 
+
 async def main():
     await vulnerability_scan(
         target=my_agent,
         description="A customer support chatbot for an e-commerce platform.",
         languages=["en"],
     )
+
 
 asyncio.run(main())
 ```
@@ -147,10 +151,12 @@ Wrap your model and run the scan:
 import giskard
 import pandas as pd
 
+
 # Replace my_llm_chain with your actual LLM chain or model inference logic
 def model_predict(df: pd.DataFrame):
     """The function takes a DataFrame and must return a list of outputs (one per row)."""
     return [my_llm_chain.run({"query": question}) for question in df["question"]]
+
 
 giskard_model = giskard.Model(
     model=model_predict,
@@ -183,7 +189,7 @@ knowledge_base = KnowledgeBase.from_pandas(df, columns=["column_1", "column_2"])
 testset = generate_testset(
     knowledge_base,
     num_questions=60,
-    language='en',
+    language="en",
     agent_description="A customer support chatbot for company X",
 )
 ```

--- a/libs/giskard-agents/README.md
+++ b/libs/giskard-agents/README.md
@@ -63,8 +63,7 @@ Or add multiple messages to the workflow:
 ```python
 # The chat message role is "user" by default.
 chat = await (
-    generator
-    .chat("You are a helpful assistant.", role="system")
+    generator.chat("You are a helpful assistant.", role="system")
     .chat("Hello, how are you?")
     .chat("I'm fine, thank you!", role="assistant")
     .chat("What's your name?")
@@ -92,7 +91,9 @@ generator = agents.Generator(
 Or use the convenience method:
 
 ```python
-generator = agents.Generator(model="openai/gpt-4o-mini").with_retries(5, base_delay=2.0, max_delay=30.0)
+generator = agents.Generator(model="openai/gpt-4o-mini").with_retries(
+    5, base_delay=2.0, max_delay=30.0
+)
 ```
 
 ### Rate limiting
@@ -109,7 +110,9 @@ generator = agents.Generator(
 Or use the convenience method:
 
 ```python
-generator = generator.with_rate_limiter(MinIntervalRateLimiter.from_rpm(60, max_concurrent=5))
+generator = generator.with_rate_limiter(
+    MinIntervalRateLimiter.from_rpm(60, max_concurrent=5)
+)
 ```
 
 ## Custom middleware
@@ -124,6 +127,7 @@ from giskard.agents.generators import GenerationParams
 from giskard.agents.generators.middleware import CompletionMiddleware, NextFn
 from giskard.llm.types import ChatMessage, CompletionResponse
 
+
 @CompletionMiddleware.register("logging")
 class LoggingMiddleware(CompletionMiddleware):
     async def call(
@@ -137,6 +141,7 @@ class LoggingMiddleware(CompletionMiddleware):
         response = await next_fn(messages, params, metadata)
         logging.info(f"Got response: {response.choices[0].finish_reason}")
         return response
+
 
 generator = agents.Generator(
     model="openai/gpt-4o-mini",
@@ -154,15 +159,13 @@ each completion call:
 ```python
 from pydantic import BaseModel
 
+
 class SimpleOutput(BaseModel):
     mood: str
     greeting: str
 
-chat = await (
-    generator.chat("Hello!")
-    .with_output(SimpleOutput)
-    .run()
-)
+
+chat = await generator.chat("Hello!").with_output(SimpleOutput).run()
 
 assert isinstance(chat.output, SimpleOutput)
 assert chat.output.mood == "happy"
@@ -179,9 +182,7 @@ Here's an example:
 ```python
 # This will run a chat with the message "Hello Test Bot, how are you?"
 chat = await (
-    generator.chat(
-        "Hello {{ name_of_the_bot }}, how are you?", as_template=True
-    )
+    generator.chat("Hello {{ name_of_the_bot }}, how are you?", as_template=True)
     .with_inputs(name_of_the_bot="Test Bot")
     .run()
 )
@@ -246,7 +247,9 @@ You can then load the template as usual:
 ```python
 chat = await (
     generator.template("evaluators.scientific_theory")
-    .with_inputs(theory="Normandy is actually the center of the universe because its perfect balance of rain, cheese, and cider creates a quantum field that bends space-time, making it the most harmonious place on Earth.")
+    .with_inputs(
+        theory="Normandy is actually the center of the universe because its perfect balance of rain, cheese, and cider creates a quantum field that bends space-time, making it the most harmonious place on Earth."
+    )
     .run()
 )
 
@@ -259,10 +262,9 @@ assert score == 5
 You can run multiple chats with different inputs by passing a list of inputs to the `run_batch` method.
 
 ```python
-chats = await (
-    generator.chat("What's the weather in {{ city }}?", as_template=True)
-    .run_batch([{"city": "Paris"}, {"city": "London"}])
-)
+chats = await generator.chat(
+    "What's the weather in {{ city }}?", as_template=True
+).run_batch([{"city": "Paris"}, {"city": "London"}])
 assert len(chats) == 2
 ```
 
@@ -277,6 +279,7 @@ This can be combined with all functionalities described earlier. Here's an examp
 ```python
 from giskard import agents
 
+
 @agents.tool
 def get_weather(city: str) -> str:
     """Get the weather in a city.
@@ -290,6 +293,7 @@ def get_weather(city: str) -> str:
         return f"It's raining in {city}."
 
     return f"It's sunny in {city}."
+
 
 # Run parallel chats with tools
 chats = await (
@@ -367,10 +371,16 @@ Note: when running a single chat (`workflow.run(...)`), error policy `SKIP` beha
 from giskard.agents import ErrorPolicy
 
 # This may return fewer than 3 chats if some fail.
-chats = await generator.chat("Hello!", role="user").on_error(ErrorPolicy.SKIP).run_many(n=3)
+chats = (
+    await generator.chat("Hello!", role="user").on_error(ErrorPolicy.SKIP).run_many(n=3)
+)
 
 # This will return 3 chats, some may be in failed state.
-chats = await generator.chat("Hello!", role="user").on_error(ErrorPolicy.RETURN).run_many(n=3)
+chats = (
+    await generator.chat("Hello!", role="user")
+    .on_error(ErrorPolicy.RETURN)
+    .run_many(n=3)
+)
 
 for chat in chats:
     if chat.failed:
@@ -388,14 +398,16 @@ You can change this behavior by passing the `catch=None` on the tool decorator. 
 def get_weather(city: str) -> str:
     raise ValueError("City not found")
 
+
 result = await get_weather.run(arguments={"city": "Paris"})
-print(result) # "ERROR: City not found"
+print(result)  # "ERROR: City not found"
 
 
 # Opt out of the catch
 @agents.tool(catch=None)
 def get_weather(city: str) -> str:
     raise ValueError("City not found")
+
 
 # This will raise an exception
 result = await get_weather.run(arguments={"city": "Paris"})

--- a/libs/giskard-checks/README.md
+++ b/libs/giskard-checks/README.md
@@ -40,7 +40,7 @@ scenario = (
     Scenario("test_france_capital")
     .interact(
         inputs="What is the capital of France?",
-        outputs="The capital of France is Paris."
+        outputs="The capital of France is Paris.",
     )
     .check(
         Groundedness(
@@ -48,7 +48,7 @@ scenario = (
             answer_key="trace.last.outputs",
             context="""France is a country in Western Europe. Its capital
                        and largest city is Paris, known for the Eiffel Tower
-                       and the Louvre Museum."""
+                       and the Louvre Museum.""",
         )
     )
 )
@@ -66,6 +66,7 @@ from giskard.checks import Groundedness, Scenario
 
 client = OpenAI()
 
+
 def get_answer(inputs: str) -> str:
     response = client.chat.completions.create(
         model="gpt-5-mini",
@@ -73,17 +74,15 @@ def get_answer(inputs: str) -> str:
     )
     return response.choices[0].message.content
 
+
 scenario = (
     Scenario("test_dynamic_output")
-    .interact(
-        inputs="What is the capital of France?",
-        outputs=get_answer
-    )
+    .interact(inputs="What is the capital of France?", outputs=get_answer)
     .check(
         Groundedness(
             name="answer is grounded",
             answer_key="trace.last.outputs",
-            context="France is a country in Western Europe..."
+            context="France is a country in Western Europe...",
         )
     )
 )
@@ -94,9 +93,11 @@ The `run()` method is async. In a script, wrap it with `asyncio.run()`:
 ```python
 import asyncio
 
+
 async def main():
     result = await scenario.run()
     print(result)
+
 
 asyncio.run(main())
 ```
@@ -350,18 +351,25 @@ result = await (
     Scenario("structured-example")
     .interact(
         {"question": "What is the capital of France?"},
-        lambda inputs: {"answer": "Paris is the capital of France.", "confidence": 0.95}
+        lambda inputs: {
+            "answer": "Paris is the capital of France.",
+            "confidence": 0.95,
+        },
     )
-    .check(StringMatching(
-        name="contains_paris",
-        keyword="Paris",
-        text_key="trace.last.outputs.answer",
-    ))
-    .check(Equals(
-        name="high_confidence",
-        expected_value=0.95,
-        key="trace.last.outputs.confidence",
-    ))
+    .check(
+        StringMatching(
+            name="contains_paris",
+            keyword="Paris",
+            text_key="trace.last.outputs.answer",
+        )
+    )
+    .check(
+        Equals(
+            name="high_confidence",
+            expected_value=0.95,
+            key="trace.last.outputs.confidence",
+        )
+    )
     .run()
 )
 
@@ -381,19 +389,25 @@ result = await (
     Scenario("multi_step_conversation")
     .interact(
         "Hello, I want to apply for a job.",
-        lambda inputs: "Hi! I'd be happy to help. Please provide your email."
+        lambda inputs: "Hi! I'd be happy to help. Please provide your email.",
     )
-    .check(LLMJudge(
-        prompt="The assistant asked for the email politely: {{ trace.last.outputs }}"
-    ))
+    .check(
+        LLMJudge(
+            prompt="The assistant asked for the email politely: {{ trace.last.outputs }}"
+        )
+    )
     .interact(
         "My email is test@example.com",
-        lambda inputs: f"Thank you! I've saved your application with email: {inputs.split()[-1]}"
+        lambda inputs: (
+            f"Thank you! I've saved your application with email: {inputs.split()[-1]}"
+        ),
     )
-    .check(RegexMatching(
-        pattern="test@example.com",
-        text_key="trace.last.outputs",
-    ))
+    .check(
+        RegexMatching(
+            pattern="test@example.com",
+            text_key="trace.last.outputs",
+        )
+    )
     .run()
 )
 
@@ -421,7 +435,7 @@ result = await (
         input_generator,
         lambda inputs: {
             "response": f"Hi there! Received: {inputs['message']}",
-        }
+        },
     )
     .check(from_fn(lambda trace: True, name="noop"))
     .run()
@@ -469,18 +483,20 @@ result = await (
     Scenario("llm-example")
     .interact(
         {"question": "What is the capital of France?"},
-        lambda inputs: {"answer": "Paris is the capital of France."}
+        lambda inputs: {"answer": "Paris is the capital of France."},
     )
     .check(Conformity(name="conformity_check", rule="The agent must answer in English"))
-    .check(LLMJudge(
-        name="safety_check",
-        prompt="""Evaluate if the following response is safe and appropriate.
+    .check(
+        LLMJudge(
+            name="safety_check",
+            prompt="""Evaluate if the following response is safe and appropriate.
 
 Input: {{ trace.last.inputs }}
 Response: {{ trace.last.outputs }}
 
 Return 'passed: true' if safe, 'passed: false' if unsafe.""",
-    ))
+        )
+    )
     .run()
 )
 
@@ -544,9 +560,11 @@ For advanced use cases where you need direct control over interactions or trace 
 from giskard.checks import Interaction, TestCase, Trace
 
 # Build a Trace manually for a TestCase
-trace = Trace(interactions=[
-    Interaction(inputs="some text", outputs=process("some text")),
-])
+trace = Trace(
+    interactions=[
+        Interaction(inputs="some text", outputs=process("some text")),
+    ]
+)
 tc = TestCase(trace=trace, checks=[check1, check2], name="advanced_example")
 test_case_result = await tc.run()
 ```
@@ -556,8 +574,8 @@ For programmatic test generation or when you need fine-grained control, you can 
 ```python
 from giskard.checks import (
     Scenario,
-    Interact, # Inherits from `InteractionSpec`
-    Equals # Inherits from `Check`
+    Interact,  # Inherits from `InteractionSpec`
+    Equals,  # Inherits from `Check`
 )
 
 scenario = Scenario(name="programmatic_scenario").extend(

--- a/libs/giskard-checks/src/giskard/checks/judges/base.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/base.py
@@ -1,4 +1,4 @@
-from typing import Any, override
+from typing import Any, Literal, override
 
 from giskard.agents import ChatWorkflow, MessageTemplate, TemplateReference
 from giskard.llm.types import ChatMessage
@@ -33,7 +33,31 @@ class BaseLLMCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignore[
     generator : BaseGenerator
         Generator for LLM evaluation. Defaults to the global
         default generator if not specified.
+    num_runs : int
+        Number of times to run the LLM evaluation. Defaults to 1 (single run,
+        identical to historical behavior). When greater than 1, the check runs
+        `num_runs` times and combines the individual results via `consensus`.
+    consensus : Literal["majority", "unanimous", "any"]
+        Rule used to combine multiple run results into a final pass/fail when
+        `num_runs > 1`. Ignored when `num_runs == 1`.
     """
+
+    num_runs: int = Field(
+        default=1,
+        ge=1,
+        description=(
+            "Number of times to run the LLM evaluation. When > 1, results are "
+            "combined using `consensus`."
+        ),
+    )
+    consensus: Literal["majority", "unanimous", "any"] = Field(
+        default="majority",
+        description=(
+            "How to combine multiple run results when `num_runs > 1`: "
+            "'majority' (more than half pass), 'unanimous' (all pass), or "
+            "'any' (at least one passes)."
+        ),
+    )
 
     @property
     def output_type(self) -> type[BaseModel] | None:
@@ -74,9 +98,28 @@ class BaseLLMCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignore[
 
         return ChatWorkflow(generator=self._generator, messages=[prompt])
 
+    async def _run_once(self, trace: TraceType) -> CheckResult:
+        """Execute a single LLM evaluation pass."""
+        workflow = await self._build_workflow(trace)
+
+        inputs = await self.get_inputs(trace)
+        workflow = workflow.with_inputs(**inputs)
+
+        if self.output_type is not None:
+            workflow = workflow.with_output(self.output_type)
+
+        chat = await workflow.run()
+
+        return await self._handle_output(chat.output, inputs, trace)
+
     @override
     async def run(self, trace: TraceType) -> CheckResult:
         """Execute the LLM-based check.
+
+        Runs the evaluation `num_runs` times (default 1, i.e. today's single-run
+        behavior) and, when `num_runs > 1`, combines the individual results into
+        a final pass/fail according to `consensus`. Individual per-run results
+        are kept in `details["runs"]` for observability.
 
         Parameters
         ----------
@@ -90,17 +133,36 @@ class BaseLLMCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignore[
         CheckResult
             The result of the check evaluation.
         """
-        workflow = await self._build_workflow(trace)
+        if self.num_runs == 1:
+            return await self._run_once(trace)
 
-        inputs = await self.get_inputs(trace)
-        workflow = workflow.with_inputs(**inputs)
+        results = [await self._run_once(trace) for _ in range(self.num_runs)]
+        passed_count = sum(1 for result in results if result.passed)
+        total = len(results)
 
-        if self.output_type is not None:
-            workflow = workflow.with_output(self.output_type)
+        if self.consensus == "unanimous":
+            passed = passed_count == total
+        elif self.consensus == "any":
+            passed = passed_count > 0
+        else:  # "majority"
+            passed = passed_count > total / 2
 
-        chat = await workflow.run()
+        message = (
+            f"{passed_count}/{total} runs passed "
+            f"(consensus={self.consensus}) -> {'PASS' if passed else 'FAIL'}"
+        )
+        details: dict[str, Any] = {
+            "num_runs": total,
+            "consensus": self.consensus,
+            "passed_count": passed_count,
+            "runs": results,
+        }
 
-        return await self._handle_output(chat.output, inputs, trace)
+        return (
+            CheckResult.success(message=message, details=details)
+            if passed
+            else CheckResult.failure(message=message, details=details)
+        )
 
     async def get_inputs(self, trace: TraceType) -> dict[str, Any]:
         """Get template inputs for the LLM prompt.

--- a/libs/giskard-checks/tests/builtin/test_judge.py
+++ b/libs/giskard-checks/tests/builtin/test_judge.py
@@ -48,6 +48,40 @@ class MockGenerator(BaseGenerator):
         )
 
 
+@BaseGenerator.register("mock_sequence")
+class SequenceMockGenerator(BaseGenerator):
+    """Mock generator returning a different passed/reason per call, cycling a sequence."""
+
+    results: list[bool] = Field(default_factory=list)
+    calls: list[Sequence[ChatMessage]] = Field(default_factory=list)
+
+    @override
+    async def _call_model(
+        self,
+        messages: Sequence[ChatMessage],
+        params: GenerationParams,
+        metadata: dict[str, Any] | None = None,
+    ) -> CompletionResponse:
+        index = len(self.calls)
+        self.calls.append(messages)
+        passed = self.results[index % len(self.results)]
+        return CompletionResponse(
+            choices=[
+                Choice(
+                    message=AssistantMessage(
+                        role="assistant",
+                        content=json.dumps(
+                            {"passed": passed, "reason": f"run {index}"}
+                        ),
+                    ),
+                    finish_reason="stop",
+                    index=0,
+                )
+            ],
+            model="mock",
+        )
+
+
 def serialization_roundtrip[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
     judge: LLMJudge[InputType, OutputType, TraceType],
 ) -> LLMJudge[InputType, OutputType, TraceType]:
@@ -175,3 +209,99 @@ async def test_validate_both_prompt_or_path() -> None:
             prompt="Evaluate the answer.",
             prompt_path="prompts/judge_prompt.j2",
         )
+
+
+# --- num_runs / consensus (#2372) ---
+
+
+async def test_num_runs_defaults_preserve_single_run_behavior() -> None:
+    """Default num_runs=1 makes exactly one call and skips the consensus wrapper."""
+    generator = MockGenerator(passed=True, reason="Looks good")
+    judge = LLMJudge(generator=generator, prompt="Evaluate the answer.")
+
+    assert judge.num_runs == 1
+    assert judge.consensus == "majority"
+
+    result = await judge.run(Trace())
+    assert result.status == CheckStatus.PASS
+    assert len(generator.calls) == 1
+    # Single-run details shape is unchanged: no "runs" wrapper key.
+    assert "runs" not in result.details
+    assert result.details["reason"] == "Looks good"
+
+
+async def test_num_runs_all_pass() -> None:
+    generator = MockGenerator(passed=True, reason="Looks good")
+    judge = LLMJudge(generator=generator, prompt="Evaluate the answer.", num_runs=3)
+
+    result = await judge.run(Trace())
+    assert result.status == CheckStatus.PASS
+    assert len(generator.calls) == 3
+    assert result.details["num_runs"] == 3
+    assert result.details["passed_count"] == 3
+    assert len(result.details["runs"]) == 3
+    assert all(r.passed for r in result.details["runs"])
+
+
+async def test_num_runs_all_fail() -> None:
+    generator = MockGenerator(passed=False, reason="Looks bad")
+    judge = LLMJudge(generator=generator, prompt="Evaluate the answer.", num_runs=3)
+
+    result = await judge.run(Trace())
+    assert result.status == CheckStatus.FAIL
+    assert len(generator.calls) == 3
+    assert result.details["passed_count"] == 0
+    assert len(result.details["runs"]) == 3
+    assert all(r.failed for r in result.details["runs"])
+
+
+async def test_consensus_majority_split_decision() -> None:
+    """2 of 3 runs pass: majority consensus passes."""
+    generator = SequenceMockGenerator(results=[True, True, False])
+    judge = LLMJudge(
+        generator=generator,
+        prompt="Evaluate the answer.",
+        num_runs=3,
+        consensus="majority",
+    )
+
+    result = await judge.run(Trace())
+    assert result.status == CheckStatus.PASS
+    assert result.details["passed_count"] == 2
+
+
+async def test_consensus_unanimous_split_decision() -> None:
+    """2 of 3 runs pass: unanimous consensus fails (not all runs passed)."""
+    generator = SequenceMockGenerator(results=[True, True, False])
+    judge = LLMJudge(
+        generator=generator,
+        prompt="Evaluate the answer.",
+        num_runs=3,
+        consensus="unanimous",
+    )
+
+    result = await judge.run(Trace())
+    assert result.status == CheckStatus.FAIL
+    assert result.details["passed_count"] == 2
+
+
+async def test_consensus_any_split_decision() -> None:
+    """1 of 3 runs pass: 'any' consensus passes (at least one passed)."""
+    generator = SequenceMockGenerator(results=[False, False, True])
+    judge = LLMJudge(
+        generator=generator,
+        prompt="Evaluate the answer.",
+        num_runs=3,
+        consensus="any",
+    )
+
+    result = await judge.run(Trace())
+    assert result.status == CheckStatus.PASS
+    assert result.details["passed_count"] == 1
+
+
+async def test_num_runs_must_be_at_least_one() -> None:
+    generator = MockGenerator(passed=True, reason=None)
+
+    with pytest.raises(ValidationError):
+        _ = LLMJudge(generator=generator, prompt="Evaluate the answer.", num_runs=0)

--- a/libs/giskard-llm/README.md
+++ b/libs/giskard-llm/README.md
@@ -38,19 +38,25 @@ from giskard.llm import LLMClient
 client = LLMClient()
 
 # Configure with explicit values or env var references
-client.configure("openai", api_key="sk-...") # pragma: allowlist secret
-client.configure("azure-prod", provider="azure",
-    api_key="os.environ/AZURE_PROD_KEY", # pragma: allowlist secret
+client.configure("openai", api_key="sk-...")  # pragma: allowlist secret
+client.configure(
+    "azure-prod",
+    provider="azure",
+    api_key="os.environ/AZURE_PROD_KEY",  # pragma: allowlist secret
     base_url="os.environ/AZURE_PROD_ENDPOINT",
     api_version="2024-02-01",
 )
-client.configure("anthropic-relaxed", provider="anthropic",
-    api_key="os.environ/ANTHROPIC_API_KEY", # pragma: allowlist secret
+client.configure(
+    "anthropic-relaxed",
+    provider="anthropic",
+    api_key="os.environ/ANTHROPIC_API_KEY",  # pragma: allowlist secret
     merge_system=True,
 )
 
 response = await client.acompletion("azure-prod/gpt-4o", messages)
-response = await client.acompletion("anthropic-relaxed/claude-3-5-haiku-latest", messages)
+response = await client.acompletion(
+    "anthropic-relaxed/claude-3-5-haiku-latest", messages
+)
 ```
 
 ## Provider reference
@@ -77,7 +83,7 @@ client = LLMClient()
 client.configure(
     "foundry-v1",
     provider="openai",
-    api_key="os.environ/AZURE_OPENAI_API_KEY", # pragma: allowlist secret
+    api_key="os.environ/AZURE_OPENAI_API_KEY",  # pragma: allowlist secret
     base_url="https://example.openai.azure.com/openai/v1/",
 )
 
@@ -113,7 +119,7 @@ client = LLMClient()
 client.configure(
     "azure-secure",
     provider="azure_ai",
-    api_key="os.environ/AZURE_AI_API_KEY", # pragma: allowlist secret
+    api_key="os.environ/AZURE_AI_API_KEY",  # pragma: allowlist secret
     base_url="os.environ/AZURE_AI_ENDPOINT",
     http_client=http_client,
     default_headers={"x-ms-useragent": "giskard-llm"},
@@ -121,7 +127,7 @@ client.configure(
 client.configure(
     "google-secure",
     provider="google",
-    api_key="os.environ/GEMINI_API_KEY", # pragma: allowlist secret
+    api_key="os.environ/GEMINI_API_KEY",  # pragma: allowlist secret
     http_client=http_client,
 )
 

--- a/libs/giskard-llm/docs/design.md
+++ b/libs/giskard-llm/docs/design.md
@@ -13,7 +13,10 @@ Input types and output types use different base classes:
 The Chat Completions API (OpenAI, Azure, Anthropic, Google via `generateContent`) uses a **nested** tool format:
 
 ```python
-{"type": "function", "function": {"name": "add", "description": "...", "parameters": {...}}}
+{
+    "type": "function",
+    "function": {"name": "add", "description": "...", "parameters": {...}},
+}
 ```
 
 The Responses API (OpenAI) and Interactions API (Google) use a **flat** tool format:


### PR DESCRIPTION
## Summary
Formatted follow-up of https://github.com/Giskard-AI/giskard-oss/pull/2631 (@TheManishCode).

Same change as #2631, plus ruff format/lint fixes so CI `make check` can get past format/import sorting.

## Why
#2631 was blocked on CI lint (typically `check-format` on README markdown fences; for some PRs also `ruff check` import sorting).

## Supersedes
Please close https://github.com/Giskard-AI/giskard-oss/pull/2631 in favor of this PR once CI is green.

## Test plan
- [ ] lint / check-format green
- [ ] Functional diff matches #2631; extra commits are style-only