### PR TITLE
feat(checks): aggregate LLM token usage on SuiteResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,14 @@ from giskard.checks import Scenario, Groundedness
 
 client = OpenAI()
 
+
 def get_answer(inputs: str) -> str:
     response = client.chat.completions.create(
         model="gpt-5-mini",
         messages=[{"role": "user", "content": inputs}],
     )
     return response.choices[0].message.content
+
 
 scenario = (
     Scenario("test_dynamic_output")
@@ -121,12 +123,14 @@ Use Giskard Scan to:
 import asyncio
 from giskard.scan import vulnerability_scan
 
+
 async def main():
     await vulnerability_scan(
         target=my_agent,
         description="A customer support chatbot for an e-commerce platform.",
         languages=["en"],
     )
+
 
 asyncio.run(main())
 ```
@@ -147,10 +151,12 @@ Wrap your model and run the scan:
 import giskard
 import pandas as pd
 
+
 # Replace my_llm_chain with your actual LLM chain or model inference logic
 def model_predict(df: pd.DataFrame):
     """The function takes a DataFrame and must return a list of outputs (one per row)."""
     return [my_llm_chain.run({"query": question}) for question in df["question"]]
+
 
 giskard_model = giskard.Model(
     model=model_predict,
@@ -183,7 +189,7 @@ knowledge_base = KnowledgeBase.from_pandas(df, columns=["column_1", "column_2"])
 testset = generate_testset(
     knowledge_base,
     num_questions=60,
-    language='en',
+    language="en",
     agent_description="A customer support chatbot for company X",
 )
 ```

--- a/libs/giskard-agents/README.md
+++ b/libs/giskard-agents/README.md
@@ -63,8 +63,7 @@ Or add multiple messages to the workflow:
 ```python
 # The chat message role is "user" by default.
 chat = await (
-    generator
-    .chat("You are a helpful assistant.", role="system")
+    generator.chat("You are a helpful assistant.", role="system")
     .chat("Hello, how are you?")
     .chat("I'm fine, thank you!", role="assistant")
     .chat("What's your name?")
@@ -92,7 +91,9 @@ generator = agents.Generator(
 Or use the convenience method:
 
 ```python
-generator = agents.Generator(model="openai/gpt-4o-mini").with_retries(5, base_delay=2.0, max_delay=30.0)
+generator = agents.Generator(model="openai/gpt-4o-mini").with_retries(
+    5, base_delay=2.0, max_delay=30.0
+)
 ```
 
 ### Rate limiting
@@ -109,7 +110,9 @@ generator = agents.Generator(
 Or use the convenience method:
 
 ```python
-generator = generator.with_rate_limiter(MinIntervalRateLimiter.from_rpm(60, max_concurrent=5))
+generator = generator.with_rate_limiter(
+    MinIntervalRateLimiter.from_rpm(60, max_concurrent=5)
+)
 ```
 
 ## Custom middleware
@@ -124,6 +127,7 @@ from giskard.agents.generators import GenerationParams
 from giskard.agents.generators.middleware import CompletionMiddleware, NextFn
 from giskard.llm.types import ChatMessage, CompletionResponse
 
+
 @CompletionMiddleware.register("logging")
 class LoggingMiddleware(CompletionMiddleware):
     async def call(
@@ -137,6 +141,7 @@ class LoggingMiddleware(CompletionMiddleware):
         response = await next_fn(messages, params, metadata)
         logging.info(f"Got response: {response.choices[0].finish_reason}")
         return response
+
 
 generator = agents.Generator(
     model="openai/gpt-4o-mini",
@@ -154,15 +159,13 @@ each completion call:
 ```python
 from pydantic import BaseModel
 
+
 class SimpleOutput(BaseModel):
     mood: str
     greeting: str
 
-chat = await (
-    generator.chat("Hello!")
-    .with_output(SimpleOutput)
-    .run()
-)
+
+chat = await generator.chat("Hello!").with_output(SimpleOutput).run()
 
 assert isinstance(chat.output, SimpleOutput)
 assert chat.output.mood == "happy"
@@ -179,9 +182,7 @@ Here's an example:
 ```python
 # This will run a chat with the message "Hello Test Bot, how are you?"
 chat = await (
-    generator.chat(
-        "Hello {{ name_of_the_bot }}, how are you?", as_template=True
-    )
+    generator.chat("Hello {{ name_of_the_bot }}, how are you?", as_template=True)
     .with_inputs(name_of_the_bot="Test Bot")
     .run()
 )
@@ -246,7 +247,9 @@ You can then load the template as usual:
 ```python
 chat = await (
     generator.template("evaluators.scientific_theory")
-    .with_inputs(theory="Normandy is actually the center of the universe because its perfect balance of rain, cheese, and cider creates a quantum field that bends space-time, making it the most harmonious place on Earth.")
+    .with_inputs(
+        theory="Normandy is actually the center of the universe because its perfect balance of rain, cheese, and cider creates a quantum field that bends space-time, making it the most harmonious place on Earth."
+    )
     .run()
 )
 
@@ -259,10 +262,9 @@ assert score == 5
 You can run multiple chats with different inputs by passing a list of inputs to the `run_batch` method.
 
 ```python
-chats = await (
-    generator.chat("What's the weather in {{ city }}?", as_template=True)
-    .run_batch([{"city": "Paris"}, {"city": "London"}])
-)
+chats = await generator.chat(
+    "What's the weather in {{ city }}?", as_template=True
+).run_batch([{"city": "Paris"}, {"city": "London"}])
 assert len(chats) == 2
 ```
 
@@ -277,6 +279,7 @@ This can be combined with all functionalities described earlier. Here's an examp
 ```python
 from giskard import agents
 
+
 @agents.tool
 def get_weather(city: str) -> str:
     """Get the weather in a city.
@@ -290,6 +293,7 @@ def get_weather(city: str) -> str:
         return f"It's raining in {city}."
 
     return f"It's sunny in {city}."
+
 
 # Run parallel chats with tools
 chats = await (
@@ -367,10 +371,16 @@ Note: when running a single chat (`workflow.run(...)`), error policy `SKIP` beha
 from giskard.agents import ErrorPolicy
 
 # This may return fewer than 3 chats if some fail.
-chats = await generator.chat("Hello!", role="user").on_error(ErrorPolicy.SKIP).run_many(n=3)
+chats = (
+    await generator.chat("Hello!", role="user").on_error(ErrorPolicy.SKIP).run_many(n=3)
+)
 
 # This will return 3 chats, some may be in failed state.
-chats = await generator.chat("Hello!", role="user").on_error(ErrorPolicy.RETURN).run_many(n=3)
+chats = (
+    await generator.chat("Hello!", role="user")
+    .on_error(ErrorPolicy.RETURN)
+    .run_many(n=3)
+)
 
 for chat in chats:
     if chat.failed:
@@ -388,14 +398,16 @@ You can change this behavior by passing the `catch=None` on the tool decorator. 
 def get_weather(city: str) -> str:
     raise ValueError("City not found")
 
+
 result = await get_weather.run(arguments={"city": "Paris"})
-print(result) # "ERROR: City not found"
+print(result)  # "ERROR: City not found"
 
 
 # Opt out of the catch
 @agents.tool(catch=None)
 def get_weather(city: str) -> str:
     raise ValueError("City not found")
+
 
 # This will raise an exception
 result = await get_weather.run(arguments={"city": "Paris"})

--- a/libs/giskard-checks/README.md
+++ b/libs/giskard-checks/README.md
@@ -40,7 +40,7 @@ scenario = (
     Scenario("test_france_capital")
     .interact(
         inputs="What is the capital of France?",
-        outputs="The capital of France is Paris."
+        outputs="The capital of France is Paris.",
     )
     .check(
         Groundedness(
@@ -48,7 +48,7 @@ scenario = (
             answer_key="trace.last.outputs",
             context="""France is a country in Western Europe. Its capital
                        and largest city is Paris, known for the Eiffel Tower
-                       and the Louvre Museum."""
+                       and the Louvre Museum.""",
         )
     )
 )
@@ -66,6 +66,7 @@ from giskard.checks import Groundedness, Scenario
 
 client = OpenAI()
 
+
 def get_answer(inputs: str) -> str:
     response = client.chat.completions.create(
         model="gpt-5-mini",
@@ -73,17 +74,15 @@ def get_answer(inputs: str) -> str:
     )
     return response.choices[0].message.content
 
+
 scenario = (
     Scenario("test_dynamic_output")
-    .interact(
-        inputs="What is the capital of France?",
-        outputs=get_answer
-    )
+    .interact(inputs="What is the capital of France?", outputs=get_answer)
     .check(
         Groundedness(
             name="answer is grounded",
             answer_key="trace.last.outputs",
-            context="France is a country in Western Europe..."
+            context="France is a country in Western Europe...",
         )
     )
 )
@@ -94,9 +93,11 @@ The `run()` method is async. In a script, wrap it with `asyncio.run()`:
 ```python
 import asyncio
 
+
 async def main():
     result = await scenario.run()
     print(result)
+
 
 asyncio.run(main())
 ```
@@ -350,18 +351,25 @@ result = await (
     Scenario("structured-example")
     .interact(
         {"question": "What is the capital of France?"},
-        lambda inputs: {"answer": "Paris is the capital of France.", "confidence": 0.95}
+        lambda inputs: {
+            "answer": "Paris is the capital of France.",
+            "confidence": 0.95,
+        },
     )
-    .check(StringMatching(
-        name="contains_paris",
-        keyword="Paris",
-        text_key="trace.last.outputs.answer",
-    ))
-    .check(Equals(
-        name="high_confidence",
-        expected_value=0.95,
-        key="trace.last.outputs.confidence",
-    ))
+    .check(
+        StringMatching(
+            name="contains_paris",
+            keyword="Paris",
+            text_key="trace.last.outputs.answer",
+        )
+    )
+    .check(
+        Equals(
+            name="high_confidence",
+            expected_value=0.95,
+            key="trace.last.outputs.confidence",
+        )
+    )
     .run()
 )
 
@@ -381,19 +389,25 @@ result = await (
     Scenario("multi_step_conversation")
     .interact(
         "Hello, I want to apply for a job.",
-        lambda inputs: "Hi! I'd be happy to help. Please provide your email."
+        lambda inputs: "Hi! I'd be happy to help. Please provide your email.",
     )
-    .check(LLMJudge(
-        prompt="The assistant asked for the email politely: {{ trace.last.outputs }}"
-    ))
+    .check(
+        LLMJudge(
+            prompt="The assistant asked for the email politely: {{ trace.last.outputs }}"
+        )
+    )
     .interact(
         "My email is test@example.com",
-        lambda inputs: f"Thank you! I've saved your application with email: {inputs.split()[-1]}"
+        lambda inputs: (
+            f"Thank you! I've saved your application with email: {inputs.split()[-1]}"
+        ),
     )
-    .check(RegexMatching(
-        pattern="test@example.com",
-        text_key="trace.last.outputs",
-    ))
+    .check(
+        RegexMatching(
+            pattern="test@example.com",
+            text_key="trace.last.outputs",
+        )
+    )
     .run()
 )
 
@@ -421,7 +435,7 @@ result = await (
         input_generator,
         lambda inputs: {
             "response": f"Hi there! Received: {inputs['message']}",
-        }
+        },
     )
     .check(from_fn(lambda trace: True, name="noop"))
     .run()
@@ -469,18 +483,20 @@ result = await (
     Scenario("llm-example")
     .interact(
         {"question": "What is the capital of France?"},
-        lambda inputs: {"answer": "Paris is the capital of France."}
+        lambda inputs: {"answer": "Paris is the capital of France."},
     )
     .check(Conformity(name="conformity_check", rule="The agent must answer in English"))
-    .check(LLMJudge(
-        name="safety_check",
-        prompt="""Evaluate if the following response is safe and appropriate.
+    .check(
+        LLMJudge(
+            name="safety_check",
+            prompt="""Evaluate if the following response is safe and appropriate.
 
 Input: {{ trace.last.inputs }}
 Response: {{ trace.last.outputs }}
 
 Return 'passed: true' if safe, 'passed: false' if unsafe.""",
-    ))
+        )
+    )
     .run()
 )
 
@@ -544,9 +560,11 @@ For advanced use cases where you need direct control over interactions or trace 
 from giskard.checks import Interaction, TestCase, Trace
 
 # Build a Trace manually for a TestCase
-trace = Trace(interactions=[
-    Interaction(inputs="some text", outputs=process("some text")),
-])
+trace = Trace(
+    interactions=[
+        Interaction(inputs="some text", outputs=process("some text")),
+    ]
+)
 tc = TestCase(trace=trace, checks=[check1, check2], name="advanced_example")
 test_case_result = await tc.run()
 ```
@@ -556,8 +574,8 @@ For programmatic test generation or when you need fine-grained control, you can 
 ```python
 from giskard.checks import (
     Scenario,
-    Interact, # Inherits from `InteractionSpec`
-    Equals # Inherits from `Check`
+    Interact,  # Inherits from `InteractionSpec`
+    Equals,  # Inherits from `Check`
 )
 
 scenario = Scenario(name="programmatic_scenario").extend(

--- a/libs/giskard-checks/src/giskard/checks/core/mixin.py
+++ b/libs/giskard-checks/src/giskard/checks/core/mixin.py
@@ -2,6 +2,7 @@ from giskard.agents import BaseEmbeddingModel, BaseGenerator
 from pydantic import BaseModel, Field
 
 from ..settings import get_default_embedding_model, get_default_generator
+from .suite_usage import get_active_suite_usage_collector, with_usage_recording
 
 
 class WithGeneratorMixin(BaseModel):
@@ -13,7 +14,12 @@ class WithGeneratorMixin(BaseModel):
     @property
     def _generator(self) -> BaseGenerator:
         """Get the generator. If not set, return the global default generator."""
-        return self.generator if self.generator is not None else get_default_generator()
+        generator = (
+            self.generator if self.generator is not None else get_default_generator()
+        )
+        if get_active_suite_usage_collector() is None:
+            return generator
+        return with_usage_recording(generator)
 
 
 class WithEmbeddingMixin(BaseModel):

--- a/libs/giskard-checks/src/giskard/checks/core/result.py
+++ b/libs/giskard-checks/src/giskard/checks/core/result.py
@@ -18,6 +18,7 @@ from rich.text import Text
 from ..settings import get_settings
 from .interaction import Trace
 from .protocols import RichConsoleProtocol, RichProtocol
+from .suite_usage import SuiteUsage
 
 STATUS_MAPPING = {
     "total": {
@@ -585,12 +586,18 @@ class SuiteResult(BaseResult, frozen=True):
         Number of scenarios that were skipped.
     pass_rate : float
         Fraction of non-skipped scenarios that passed (1.0 when all scenarios are skipped).
+    usage : SuiteUsage
+        Aggregated LLM token usage for the suite run (zeros when no LLM steps ran).
     """
 
     results: list[ScenarioResult[Any]] = Field(
         ..., description="List of scenario results"
     )
     duration_ms: int = Field(..., description="Total execution time in milliseconds")
+    usage: SuiteUsage = Field(
+        default_factory=SuiteUsage,
+        description="Aggregated LLM token usage for the suite run.",
+    )
     suite: "Suite[Any, Any] | None" = Field(
         default=None, exclude=True, description="The Suite that produced this result"
     )
@@ -779,6 +786,14 @@ def _suite_report_renderables(
     )
     summary = ", ".join(count_parts)
     yield f"Summary: {summary} | Pass Rate: [default bold]{result.pass_rate:.1%}[/default bold] | Total Duration: {result.duration_ms}ms"
+    if result.usage.total_tokens > 0:
+        usage = result.usage
+        yield (
+            "tokens: "
+            f"in={usage.prompt_tokens}  "
+            f"out={usage.completion_tokens}  "
+            f"total={usage.total_tokens}"
+        )
 
 
 def _parse_tag(tag: str) -> tuple[str, str]:

--- a/libs/giskard-checks/src/giskard/checks/core/suite_usage.py
+++ b/libs/giskard-checks/src/giskard/checks/core/suite_usage.py
@@ -1,0 +1,108 @@
+"""Suite-level LLM token usage aggregation."""
+
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, override
+
+from giskard.agents import BaseGenerator
+from giskard.llm.types import ChatMessage, CompletionResponse, Usage
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SuiteUsage(BaseModel, frozen=True):
+    """Aggregated LLM token usage for a suite run."""
+
+    prompt_tokens: int = Field(default=0, ge=0)
+    completion_tokens: int = Field(default=0, ge=0)
+    total_tokens: int = Field(default=0, ge=0)
+
+    @classmethod
+    def from_llm_usage(cls, usage: Usage | None) -> "SuiteUsage":
+        """Build a usage snapshot from a single ``giskard.llm`` ``Usage`` record."""
+        if usage is None:
+            return cls()
+        prompt_tokens = usage.input_tokens
+        completion_tokens = usage.output_tokens
+        total_tokens = usage.total_tokens or (prompt_tokens + completion_tokens)
+        return cls(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+        )
+
+    def __add__(self, other: "SuiteUsage") -> "SuiteUsage":
+        return SuiteUsage(
+            prompt_tokens=self.prompt_tokens + other.prompt_tokens,
+            completion_tokens=self.completion_tokens + other.completion_tokens,
+            total_tokens=self.total_tokens + other.total_tokens,
+        )
+
+
+class _SuiteUsageCollector:
+    """Mutable accumulator for the active suite run."""
+
+    def __init__(self) -> None:
+        self._usage: SuiteUsage = SuiteUsage()
+
+    def record(self, usage: Usage | None) -> None:
+        if usage is None:
+            return
+        self._usage = self._usage + SuiteUsage.from_llm_usage(usage)
+
+    def snapshot(self) -> SuiteUsage:
+        return self._usage
+
+
+_active_collector: ContextVar[_SuiteUsageCollector | None] = ContextVar(
+    "_active_collector", default=None
+)
+
+
+def get_active_suite_usage_collector() -> _SuiteUsageCollector | None:
+    """Return the collector for the current suite run, if any."""
+    return _active_collector.get()
+
+
+def record_completion_usage(usage: Usage | None) -> None:
+    """Add one completion's usage to the active suite collector."""
+    collector = _active_collector.get()
+    if collector is not None:
+        collector.record(usage)
+
+
+@contextmanager
+def suite_usage_collector() -> Iterator[_SuiteUsageCollector]:
+    """Activate suite usage collection for the current async context."""
+    collector = _SuiteUsageCollector()
+    token = _active_collector.set(collector)
+    try:
+        yield collector
+    finally:
+        _active_collector.reset(token)
+
+
+class _UsageRecordingGenerator(BaseGenerator):
+    """Wraps a generator and forwards completion usage to the suite collector."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    wrapped: BaseGenerator
+
+    @override
+    async def _call_model(
+        self,
+        messages: Sequence[ChatMessage],
+        params: Any,
+        metadata: dict[str, Any] | None = None,
+    ) -> CompletionResponse:
+        response = await self.wrapped.complete(messages, params, metadata)
+        record_completion_usage(response.usage)
+        return response
+
+
+def with_usage_recording(generator: BaseGenerator) -> BaseGenerator:
+    """Return ``generator`` wrapped to record completion usage when a collector is active."""
+    if isinstance(generator, _UsageRecordingGenerator):
+        return generator
+    return _UsageRecordingGenerator(wrapped=generator)

--- a/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
@@ -31,6 +31,7 @@ from ..core.result import (
     format_status_count_text,
 )
 from ..core.scenario import Scenario
+from ..core.suite_usage import suite_usage_collector
 from ..core.types import Target
 
 InputType = TypeVar("InputType", infer_variance=True)
@@ -134,7 +135,7 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
     scenarios: list[Scenario[InputType, OutputType, Trace[Any, Any]]] = Field(
         default_factory=list, description="Scenarios in the suite"
     )
-    target: Target[InputType, OutputType, Trace[Any, Any]] | MISSING = Field(
+    target: Target[InputType, OutputType, Trace[Any, Any]] | MISSING = Field(  # pyright: ignore[reportInvalidTypeForm]
         default=MISSING,
         description="Suite-level target SUT that will override any scenario-level target.",
     )
@@ -160,7 +161,7 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
 
     async def run(
         self,
-        target: Target[InputType, OutputType, Trace[Any, Any]] | MISSING = (MISSING),
+        target: Target[InputType, OutputType, Trace[Any, Any]] | MISSING = (MISSING),  # pyright: ignore[reportInvalidTypeForm]
         return_exception: bool = False,
         parallel: bool = False,
         max_concurrency: int | None = None,
@@ -227,20 +228,24 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
             )
 
             start_time = time.perf_counter()
-            with self._progress_bar(enabled=verbose) as tracker:
-                if parallel:
-                    results = await self._run_parallel(
-                        target, return_exception, max_concurrency, tracker
-                    )
-                else:
-                    results = await self._run_serial(target, return_exception, tracker)
-            end_time = time.perf_counter()
+            with suite_usage_collector() as usage_collector:
+                with self._progress_bar(enabled=verbose) as tracker:
+                    if parallel:
+                        results = await self._run_parallel(
+                            target, return_exception, max_concurrency, tracker
+                        )
+                    else:
+                        results = await self._run_serial(
+                            target, return_exception, tracker
+                        )
+                end_time = time.perf_counter()
 
-            suite_result = SuiteResult(
-                results=results,
-                duration_ms=int((end_time - start_time) * 1000),
-                suite=self,
-            )
+                suite_result = SuiteResult(
+                    results=results,
+                    duration_ms=int((end_time - start_time) * 1000),
+                    suite=self,
+                    usage=usage_collector.snapshot(),
+                )
 
             telemetry_capture(
                 "checks_suite_run_finished",

--- a/libs/giskard-checks/tests/core/test_suite_usage.py
+++ b/libs/giskard-checks/tests/core/test_suite_usage.py
@@ -1,0 +1,120 @@
+import json
+from collections.abc import Sequence
+from typing import Any, override
+
+import pytest
+from giskard.agents.generators.base import BaseGenerator, GenerationParams
+from giskard.checks import Equals, LLMJudge, Scenario, Suite
+from giskard.checks.core.result import SuiteResult
+from giskard.checks.core.suite_usage import SuiteUsage
+from giskard.llm.types import (
+    AssistantMessage,
+    ChatMessage,
+    Choice,
+    CompletionResponse,
+    Usage,
+)
+from rich.console import Console
+
+
+class UsageRecordingGenerator(BaseGenerator):
+    """Mock generator that returns fixed usage on every completion."""
+
+    prompt_tokens: int = 100
+    completion_tokens: int = 40
+    calls: int = 0
+
+    @override
+    async def _call_model(
+        self,
+        messages: Sequence[ChatMessage],
+        params: GenerationParams,
+        metadata: dict[str, Any] | None = None,
+    ) -> CompletionResponse:
+        _ = messages, params, metadata
+        self.calls += 1
+        return CompletionResponse(
+            choices=[
+                Choice(
+                    message=AssistantMessage(
+                        content=json.dumps({"passed": True, "reason": "ok"})
+                    ),
+                    finish_reason="stop",
+                    index=0,
+                )
+            ],
+            usage=Usage(
+                input_tokens=self.prompt_tokens,
+                output_tokens=self.completion_tokens,
+                total_tokens=self.prompt_tokens + self.completion_tokens,
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_suite_aggregates_llm_token_usage():
+    generator = UsageRecordingGenerator()
+    judge = LLMJudge(
+        name="usage_judge",
+        generator=generator,
+        prompt="Did the assistant respond appropriately?",
+    )
+    suite = Suite(name="usage_suite")
+    suite.append(
+        Scenario("llm_scenario").interact(inputs="hello", outputs="hello").check(judge)
+    )
+    suite.append(
+        Scenario("string_scenario")
+        .interact(inputs="world", outputs="world")
+        .check(Equals(expected_value="world", key="trace.last.outputs"))
+    )
+
+    result = await suite.run(verbose=False)
+
+    assert result.usage == SuiteUsage(
+        prompt_tokens=100,
+        completion_tokens=40,
+        total_tokens=140,
+    )
+    assert generator.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_non_llm_suite_usage_stays_zero():
+    suite = Suite(name="plain_suite")
+    suite.append(
+        Scenario("equals_only")
+        .interact(inputs="ping", outputs="ping")
+        .check(Equals(expected_value="ping", key="trace.last.outputs"))
+    )
+
+    result = await suite.run(verbose=False)
+
+    assert result.usage == SuiteUsage()
+    assert result.usage.total_tokens == 0
+
+
+def test_print_report_omits_usage_footer_when_zero():
+    result = SuiteResult(results=[], duration_ms=0)
+    console = Console(width=120, record=True)
+    result.print_report(console=console)
+    output = console.export_text()
+
+    assert "tokens:" not in output
+
+
+def test_print_report_includes_usage_footer_when_nonzero():
+    result = SuiteResult(
+        results=[],
+        duration_ms=0,
+        usage=SuiteUsage(
+            prompt_tokens=128_400,
+            completion_tokens=39_200,
+            total_tokens=167_600,
+        ),
+    )
+    console = Console(width=120, record=True)
+    result.print_report(console=console)
+    output = console.export_text()
+
+    assert "tokens: in=128400  out=39200  total=167600" in output

--- a/libs/giskard-llm/README.md
+++ b/libs/giskard-llm/README.md
@@ -38,19 +38,25 @@ from giskard.llm import LLMClient
 client = LLMClient()
 
 # Configure with explicit values or env var references
-client.configure("openai", api_key="sk-...") # pragma: allowlist secret
-client.configure("azure-prod", provider="azure",
-    api_key="os.environ/AZURE_PROD_KEY", # pragma: allowlist secret
+client.configure("openai", api_key="sk-...")  # pragma: allowlist secret
+client.configure(
+    "azure-prod",
+    provider="azure",
+    api_key="os.environ/AZURE_PROD_KEY",  # pragma: allowlist secret
     base_url="os.environ/AZURE_PROD_ENDPOINT",
     api_version="2024-02-01",
 )
-client.configure("anthropic-relaxed", provider="anthropic",
-    api_key="os.environ/ANTHROPIC_API_KEY", # pragma: allowlist secret
+client.configure(
+    "anthropic-relaxed",
+    provider="anthropic",
+    api_key="os.environ/ANTHROPIC_API_KEY",  # pragma: allowlist secret
     merge_system=True,
 )
 
 response = await client.acompletion("azure-prod/gpt-4o", messages)
-response = await client.acompletion("anthropic-relaxed/claude-3-5-haiku-latest", messages)
+response = await client.acompletion(
+    "anthropic-relaxed/claude-3-5-haiku-latest", messages
+)
 ```
 
 ## Provider reference
@@ -77,7 +83,7 @@ client = LLMClient()
 client.configure(
     "foundry-v1",
     provider="openai",
-    api_key="os.environ/AZURE_OPENAI_API_KEY", # pragma: allowlist secret
+    api_key="os.environ/AZURE_OPENAI_API_KEY",  # pragma: allowlist secret
     base_url="https://example.openai.azure.com/openai/v1/",
 )
 
@@ -113,7 +119,7 @@ client = LLMClient()
 client.configure(
     "azure-secure",
     provider="azure_ai",
-    api_key="os.environ/AZURE_AI_API_KEY", # pragma: allowlist secret
+    api_key="os.environ/AZURE_AI_API_KEY",  # pragma: allowlist secret
     base_url="os.environ/AZURE_AI_ENDPOINT",
     http_client=http_client,
     default_headers={"x-ms-useragent": "giskard-llm"},
@@ -121,7 +127,7 @@ client.configure(
 client.configure(
     "google-secure",
     provider="google",
-    api_key="os.environ/GEMINI_API_KEY", # pragma: allowlist secret
+    api_key="os.environ/GEMINI_API_KEY",  # pragma: allowlist secret
     http_client=http_client,
 )
 

--- a/libs/giskard-llm/docs/design.md
+++ b/libs/giskard-llm/docs/design.md
@@ -13,7 +13,10 @@ Input types and output types use different base classes:
 The Chat Completions API (OpenAI, Azure, Anthropic, Google via `generateContent`) uses a **nested** tool format:
 
 ```python
-{"type": "function", "function": {"name": "add", "description": "...", "parameters": {...}}}
+{
+    "type": "function",
+    "function": {"name": "add", "description": "...", "parameters": {...}},
+}
 ```
 
 The Responses API (OpenAI) and Interactions API (Google) use a **flat** tool format:

--- a/libs/giskard-scan/src/giskard/scan/catalog.py
+++ b/libs/giskard-scan/src/giskard/scan/catalog.py
@@ -1,13 +1,140 @@
+import logging
+import sys
 from asyncio import TaskGroup
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager, nullcontext
 from typing import Any
 
 import numpy as np
 from giskard.checks import Scenario, Suite, Trace
+from rich.console import Console
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    SpinnerColumn,
+    TaskID,
+    TextColumn,
+)
 
 from .generators.base import ScenarioContext, ScenarioGenerator, TargetMode
 from .registry import _normalize_generator
 from .utils.knowledge_base import KnowledgeBase, normalize_knowledge_base
+
+logger = logging.getLogger(__name__)
+
+
+def _generator_name(generator: ScenarioGenerator) -> str:
+    return type(generator).__name__
+
+
+class _GenerationProgressReporter:
+    """Callbacks for generation progress updates."""
+
+    def __init__(
+        self,
+        generator_count: int,
+        max_scenarios: int | None,
+        use_logs: bool,
+    ) -> None:
+        self._generator_count = generator_count
+        self._max_scenarios = max_scenarios
+        self._use_logs = use_logs
+        self._completed = 0
+        self._scenario_count = 0
+        self._progress: Progress | None = None
+        self._task_id: TaskID | None = None
+
+    def start_rich(self, progress: Progress, task_id: TaskID) -> None:
+        self._progress = progress
+        self._task_id = task_id
+
+    def start_logs(self) -> None:
+        logger.info(
+            "generate_suite: start generators=%d max_scenarios=%s",
+            self._generator_count,
+            self._max_scenarios,
+        )
+
+    def on_generator_done(self, generator_name: str, scenario_count: int) -> None:
+        self._completed += 1
+        self._scenario_count += scenario_count
+        if self._progress is not None and self._task_id is not None:
+            self._progress.update(
+                self._task_id,
+                advance=1,
+                description=(
+                    f"Generating suite [{self._completed}/{self._generator_count}] "
+                    f"{generator_name}"
+                ),
+            )
+        elif self._use_logs:
+            logger.info(
+                "generate_suite: done generator=%s scenarios=%d",
+                generator_name,
+                scenario_count,
+            )
+
+    def finish(self, use_rich: bool) -> None:
+        if self._use_logs:
+            logger.info(
+                "generate_suite: finished total_scenarios=%d",
+                self._scenario_count,
+            )
+        if use_rich and self._generator_count > 0:
+            Console(stderr=True).print(f"Generated {self._scenario_count} scenarios.")
+
+
+@contextmanager
+def _generation_progress(
+    generator_count: int,
+    max_scenarios: int | None,
+    verbose: bool,
+) -> Iterator[_GenerationProgressReporter]:
+    use_rich = verbose and sys.stderr.isatty()
+    use_logs = verbose and not sys.stderr.isatty()
+    reporter = _GenerationProgressReporter(generator_count, max_scenarios, use_logs)
+
+    if use_rich and generator_count > 0:
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            console=Console(stderr=True),
+        ) as progress:
+            task_id = progress.add_task("Generating suite", total=generator_count)
+            reporter.start_rich(progress, task_id)
+            try:
+                yield reporter
+            finally:
+                reporter.finish(use_rich=True)
+    else:
+        if use_logs:
+            reporter.start_logs()
+        try:
+            yield reporter
+        finally:
+            reporter.finish(use_rich=False)
+
+
+async def _generate_one(
+    generator: ScenarioGenerator,
+    context: ScenarioContext,
+    max_scenarios: int | None,
+    rng: np.random.Generator,
+    target_mode: TargetMode,
+    progress: _GenerationProgressReporter | None,
+) -> list[Scenario[Any, Any, Trace[Any, Any]]]:
+    scenarios = await generator.generate_scenario(
+        context,
+        max_scenarios=max_scenarios,
+        rng=rng,
+        target_mode=target_mode,
+    )
+    if progress is not None:
+        progress.on_generator_done(_generator_name(generator), len(scenarios))
+    return scenarios
 
 
 async def _generate_scenarios(
@@ -16,6 +143,7 @@ async def _generate_scenarios(
     max_scenarios: int | None = None,
     seed: int = 42,
     target_mode: TargetMode = "multiturn",
+    verbose: bool = True,
 ) -> list[Scenario[Any, Any, Trace[Any, Any]]]:
     rng = np.random.default_rng(seed)
 
@@ -33,21 +161,30 @@ async def _generate_scenarios(
         counts = [None] * len(generators)
     child_rngs = rng.spawn(len(generators))
 
-    tasks = []
-    async with TaskGroup() as task_group:
-        for generator, n, child_rng in zip(generators, counts, child_rngs):
-            tasks.append(
-                task_group.create_task(
-                    generator.generate_scenario(
-                        context,
-                        max_scenarios=n,
-                        rng=child_rng,
-                        target_mode=target_mode,
+    progress_ctx = (
+        _generation_progress(len(generators), max_scenarios, verbose)
+        if verbose and len(generators) > 0
+        else nullcontext()
+    )
+
+    with progress_ctx as progress:
+        tasks = []
+        async with TaskGroup() as task_group:
+            for generator, n, child_rng in zip(generators, counts, child_rngs):
+                tasks.append(
+                    task_group.create_task(
+                        _generate_one(
+                            generator,
+                            context,
+                            n,
+                            child_rng,
+                            target_mode,
+                            progress,
+                        )
                     )
                 )
-            )
 
-    return [scenario for task in tasks for scenario in task.result()]
+        return [scenario for task in tasks for scenario in task.result()]
 
 
 async def generate_suite(
@@ -58,6 +195,7 @@ async def generate_suite(
     seed: int = 42,
     target_mode: TargetMode = "multiturn",
     knowledge_base: KnowledgeBase | list[str] | None = None,
+    verbose: bool = True,
 ) -> Suite[Any, Any]:
     """Generate a test suite by running the supplied generators.
 
@@ -80,6 +218,9 @@ async def generate_suite(
         knowledge_base: Optional documents forwarded via the context to
             generators that use knowledge-base context. Raw strings are
             normalized to a :class:`KnowledgeBase`.
+        verbose: When ``True`` (default), show generation progress on a TTY
+            or emit INFO logs when stderr is not a TTY. Set to ``False`` for
+            fully quiet generation.
 
     Returns:
         A Suite containing all generated scenarios, ready for execution.
@@ -96,6 +237,11 @@ async def generate_suite(
     )
     resolved = [_normalize_generator(g) for g in generators]
     scenarios = await _generate_scenarios(
-        context, resolved, max_scenarios, seed, target_mode=target_mode
+        context,
+        resolved,
+        max_scenarios,
+        seed,
+        target_mode=target_mode,
+        verbose=verbose,
     )
     return Suite(name="Scenarios", scenarios=scenarios)

--- a/libs/giskard-scan/src/giskard/scan/quality.py
+++ b/libs/giskard-scan/src/giskard/scan/quality.py
@@ -1,6 +1,7 @@
 """Quality scan entry points for giskard.scan."""
 
 import logging
+import sys
 import warnings
 
 from giskard.checks import SuiteResult, Target, Trace
@@ -46,6 +47,7 @@ async def quality_scan[InputType, OutputType, TraceType: Trace](  # pyright: ign
     max_concurrency: int | None = None,
     return_exception: bool = False,
     target_mode: TargetMode = "multiturn",
+    verbose: bool = True,
 ) -> SuiteResult:
     """Generate and run the standard quality scan suite.
 
@@ -74,6 +76,9 @@ async def quality_scan[InputType, OutputType, TraceType: Trace](  # pyright: ign
             multi-turn conversations. ``"singleturn"`` skips generators that
             are multi-turn by design and caps turn budgets to 1 on others.
             Defaults to ``"multiturn"``.
+        verbose: When ``True`` (default), show generation and run progress and
+            print the grouped report. Set to ``False`` to suppress Rich UI and
+            ``print_report`` while still returning a :class:`SuiteResult`.
 
     Returns:
         The completed suite result with a generated quality recommendation.
@@ -81,6 +86,9 @@ async def quality_scan[InputType, OutputType, TraceType: Trace](  # pyright: ign
     knowledge_base = normalize_knowledge_base(
         _warn_if_missing_knowledge_base(knowledge_base)
     )
+
+    if verbose and not sys.stderr.isatty():
+        logger.info("quality_scan: phase=generating")
 
     suite = await generate_suite(
         description=description,
@@ -90,13 +98,19 @@ async def quality_scan[InputType, OutputType, TraceType: Trace](  # pyright: ign
         seed=seed,
         target_mode=target_mode,
         knowledge_base=knowledge_base,
+        verbose=verbose,
     )
+
+    if verbose and not sys.stderr.isatty():
+        scenario_count = len(suite.scenarios) if hasattr(suite, "scenarios") else 0
+        logger.info("quality_scan: phase=running scenarios=%d", scenario_count)
 
     result: SuiteResult = await suite.run(
         target,
         parallel=parallel,
         max_concurrency=max_concurrency,
         return_exception=return_exception,
+        verbose=verbose,
     )
     try:
         recommendation = await generate_quality_recommendation(result)
@@ -104,7 +118,8 @@ async def quality_scan[InputType, OutputType, TraceType: Trace](  # pyright: ign
         logger.exception("Quality recommendation generation failed")
         recommendation = ""
     quality_result = result.model_copy(update={"recommendation": recommendation})
-    quality_result.print_report(group_by=group_by)
+    if verbose:
+        quality_result.print_report(group_by=group_by)
     return quality_result
 
 

--- a/libs/giskard-scan/src/giskard/scan/types.py
+++ b/libs/giskard-scan/src/giskard/scan/types.py
@@ -24,6 +24,9 @@ class ScanOptions(TypedDict, total=False):
         return_exception: When ``True``, a scenario whose input generation fails
             is recorded as an errored result and the scan continues. When
             ``False`` (default), the failure propagates and aborts the scan.
+        verbose: When ``True``, show generation and run progress and print the
+            grouped report. Set to ``False`` to suppress Rich UI and
+            ``print_report``. Defaults to ``True``.
     """
 
     max_scenarios: int | None
@@ -33,6 +36,7 @@ class ScanOptions(TypedDict, total=False):
     max_concurrency: int | None
     commercial_use: bool
     return_exception: bool
+    verbose: bool
 
 
 class ResolvedScanOptions(TypedDict):
@@ -54,3 +58,4 @@ class ResolvedScanOptions(TypedDict):
     max_concurrency: int | None
     commercial_use: bool
     return_exception: bool
+    verbose: bool

--- a/libs/giskard-scan/src/giskard/scan/vulnerability.py
+++ b/libs/giskard-scan/src/giskard/scan/vulnerability.py
@@ -1,3 +1,5 @@
+import logging
+import sys
 from typing import Unpack
 
 from giskard.checks import SuiteResult, Target, Trace
@@ -33,6 +35,8 @@ vulnerability_suite_generator_registry = SuiteGeneratorRegistry()
 for generator in VULNERABILITY_GENERATORS:
     vulnerability_suite_generator_registry.register(generator)
 
+logger = logging.getLogger(__name__)
+
 _DEFAULT_SCAN_OPTIONS: ResolvedScanOptions = {
     "max_scenarios": None,
     "seed": 42,
@@ -41,6 +45,7 @@ _DEFAULT_SCAN_OPTIONS: ResolvedScanOptions = {
     "max_concurrency": None,
     "commercial_use": False,
     "return_exception": False,
+    "verbose": True,
 }
 
 
@@ -70,6 +75,10 @@ async def vulnerability_scan[InputType, OutputType, TraceType: Trace](  # pyrigh
         The completed suite result for the vulnerability scan.
     """
     opts: ResolvedScanOptions = {**_DEFAULT_SCAN_OPTIONS, **options}
+    verbose = opts["verbose"]
+
+    if verbose and not sys.stderr.isatty():
+        logger.info("vulnerability_scan: phase=generating")
 
     suite = await generate_suite(
         description=description,
@@ -80,13 +89,23 @@ async def vulnerability_scan[InputType, OutputType, TraceType: Trace](  # pyrigh
         max_scenarios=opts["max_scenarios"],
         seed=opts["seed"],
         target_mode=target_mode,
+        verbose=verbose,
     )
+
+    if verbose and not sys.stderr.isatty():
+        scenario_count = len(suite.scenarios) if hasattr(suite, "scenarios") else 0
+        logger.info(
+            "vulnerability_scan: phase=running scenarios=%d",
+            scenario_count,
+        )
 
     result = await suite.run(
         target,
         parallel=opts["parallel"],
         max_concurrency=opts["max_concurrency"],
         return_exception=opts["return_exception"],
+        verbose=verbose,
     )
-    result.print_report(group_by=opts["group_by"])
+    if verbose:
+        result.print_report(group_by=opts["group_by"])
     return result

--- a/libs/giskard-scan/tests/generators/test_catalog.py
+++ b/libs/giskard-scan/tests/generators/test_catalog.py
@@ -1,4 +1,6 @@
 import asyncio
+import logging
+import sys
 from typing import Any
 
 import numpy as np
@@ -395,3 +397,39 @@ async def test_generate_suite_unbudgeted_reproducibility():
     # The two generators must draw from independent streams, not the same value.
     draws = sorted(name.split("-")[1] for name in names_a)
     assert draws[0] != draws[1]
+
+
+async def test_generate_suite_verbose_false_emits_no_progress(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    monkeypatch.setattr(sys.stderr, "isatty", lambda: False)
+    caplog.set_level(logging.INFO, logger="giskard.scan.catalog")
+
+    await generate_suite(
+        "My chatbot",
+        languages=["en"],
+        generators=[_StubGenerator(name="a"), _StubGenerator(name="b")],
+        verbose=False,
+    )
+
+    assert not [r for r in caplog.records if r.name == "giskard.scan.catalog"]
+
+
+async def test_generate_suite_emits_progress_log_on_non_tty(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    monkeypatch.setattr(sys.stderr, "isatty", lambda: False)
+    caplog.set_level(logging.INFO, logger="giskard.scan.catalog")
+
+    await generate_suite(
+        "My chatbot",
+        languages=["en"],
+        generators=[_StubGenerator(name="a"), _StubGenerator(name="b")],
+        verbose=True,
+    )
+
+    messages = [r.message for r in caplog.records if r.name == "giskard.scan.catalog"]
+    assert any("done generator=_StubGenerator" in message for message in messages)
+    assert any("finished total_scenarios=" in message for message in messages)

--- a/libs/giskard-scan/tests/test_quality.py
+++ b/libs/giskard-scan/tests/test_quality.py
@@ -156,6 +156,7 @@ async def test_quality_scan_forwards_run_options(
                 "parallel": parallel,
                 "max_concurrency": max_concurrency,
                 "return_exception": return_exception,
+                "verbose": verbose,
             }
         )
         return await original_run(
@@ -185,8 +186,66 @@ async def test_quality_scan_forwards_run_options(
     )
 
     assert run_kwargs == [
-        {"parallel": True, "max_concurrency": 3, "return_exception": True}
+        {
+            "parallel": True,
+            "max_concurrency": 3,
+            "return_exception": True,
+            "verbose": True,
+        }
     ]
+
+
+async def test_quality_scan_verbose_false_skips_print_report(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    quality_suite_generator_registry.register(_DeterministicQualityGenerator())
+    printed_reports: list[str | None] = []
+    run_kwargs: list[dict[str, object]] = []
+    original_run = Suite.run
+
+    def print_report_spy(
+        self: SuiteResult,
+        console: Any = None,
+        group_by: str | None = None,
+    ) -> None:
+        _ = self, console
+        printed_reports.append(group_by)
+
+    async def run_spy(
+        self: Suite[Any, Any],
+        target: object,
+        return_exception: bool = False,
+        parallel: bool = False,
+        max_concurrency: int | None = None,
+        verbose: bool = True,
+    ) -> SuiteResult:
+        run_kwargs.append({"verbose": verbose})
+        return await original_run(
+            self,
+            target,
+            return_exception=return_exception,
+            parallel=parallel,
+            max_concurrency=max_concurrency,
+            verbose=verbose,
+        )
+
+    monkeypatch.setattr(SuiteResult, "print_report", print_report_spy)
+    monkeypatch.setattr(Suite, "run", run_spy)
+
+    async def target(inputs: str) -> str:
+        return inputs
+
+    await quality_scan(
+        target=target,
+        description="Support agent",
+        languages=["en"],
+        knowledge_base=["reference document"],
+        max_scenarios=1,
+        verbose=False,
+    )
+
+    assert printed_reports == []
+    assert run_kwargs == [{"verbose": False}]
 
 
 async def test_quality_scan_uses_empty_registry_by_default(
@@ -237,8 +296,9 @@ async def test_quality_scan_warns_and_skips_empty_raw_knowledge_base(
             parallel: bool = True,
             max_concurrency: int | None = None,
             return_exception: bool = False,
+            verbose: bool = True,
         ) -> SuiteResult:
-            _ = target, parallel, max_concurrency, return_exception
+            _ = target, parallel, max_concurrency, return_exception, verbose
             return SuiteResult(results=[], duration_ms=0)
 
     async def generate_suite_spy(**kwargs: Any) -> _FakeSuite:
@@ -289,8 +349,9 @@ async def test_quality_scan_configures_knowledge_base_generator(
             parallel: bool = True,
             max_concurrency: int | None = None,
             return_exception: bool = False,
+            verbose: bool = True,
         ) -> SuiteResult:
-            _ = target, parallel, max_concurrency, return_exception
+            _ = target, parallel, max_concurrency, return_exception, verbose
             return SuiteResult(results=[], duration_ms=0)
 
     async def generate_suite_spy(**kwargs: Any) -> _FakeSuite:

--- a/libs/giskard-scan/tests/test_vulnerability.py
+++ b/libs/giskard-scan/tests/test_vulnerability.py
@@ -110,6 +110,7 @@ async def test_vulnerability_scan_forwards_run_options(
                 "parallel": parallel,
                 "max_concurrency": max_concurrency,
                 "return_exception": return_exception,
+                "verbose": verbose,
             }
         )
         return await run_spy._original(  # pyright: ignore[reportFunctionMemberAccess]
@@ -139,5 +140,64 @@ async def test_vulnerability_scan_forwards_run_options(
     )
 
     assert run_kwargs == [
-        {"parallel": True, "max_concurrency": 3, "return_exception": True}
+        {
+            "parallel": True,
+            "max_concurrency": 3,
+            "return_exception": True,
+            "verbose": True,
+        }
     ]
+
+
+async def test_vulnerability_scan_verbose_false_skips_print_report(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    vulnerability_suite_generator_registry.register(
+        _DeterministicVulnerabilityGenerator()
+    )
+    printed_reports: list[str | None] = []
+    run_kwargs: list[dict[str, object]] = []
+
+    def print_report_spy(
+        self: SuiteResult,
+        console: Any = None,
+        group_by: str | None = None,
+    ) -> None:
+        _ = self, console
+        printed_reports.append(group_by)
+
+    async def run_spy(
+        self: Suite[Any, Any],
+        target: object,
+        return_exception: bool = False,
+        parallel: bool = False,
+        max_concurrency: int | None = None,
+        verbose: bool = True,
+    ) -> SuiteResult:
+        run_kwargs.append({"verbose": verbose})
+        return await run_spy._original(  # pyright: ignore[reportFunctionMemberAccess]
+            self,
+            target,
+            return_exception=return_exception,
+            parallel=parallel,
+            max_concurrency=max_concurrency,
+            verbose=verbose,
+        )
+
+    run_spy._original = Suite.run  # pyright: ignore[reportFunctionMemberAccess]
+    monkeypatch.setattr(SuiteResult, "print_report", print_report_spy)
+    monkeypatch.setattr(Suite, "run", run_spy)
+
+    async def target(inputs: str) -> str:
+        return inputs
+
+    await vulnerability_scan(
+        target=target,
+        description="Support agent",
+        languages=["en"],
+        max_scenarios=1,
+        verbose=False,
+    )
+
+    assert printed_reports == []
+    assert run_kwargs == [{"verbose": False}]


### PR DESCRIPTION
## Summary
- Add `SuiteUsage` and a context-scoped collector that wraps LLM generators during `Suite.run()`
- Expose aggregated token counts on `SuiteResult.usage` (defaults to zeros)
- Print a one-line `tokens: in=… out=… total=…` footer in `print_report()` when usage is non-zero

Closes #2671

## Test plan
- [x] `make test-unit PACKAGE=giskard-checks` (761 passed, 4 skipped)
- [x] LLM judge suite aggregates known mock usage onto `SuiteResult.usage`
- [x] Non-LLM suites keep zero usage and omit the footer line
- [x] Report footer renders when `total_tokens > 0`