### PR TITLE
feat(scan): stream or subsample datasets; avoid duplicate HarmBench loads

### DIFF
--- a/libs/giskard-scan/src/giskard/scan/catalog.py
+++ b/libs/giskard-scan/src/giskard/scan/catalog.py
@@ -7,6 +7,7 @@ from giskard.checks import Scenario, Suite, Trace
 
 from .generators.base import ScenarioContext, ScenarioGenerator, TargetMode
 from .registry import _normalize_generator
+from .utils.dataset_loader import activate_dataset_cache, deactivate_dataset_cache
 from .utils.knowledge_base import KnowledgeBase, normalize_knowledge_base
 
 
@@ -95,7 +96,11 @@ async def generate_suite(
         knowledge_base=normalize_knowledge_base(knowledge_base),
     )
     resolved = [_normalize_generator(g) for g in generators]
-    scenarios = await _generate_scenarios(
-        context, resolved, max_scenarios, seed, target_mode=target_mode
-    )
+    activate_dataset_cache()
+    try:
+        scenarios = await _generate_scenarios(
+            context, resolved, max_scenarios, seed, target_mode=target_mode
+        )
+    finally:
+        deactivate_dataset_cache()
     return Suite(name="Scenarios", scenarios=scenarios)

--- a/libs/giskard-scan/src/giskard/scan/generators/base.py
+++ b/libs/giskard-scan/src/giskard/scan/generators/base.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import Any, Literal, override
 
@@ -8,6 +8,12 @@ import numpy as np
 from giskard.checks import BaseLLMGenerator, Interact, Scenario, Trace
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
+from ..utils.dataset_loader import (
+    get_or_load_cached,
+    is_dataset_cache_active,
+    iter_jsonl,
+    reservoir_sample,
+)
 from ..utils.knowledge_base import KnowledgeBase
 
 logger = logging.getLogger(__name__)
@@ -123,7 +129,11 @@ class BaseDatasetScenarioGenerator(ScenarioGenerator):
     tags: list[str] = Field(default_factory=list)
 
     def load_scenarios(
-        self, description: str, languages: list[str]
+        self,
+        description: str,
+        languages: list[str],
+        max_scenarios: int | None = None,
+        rng: np.random.Generator | None = None,
     ) -> list[Scenario[Any, Any, Trace[Any, Any]]]:
         """Load scenarios, annotating each with ``description`` and ``languages``.
 
@@ -131,6 +141,77 @@ class BaseDatasetScenarioGenerator(ScenarioGenerator):
             A list of scenarios.
         """
         raise NotImplementedError
+
+    def _dataset_identity(self) -> object:
+        """Return a hashable identity for suite-scoped dataset caching."""
+        raise NotImplementedError
+
+    def _dataset_cache_key(
+        self, description: str, languages: list[str]
+    ) -> tuple[Any, ...]:
+        return (self._dataset_identity(), description, tuple(languages))
+
+    def _iter_dataset_records(
+        self, description: str, languages: list[str]
+    ) -> Iterator[tuple[dict[str, Any], str]]:
+        raise NotImplementedError
+
+    def _parse_records(
+        self,
+        records: Iterable[tuple[dict[str, Any], str]],
+        description: str,
+        languages: list[str],
+    ) -> list[Scenario[Any, Any, Trace[Any, Any]]]:
+        scenarios: list[Scenario[Any, Any, Trace[Any, Any]]] = []
+        for record, source in records:
+            try:
+                scenario = Scenario.model_validate(record)
+            except ValidationError as e:
+                raise ValueError(f"Malformed JSON in {source}: {e}") from e
+            scenario = scenario.with_annotations(
+                {
+                    **scenario.annotations,
+                    "description": description,
+                    "languages": languages,
+                }
+            )
+            if self.tags:
+                scenario = scenario.with_tags(self.tags)
+            scenarios.append(scenario)
+        return scenarios
+
+    def _load_scenarios_with_sampling(
+        self,
+        description: str,
+        languages: list[str],
+        max_scenarios: int | None = None,
+        rng: np.random.Generator | None = None,
+    ) -> list[Scenario[Any, Any, Trace[Any, Any]]]:
+        def loader() -> list[Scenario[Any, Any, Trace[Any, Any]]]:
+            return self._parse_records(
+                self._iter_dataset_records(description, languages),
+                description,
+                languages,
+            )
+
+        if is_dataset_cache_active():
+            all_scenarios = get_or_load_cached(
+                self._dataset_cache_key(description, languages), loader
+            )
+            if max_scenarios is not None and max_scenarios < len(all_scenarios):
+                rng = rng if rng is not None else np.random.default_rng()
+                indices = rng.choice(
+                    len(all_scenarios), size=max_scenarios, replace=False
+                )
+                return [all_scenarios[i] for i in sorted(indices)]
+            return list(all_scenarios)
+
+        records = self._iter_dataset_records(description, languages)
+        if max_scenarios is not None:
+            rng = rng if rng is not None else np.random.default_rng()
+            selected = reservoir_sample(records, max_scenarios, rng)
+            return self._parse_records(selected, description, languages)
+        return self._parse_records(records, description, languages)
 
     def _parse_scenarios(
         self,
@@ -200,21 +281,16 @@ class BaseDatasetScenarioGenerator(ScenarioGenerator):
             A list of annotated :class:`~giskard.checks.core.scenario.Scenario`
             objects, ordered by their original dataset position.
         """
-        # load_scenarios does blocking I/O (file reads, and network for the HF
-        # subclass). Generators run concurrently via asyncio.TaskGroup, so offload
-        # to a thread to avoid stalling the event loop and the other generators.
-        scenarios = await asyncio.to_thread(
-            self.load_scenarios, context.description, context.languages
-        )
-
-        max_scenarios = (
+        effective_max = (
             max_scenarios if max_scenarios is not None else _DEFAULT_MAX_SCENARIOS
         )
-
-        if max_scenarios < len(scenarios):
-            rng = rng if rng is not None else np.random.default_rng()
-            indices = rng.choice(len(scenarios), size=max_scenarios, replace=False)
-            scenarios = [scenarios[i] for i in sorted(indices)]
+        scenarios = await asyncio.to_thread(
+            self.load_scenarios,
+            context.description,
+            context.languages,
+            effective_max,
+            rng,
+        )
 
         if target_mode == "singleturn":
             for scenario in scenarios:
@@ -257,20 +333,30 @@ class LocalDatasetScenarioGenerator(BaseDatasetScenarioGenerator):
     dataset_name: str
 
     @override
-    def load_scenarios(
-        self, description: str, languages: list[str]
-    ) -> list[Scenario[Any, Any, Trace[Any, Any]]]:
-        path = _DATA_DIR / f"{self.dataset_name}.jsonl"
+    def _dataset_identity(self) -> object:
+        return self.dataset_name
 
+    @override
+    def _iter_dataset_records(
+        self, description: str, languages: list[str]
+    ) -> Iterator[tuple[dict[str, Any], str]]:
+        path = _DATA_DIR / f"{self.dataset_name}.jsonl"
         if not path.exists():
             raise RuntimeError(
                 f"Dataset file not found: {path}. This may indicate a broken installation — try reinstalling the package."
             )
+        source = str(path)
+        for record in iter_jsonl(path):
+            yield record, source
 
-        with path.open(encoding="utf-8") as f:
-            return self._parse_scenarios(
-                f,
-                description=description,
-                languages=languages,
-                source=str(path),
-            )
+    @override
+    def load_scenarios(
+        self,
+        description: str,
+        languages: list[str],
+        max_scenarios: int | None = None,
+        rng: np.random.Generator | None = None,
+    ) -> list[Scenario[Any, Any, Trace[Any, Any]]]:
+        return self._load_scenarios_with_sampling(
+            description, languages, max_scenarios, rng
+        )

--- a/libs/giskard-scan/src/giskard/scan/generators/gcg.py
+++ b/libs/giskard-scan/src/giskard/scan/generators/gcg.py
@@ -2,6 +2,7 @@
 
 from typing import Any, override
 
+import numpy as np
 from giskard.checks import DatasetInputGenerator, Interact, Scenario, Trace
 from pydantic import Field
 
@@ -55,9 +56,15 @@ class GCGInjectionScenarioGenerator(HuggingFaceDatasetScenarioGenerator):
 
     @override
     def load_scenarios(
-        self, description: str, languages: list[str]
+        self,
+        description: str,
+        languages: list[str],
+        max_scenarios: int | None = None,
+        rng: np.random.Generator | None = None,
     ) -> list[Scenario[Any, Any, Trace[Any, Any]]]:
-        base_scenarios = super().load_scenarios(description, languages)
+        base_scenarios = super().load_scenarios(
+            description, languages, max_scenarios, rng
+        )
         return [
             self._with_suffix(
                 scenario, _SUFFIXES[index % len(_SUFFIXES)], index % len(_SUFFIXES)

--- a/libs/giskard-scan/src/giskard/scan/generators/huggingface.py
+++ b/libs/giskard-scan/src/giskard/scan/generators/huggingface.py
@@ -1,9 +1,10 @@
 import logging
+from collections.abc import Iterator
 from functools import lru_cache
-from pathlib import Path
 from typing import Any, override
 
 import httpx
+import numpy as np
 from giskard.checks import Scenario, Trace
 from huggingface_hub import DatasetCard, hf_hub_download, list_repo_files
 from huggingface_hub.errors import (
@@ -13,6 +14,7 @@ from huggingface_hub.errors import (
 )
 from pydantic import Field
 
+from ..utils.dataset_loader import iter_jsonl
 from .base import BaseDatasetScenarioGenerator
 
 logger = logging.getLogger(__name__)
@@ -118,18 +120,15 @@ class HuggingFaceDatasetScenarioGenerator(BaseDatasetScenarioGenerator):
         return self.repo_allow_commercial_use
 
     @override
-    def load_scenarios(
+    def _dataset_identity(self) -> object:
+        return self.repo_id
+
+    @override
+    def _iter_dataset_records(
         self, description: str, languages: list[str]
-    ) -> list[Scenario[Any, Any, Trace[Any, Any]]]:
-        try:
-            subsets = _language_subsets(self.repo_id)
-        except _HUB_LOAD_ERRORS as exc:
-            if not _handle_hub_outage(self.repo_id, exc):
-                raise
-            return []
-
+    ) -> Iterator[tuple[dict[str, Any], str]]:
+        subsets = _language_subsets(self.repo_id)
         compatible = [language for language in languages if language in subsets]
-
         if not compatible:
             logger.warning(
                 "No compatible language subset found in %s for requested languages "
@@ -138,27 +137,30 @@ class HuggingFaceDatasetScenarioGenerator(BaseDatasetScenarioGenerator):
                 languages,
                 sorted(subsets),
             )
-            return []
+            return
 
-        scenarios: list[Scenario[Any, Any, Trace[Any, Any]]] = []
+        for language in compatible:
+            for repo_file in subsets[language]:
+                local_path = hf_hub_download(
+                    self.repo_id, repo_file, repo_type="dataset"
+                )
+                source = f"{self.repo_id}/{repo_file}"
+                for record in iter_jsonl(local_path, source=source):
+                    yield record, source
+
+    @override
+    def load_scenarios(
+        self,
+        description: str,
+        languages: list[str],
+        max_scenarios: int | None = None,
+        rng: np.random.Generator | None = None,
+    ) -> list[Scenario[Any, Any, Trace[Any, Any]]]:
         try:
-            for language in compatible:
-                for repo_file in subsets[language]:
-                    local_path = hf_hub_download(
-                        self.repo_id, repo_file, repo_type="dataset"
-                    )
-                    with Path(local_path).open(encoding="utf-8") as f:
-                        scenarios.extend(
-                            self._parse_scenarios(
-                                f,
-                                description=description,
-                                languages=languages,
-                                source=f"{self.repo_id}/{repo_file}",
-                            )
-                        )
+            return self._load_scenarios_with_sampling(
+                description, languages, max_scenarios, rng
+            )
         except _HUB_LOAD_ERRORS as exc:
             if not _handle_hub_outage(self.repo_id, exc):
                 raise
             return []
-
-        return scenarios

--- a/libs/giskard-scan/src/giskard/scan/utils/dataset_loader.py
+++ b/libs/giskard-scan/src/giskard/scan/utils/dataset_loader.py
@@ -1,0 +1,82 @@
+"""Internal helpers for streaming JSONL datasets and suite-scoped caching."""
+
+import json
+import threading
+from collections.abc import Callable, Iterable, Iterator
+from pathlib import Path
+from typing import Any, TypeVar, cast
+
+import numpy as np
+
+T = TypeVar("T")
+
+_suite_cache: dict[tuple[object, ...], list[Any]] | None = None
+_cache_lock = threading.Lock()
+
+
+def iter_jsonl(
+    path: Path | str, *, source: str | None = None
+) -> Iterator[dict[str, Any]]:
+    """Yield one parsed JSON object per non-blank line in a JSONL file."""
+    jsonl_path = Path(path)
+    label = source if source is not None else str(jsonl_path)
+    with jsonl_path.open(encoding="utf-8") as handle:
+        for line_num, line in enumerate(handle, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                yield json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"Malformed JSON in {label}:{line_num}: {exc}"
+                ) from exc
+
+
+def reservoir_sample[T](
+    items: Iterable[T], k: int, rng: np.random.Generator
+) -> list[T]:
+    """Return a uniform random sample of size ``k`` from a stream (Algorithm R)."""
+    if k < 0:
+        raise ValueError(f"k must be non-negative, got {k}")
+    if k == 0:
+        return []
+
+    reservoir: list[T] = []
+    for index, item in enumerate(items):
+        if index < k:
+            reservoir.append(item)
+        else:
+            slot = int(rng.integers(0, index + 1))
+            if slot < k:
+                reservoir[slot] = item
+    return reservoir
+
+
+def activate_dataset_cache() -> None:
+    global _suite_cache
+    _suite_cache = {}
+
+
+def deactivate_dataset_cache() -> None:
+    global _suite_cache
+    _suite_cache = None
+
+
+def is_dataset_cache_active() -> bool:
+    return _suite_cache is not None
+
+
+def get_or_load_cached[T](
+    key: tuple[object, ...], loader: Callable[[], list[T]]
+) -> list[T]:
+    if _suite_cache is None:
+        return loader()
+
+    with _cache_lock:
+        cached = _suite_cache.get(key)
+        if cached is not None:
+            return cast(list[T], cached)
+        loaded = loader()
+        _suite_cache[key] = loaded
+        return loaded

--- a/libs/giskard-scan/tests/generators/test_dataset_loading.py
+++ b/libs/giskard-scan/tests/generators/test_dataset_loading.py
@@ -1,0 +1,129 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import giskard.scan.generators.base as base_mod
+import numpy as np
+from giskard.scan.generators.base import LocalDatasetScenarioGenerator, ScenarioContext
+from giskard.scan.utils import dataset_loader as dl_mod
+from giskard.scan.utils.dataset_loader import (
+    activate_dataset_cache,
+    deactivate_dataset_cache,
+)
+
+
+class _StubDatasetGenerator(LocalDatasetScenarioGenerator):
+    dataset_name: str = "stub"
+
+
+def _write_jsonl(path: Path, count: int) -> None:
+    path.write_text(
+        "\n".join(
+            json.dumps({"name": f"s{i}", "steps": [], "annotations": {}})
+            for i in range(count)
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+async def test_streaming_subsample_returns_requested_count(tmp_path, monkeypatch):
+    _write_jsonl(tmp_path / "stub.jsonl", 500)
+    monkeypatch.setattr(base_mod, "_DATA_DIR", tmp_path)
+    gen = _StubDatasetGenerator()
+    result = await gen.generate_scenario(
+        ScenarioContext(description="desc", languages=["en"]),
+        max_scenarios=20,
+        rng=np.random.default_rng(42),
+    )
+    assert len(result) == 20
+
+
+async def test_streaming_subsample_uses_reservoir_with_budget(tmp_path, monkeypatch):
+    _write_jsonl(tmp_path / "stub.jsonl", 500)
+    monkeypatch.setattr(base_mod, "_DATA_DIR", tmp_path)
+    seen = {"k": None}
+    original = dl_mod.reservoir_sample
+
+    def spy(items, k, rng):
+        seen["k"] = k
+        return original(items, k, rng)
+
+    monkeypatch.setattr(base_mod, "reservoir_sample", spy)
+    gen = _StubDatasetGenerator()
+    await gen.generate_scenario(
+        ScenarioContext(description="desc", languages=["en"]),
+        max_scenarios=20,
+        rng=np.random.default_rng(42),
+    )
+    assert seen["k"] == 20
+
+
+async def test_suite_cache_shares_single_harmbench_parse(tmp_path, monkeypatch):
+    from giskard.scan.generators import huggingface as hf_mod
+    from giskard.scan.generators.gcg import GCGInjectionScenarioGenerator
+    from giskard.scan.generators.huggingface import HuggingFaceDatasetScenarioGenerator
+
+    files: dict[str, str] = {}
+    configs: list[dict[str, Any]] = []
+    repo_file = "harmbench.en.jsonl"
+    path = tmp_path / repo_file
+    path.write_text(
+        "\n".join(
+            json.dumps({"name": f"s{i}", "steps": [], "annotations": {}})
+            for i in range(30)
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    files[repo_file] = str(path)
+    configs.append(
+        {
+            "config_name": "en",
+            "data_files": [{"split": "test", "path": repo_file}],
+        }
+    )
+
+    monkeypatch.setattr(
+        hf_mod.DatasetCard,
+        "load",
+        staticmethod(
+            lambda repo_id, repo_type=None: SimpleNamespace(
+                data=SimpleNamespace(configs=list(configs))
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        hf_mod, "list_repo_files", lambda repo_id, repo_type=None: list(files)
+    )
+    monkeypatch.setattr(
+        hf_mod,
+        "hf_hub_download",
+        lambda repo_id, repo_file, repo_type=None: files[repo_file],
+    )
+    hf_mod._language_subsets.cache_clear()
+
+    load_calls = {"count": 0}
+    original_iter = dl_mod.iter_jsonl
+
+    def spy_iter(path, source=None):
+        load_calls["count"] += 1
+        return original_iter(path, source=source)
+
+    monkeypatch.setattr(hf_mod, "iter_jsonl", spy_iter)
+
+    repo_id = "giskardai/harmbench-scenarios"
+    plain = HuggingFaceDatasetScenarioGenerator(repo_id=repo_id)
+    gcg = GCGInjectionScenarioGenerator()
+    context = ScenarioContext(description="desc", languages=["en"])
+    rng_a, rng_b = np.random.default_rng(1), np.random.default_rng(2)
+
+    activate_dataset_cache()
+    try:
+        await plain.generate_scenario(context, max_scenarios=5, rng=rng_a)
+        await gcg.generate_scenario(context, max_scenarios=5, rng=rng_b)
+    finally:
+        deactivate_dataset_cache()
+
+    assert load_calls["count"] == 1

--- a/libs/giskard-scan/tests/generators/test_gcg.py
+++ b/libs/giskard-scan/tests/generators/test_gcg.py
@@ -44,7 +44,7 @@ def _load(
     monkeypatch.setattr(
         HuggingFaceDatasetScenarioGenerator,
         "load_scenarios",
-        lambda self, description, languages: list(base),
+        lambda self, description, languages, max_scenarios=None, rng=None: list(base),
     )
     return GCGInjectionScenarioGenerator().load_scenarios("desc", ["en"])
 

--- a/libs/giskard-scan/tests/utils/test_dataset_loader.py
+++ b/libs/giskard-scan/tests/utils/test_dataset_loader.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+from giskard.scan.utils.dataset_loader import iter_jsonl, reservoir_sample
+
+
+def test_iter_jsonl_skips_blank_lines(tmp_path: Path) -> None:
+    path = tmp_path / "data.jsonl"
+    path.write_text('{"a": 1}\n\n{"a": 2}\n', encoding="utf-8")
+    assert list(iter_jsonl(path)) == [{"a": 1}, {"a": 2}]
+
+
+def test_iter_jsonl_raises_on_malformed_json(tmp_path: Path) -> None:
+    path = tmp_path / "bad.jsonl"
+    path.write_text('{"ok": true}\n{not json}\n', encoding="utf-8")
+    with pytest.raises(ValueError, match=r"bad\.jsonl:2"):
+        list(iter_jsonl(path))
+
+
+def test_reservoir_sample_returns_all_when_stream_shorter_than_k() -> None:
+    rng = np.random.default_rng(0)
+    assert reservoir_sample([1, 2, 3], 10, rng) == [1, 2, 3]
+
+
+def test_reservoir_sample_size_matches_k() -> None:
+    rng = np.random.default_rng(42)
+    sample = reservoir_sample(range(500), 20, rng)
+    assert len(sample) == 20
+
+
+def test_reservoir_sample_is_reproducible_with_same_seed() -> None:
+    sample_a = reservoir_sample(range(500), 20, np.random.default_rng(7))
+    sample_b = reservoir_sample(range(500), 20, np.random.default_rng(7))
+    assert sample_a == sample_b
+
+
+def test_reservoir_sample_rejects_negative_k() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        reservoir_sample([1], -1, np.random.default_rng(0))


### PR DESCRIPTION
Closes #2669

## Summary

- Add internal `iter_jsonl` and `reservoir_sample` helpers for streaming JSONL and uniform subsampling without full materialization.
- Refactor dataset generators to sample while streaming; subsample during load instead of read-all-then-`rng.choice`.
- Activate a suite-scoped dataset cache in `generate_suite` so HarmBench (and other shared corpora) are parsed once and reused across generators such as plain HF and GCG.
- Public `ScenarioGenerator.generate_scenario(...)` signatures are unchanged.

## Test plan

- [x] `make format`
- [x] `make test-unit PACKAGE=giskard-scan` (166 passed)
- [x] 500-line JSONL fixture with `max_scenarios=20` returns 20 scenarios via reservoir sampling
- [x] HarmBench plain + GCG generators share one `iter_jsonl` parse when cache is active