### PR TITLE
chore(scan): export default registry generators on the public API

### DIFF
--- a/libs/giskard-scan/src/giskard/scan/__init__.py
+++ b/libs/giskard-scan/src/giskard/scan/__init__.py
@@ -9,6 +9,7 @@ from .catalog import generate_suite
 from .generators.adversarial import AdversarialScenarioGenerator
 from .generators.base import LocalDatasetScenarioGenerator, ScenarioGenerator
 from .generators.crescendo import CrescendoAttackScenarioGenerator
+from .generators.gcg import GCGInjectionScenarioGenerator
 from .generators.goat import GOATAttackScenarioGenerator
 from .generators.huggingface import HuggingFaceDatasetScenarioGenerator
 from .generators.knowledge_base import (
@@ -36,6 +37,7 @@ __all__ = [
     "LocalDatasetScenarioGenerator",
     "AdversarialScenarioGenerator",
     "CrescendoAttackScenarioGenerator",
+    "GCGInjectionScenarioGenerator",
     "GOATAttackScenarioGenerator",
     "HuggingFaceDatasetScenarioGenerator",
     "PromptInjectionScenarioGenerator",

--- a/libs/giskard-scan/src/giskard/scan/generators/__init__.py
+++ b/libs/giskard-scan/src/giskard/scan/generators/__init__.py
@@ -3,7 +3,9 @@
 from .adversarial import AdversarialScenarioGenerator
 from .base import LocalDatasetScenarioGenerator, ScenarioContext, ScenarioGenerator
 from .crescendo import CrescendoAttackScenarioGenerator
+from .gcg import GCGInjectionScenarioGenerator
 from .goat import GOATAttackScenarioGenerator
+from .huggingface import HuggingFaceDatasetScenarioGenerator
 from .knowledge_base import (
     HallucinationScenarioGenerator,
     KnowledgeBaseScenarioGenerator,
@@ -18,8 +20,10 @@ __all__ = [
     "AdversarialScenarioGenerator",
     "CrescendoAttackScenarioGenerator",
     "LocalDatasetScenarioGenerator",
+    "GCGInjectionScenarioGenerator",
     "GOATAttackScenarioGenerator",
     "HallucinationScenarioGenerator",
+    "HuggingFaceDatasetScenarioGenerator",
     "KnowledgeBaseScenarioGenerator",
     "MultiTopicScenarioGenerator",
     "OutOfScopeScenarioGenerator",

--- a/libs/giskard-scan/tests/test_public_api.py
+++ b/libs/giskard-scan/tests/test_public_api.py
@@ -1,3 +1,4 @@
+import giskard.scan as scan
 from giskard.scan import (
     AdversarialScenarioGenerator,
     CrescendoAttackScenarioGenerator,
@@ -18,6 +19,19 @@ from giskard.scan import (
     vulnerability_scan,
     vulnerability_suite_generator_registry,
 )
+
+
+def _registry_generator_types(registry: SuiteGeneratorRegistry) -> set[type]:
+    return {type(generator) for generator in registry.generators()}
+
+
+def test_default_registry_generators_are_public():
+    public_names = set(scan.__all__)
+    for generator_type in _registry_generator_types(
+        vulnerability_suite_generator_registry
+    ) | _registry_generator_types(quality_suite_generator_registry):
+        assert generator_type.__name__ in public_names
+        assert getattr(scan, generator_type.__name__) is generator_type
 
 
 def test_all_public_symbols_importable():

--- a/libs/giskard-scan/tests/test_public_api.py
+++ b/libs/giskard-scan/tests/test_public_api.py
@@ -1,4 +1,5 @@
 import giskard.scan as scan
+import giskard.scan.generators as generators
 from giskard.scan import (
     AdversarialScenarioGenerator,
     CrescendoAttackScenarioGenerator,
@@ -26,12 +27,14 @@ def _registry_generator_types(registry: SuiteGeneratorRegistry) -> set[type]:
 
 
 def test_default_registry_generators_are_public():
-    public_names = set(scan.__all__)
-    for generator_type in _registry_generator_types(
+    generator_types = _registry_generator_types(
         vulnerability_suite_generator_registry
-    ) | _registry_generator_types(quality_suite_generator_registry):
-        assert generator_type.__name__ in public_names
-        assert getattr(scan, generator_type.__name__) is generator_type
+    ) | _registry_generator_types(quality_suite_generator_registry)
+    for module in (scan, generators):
+        public_names = set(module.__all__)
+        for generator_type in generator_types:
+            assert generator_type.__name__ in public_names
+            assert getattr(module, generator_type.__name__) is generator_type
 
 
 def test_all_public_symbols_importable():


### PR DESCRIPTION
## Summary
- Re-export `GCGInjectionScenarioGenerator` from `giskard.scan` and `giskard.scan.generators` (it was already in the default vulnerability registry)
- Also export `HuggingFaceDatasetScenarioGenerator` from `giskard.scan.generators` for consistency
- Add `test_default_registry_generators_are_public` so new registry types must stay on the public API

Closes #2664

## Test plan
- [x] `make test-unit PACKAGE=giskard-scan` → 156 passed
- [x] `uv run basedpyright --level error libs/giskard-scan` → 0 errors
- [ ] Confirm `from giskard.scan import GCGInjectionScenarioGenerator` works in a clean env