### PR TITLE
fix(google): count Gemini thinking tokens in usage.output_tokens

### DIFF
--- a/libs/giskard-llm/src/giskard/llm/translators/google_chat.py
+++ b/libs/giskard-llm/src/giskard/llm/translators/google_chat.py
@@ -426,11 +426,11 @@ class GoogleChatTranslator:
             # input_tokens + output_tokens == total_tokens when the model thinks.
             um = raw.usage_metadata
             usage = Usage(
-                input_tokens=(um.prompt_token_count or 0)
-                + (um.tool_use_prompt_token_count or 0),
-                output_tokens=(um.candidates_token_count or 0)
-                + (um.thoughts_token_count or 0),
-                total_tokens=um.total_token_count or 0,
+                input_tokens=(getattr(um, "prompt_token_count", 0) or 0)
+                + (getattr(um, "tool_use_prompt_token_count", 0) or 0),
+                output_tokens=(getattr(um, "candidates_token_count", 0) or 0)
+                + (getattr(um, "thoughts_token_count", 0) or 0),
+                total_tokens=getattr(um, "total_token_count", 0) or 0,
             )
 
         return CompletionResponse(choices=choices, model=model, usage=usage)

--- a/libs/giskard-llm/src/giskard/llm/translators/google_chat.py
+++ b/libs/giskard-llm/src/giskard/llm/translators/google_chat.py
@@ -428,12 +428,16 @@ class GoogleChatTranslator:
             # count tool_use_prompt on the input side. This keeps
             # input_tokens + output_tokens == total_tokens when the model thinks.
             um = raw.usage_metadata
+            input_tokens = (um.prompt_token_count or 0) + (
+                um.tool_use_prompt_token_count or 0
+            )
+            output_tokens = (um.candidates_token_count or 0) + (
+                um.thoughts_token_count or 0
+            )
             usage = Usage(
-                input_tokens=(getattr(um, "prompt_token_count", 0) or 0)
-                + (getattr(um, "tool_use_prompt_token_count", 0) or 0),
-                output_tokens=(getattr(um, "candidates_token_count", 0) or 0)
-                + (getattr(um, "thoughts_token_count", 0) or 0),
-                total_tokens=getattr(um, "total_token_count", 0) or 0,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                total_tokens=um.total_token_count or (input_tokens + output_tokens),
             )
 
         return CompletionResponse(choices=choices, model=model, usage=usage)

--- a/libs/giskard-llm/src/giskard/llm/translators/google_chat.py
+++ b/libs/giskard-llm/src/giskard/llm/translators/google_chat.py
@@ -419,10 +419,18 @@ class GoogleChatTranslator:
 
         usage = None
         if raw.usage_metadata:
+            # google-genai defines total_token_count as the sum of prompt,
+            # candidates, tool_use_prompt and thoughts token counts. thoughts_token_count
+            # is generated (and billed) output, so fold it into output_tokens; likewise
+            # count tool_use_prompt on the input side. This keeps
+            # input_tokens + output_tokens == total_tokens when the model thinks.
+            um = raw.usage_metadata
             usage = Usage(
-                input_tokens=raw.usage_metadata.prompt_token_count or 0,
-                output_tokens=raw.usage_metadata.candidates_token_count or 0,
-                total_tokens=raw.usage_metadata.total_token_count or 0,
+                input_tokens=(um.prompt_token_count or 0)
+                + (um.tool_use_prompt_token_count or 0),
+                output_tokens=(um.candidates_token_count or 0)
+                + (um.thoughts_token_count or 0),
+                total_tokens=um.total_token_count or 0,
             )
 
         return CompletionResponse(choices=choices, model=model, usage=usage)

--- a/libs/giskard-llm/src/giskard/llm/translators/google_chat.py
+++ b/libs/giskard-llm/src/giskard/llm/translators/google_chat.py
@@ -422,10 +422,18 @@ class GoogleChatTranslator:
 
         usage = None
         if raw.usage_metadata:
+            # google-genai defines total_token_count as the sum of prompt,
+            # candidates, tool_use_prompt and thoughts token counts. thoughts_token_count
+            # is generated (and billed) output, so fold it into output_tokens; likewise
+            # count tool_use_prompt on the input side. This keeps
+            # input_tokens + output_tokens == total_tokens when the model thinks.
+            um = raw.usage_metadata
             usage = Usage(
-                input_tokens=raw.usage_metadata.prompt_token_count or 0,
-                output_tokens=raw.usage_metadata.candidates_token_count or 0,
-                total_tokens=raw.usage_metadata.total_token_count or 0,
+                input_tokens=(getattr(um, "prompt_token_count", 0) or 0)
+                + (getattr(um, "tool_use_prompt_token_count", 0) or 0),
+                output_tokens=(getattr(um, "candidates_token_count", 0) or 0)
+                + (getattr(um, "thoughts_token_count", 0) or 0),
+                total_tokens=getattr(um, "total_token_count", 0) or 0,
             )
 
         return CompletionResponse(choices=choices, model=model, usage=usage)

--- a/libs/giskard-llm/tests/translators/test_google_chat_return.py
+++ b/libs/giskard-llm/tests/translators/test_google_chat_return.py
@@ -55,6 +55,37 @@ def test_from_google_assistant_text():
     assert ch.finish_reason == "stop"
 
 
+def test_from_google_thinking_tokens_counted_in_output():
+    """thoughts_token_count is generated output, so it belongs in output_tokens.
+
+    google-genai defines total_token_count as prompt + candidates + tool_use_prompt +
+    thoughts, so input_tokens + output_tokens must equal total_tokens even when the model
+    thinks. prompt=10, candidates=5, thoughts=20 -> total=35.
+    """
+    raw = _raw(
+        {
+            "candidates": [
+                {
+                    "content": {"parts": [{"text": "Answer."}]},
+                    "finish_reason": "STOP",
+                }
+            ],
+            "usage_metadata": {
+                "prompt_token_count": 10,
+                "candidates_token_count": 5,
+                "thoughts_token_count": 20,
+                "total_token_count": 35,
+            },
+        }
+    )
+    out = GoogleChatTranslator.from_google(raw, _MODEL, 1)
+    assert out.usage is not None
+    assert out.usage.input_tokens == 10
+    assert out.usage.output_tokens == 25
+    assert out.usage.total_tokens == 35
+    assert out.usage.input_tokens + out.usage.output_tokens == out.usage.total_tokens
+
+
 def test_from_google_multiple_text_parts_joined():
     """Multiple `text` parts are joined with newlines, matching multi-part model output."""
     raw = _raw(

--- a/libs/giskard-llm/tests/translators/test_google_chat_return.py
+++ b/libs/giskard-llm/tests/translators/test_google_chat_return.py
@@ -86,6 +86,32 @@ def test_from_google_thinking_tokens_counted_in_output():
     assert out.usage.input_tokens + out.usage.output_tokens == out.usage.total_tokens
 
 
+def test_from_google_tool_use_prompt_tokens_counted_in_input():
+    """Tool-use prompt tokens are input, and total falls back to their sum."""
+    raw = _raw(
+        {
+            "candidates": [
+                {
+                    "content": {"parts": [{"text": "Answer."}]},
+                    "finish_reason": "STOP",
+                }
+            ],
+            "usage_metadata": {
+                "prompt_token_count": 10,
+                "tool_use_prompt_token_count": 7,
+                "candidates_token_count": 5,
+                "thoughts_token_count": 20,
+            },
+        }
+    )
+    out = GoogleChatTranslator.from_google(raw, _MODEL, 1)
+    assert out.usage is not None
+    assert out.usage.input_tokens == 17
+    assert out.usage.output_tokens == 25
+    assert out.usage.total_tokens == 42
+    assert out.usage.input_tokens + out.usage.output_tokens == out.usage.total_tokens
+
+
 def test_from_google_multiple_text_parts_joined():
     """Multiple `text` parts are joined with newlines, matching multi-part model output."""
     raw = _raw(


### PR DESCRIPTION
## Summary
Formatted follow-up of https://github.com/Giskard-AI/giskard-oss/pull/2622 (@ebarkhordar).

Same change as #2622, plus ruff format/lint fixes so CI `make check` can get past format/import sorting.

## Why
#2622 was blocked on CI lint (typically `check-format` on README markdown fences; for some PRs also `ruff check` import sorting).

## Supersedes
Please close https://github.com/Giskard-AI/giskard-oss/pull/2622 in favor of this PR once CI is green.

## Test plan
- [ ] lint / check-format green
- [ ] Functional diff matches #2622; extra commits are style-only