### PR TITLE
chore(pyright): flag and remove unused ignore comments

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/builtin/fn.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/fn.py
@@ -23,7 +23,7 @@ The callable can be synchronous or asynchronous and must return either:
 @Check.register("fn")
 class FnCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]@
     Check[InputType, OutputType, TraceType]
-):  # pyright: ignore[reportMissingTypeArgument]
+):
     """A `Check` whose logic is a Python callable.
 
     Parameters are modeled as pydantic fields. At runtime, the `run` method will

--- a/libs/giskard-checks/src/giskard/checks/builtin/rego_policy.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/rego_policy.py
@@ -115,7 +115,7 @@ class RegoPolicy[InputType, OutputType, TraceType: Trace](  # pyright: ignore[re
 
     def _compile_engine(self, regorus: Any) -> Any:
         """Load policy and data into a regorus engine and cache it."""
-        engine = regorus.Engine()  # pyright: ignore[reportAttributeAccessIssue]
+        engine = regorus.Engine()
         engine.add_policy(_POLICY_FILENAME, self.policy)
         if self.data:
             engine.add_data(self.data)

--- a/libs/giskard-checks/src/giskard/checks/generators/dataset.py
+++ b/libs/giskard-checks/src/giskard/checks/generators/dataset.py
@@ -14,7 +14,7 @@ PROMPT_PLACEHOLDER = "{{prompt}}"
 _MAPPING_TEMPLATE = "giskard.checks::generators/dataset_input_mapping.j2"
 
 
-class MappingTemplate[T](BaseModel):  # pyright: ignore[reportMissingTypeArgument]
+class MappingTemplate[T](BaseModel):
     """LLM output: a valid instance of the target schema with a {{prompt}} marker.
 
     Either ``message`` (a valid ``T`` containing the ``{{prompt}}`` token in the

--- a/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
@@ -38,7 +38,7 @@ def _validate_multiple_runs(value: int | None) -> int | None:
 
 def _build_steps[InputType, OutputType, TraceType: Trace[Any, Any]](
     scenario: Scenario[InputType, OutputType, TraceType],
-    target: Target[InputType, OutputType, TraceType] | MISSING,  # pyright: ignore[reportInvalidTypeForm]
+    target: Target[InputType, OutputType, TraceType] | MISSING,
 ) -> list[Step[InputType, OutputType, TraceType]]:
     """Build steps with target bound to Interact outputs where needed.
 
@@ -66,7 +66,7 @@ def _build_steps[InputType, OutputType, TraceType: Trace[Any, Any]](
 
 def _resolve_trace_type[InputType, OutputType, TraceType: Trace[Any, Any]](
     scenario: Scenario[InputType, OutputType, TraceType],
-    run_target: Target[InputType, OutputType, TraceType] | MISSING,  # pyright: ignore[reportInvalidTypeForm]
+    run_target: Target[InputType, OutputType, TraceType] | MISSING,
 ) -> type[TraceType]:
     if scenario.trace_type is not None:
         return scenario.trace_type
@@ -126,7 +126,7 @@ class ScenarioRunner:
     async def _run_once[InputType, OutputType, TraceType: Trace[Any, Any]](
         self,
         scenario: Scenario[InputType, OutputType, TraceType],
-        target: Target[InputType, OutputType, TraceType] | MISSING = MISSING,  # pyright: ignore[reportInvalidTypeForm]
+        target: Target[InputType, OutputType, TraceType] | MISSING = MISSING,
         return_exception: bool = False,
     ) -> ScenarioResult[TraceType]:
         start_time = time.perf_counter()
@@ -236,7 +236,7 @@ class ScenarioRunner:
     async def run[InputType, OutputType, TraceType: Trace[Any, Any]](
         self,
         scenario: Scenario[InputType, OutputType, TraceType],
-        target: Target[InputType, OutputType, TraceType] | MISSING = MISSING,  # pyright: ignore[reportInvalidTypeForm]
+        target: Target[InputType, OutputType, TraceType] | MISSING = MISSING,
         return_exception: bool = False,
         multiple_runs: int | None = None,
     ) -> ScenarioResult[TraceType]:

--- a/libs/giskard-llm/tests/test_providers.py
+++ b/libs/giskard-llm/tests/test_providers.py
@@ -230,7 +230,7 @@ async def test_openai_completion_with_typed_tool_calls(mock_import):
 async def test_openai_embedding(mock_import):
     mock_import.return_value = MagicMock()
     provider = _make_openai_provider()
-    provider._client.embeddings = MagicMock()  # pyright: ignore[reportAttributeAccessIssue]
+    provider._client.embeddings = MagicMock()
     provider._client.embeddings.create = AsyncMock(
         return_value=_make_openai_embedding_response([[0.1, 0.2], [0.3, 0.4]])
     )
@@ -513,7 +513,7 @@ def _make_httpx_sdk_exc(cls: type) -> Exception:
 @pytest.mark.openai
 def test_openai_map_error_completeness():
     """Every openai.APIError subclass must be mapped to an LLMError."""
-    import openai  # pyright: ignore[reportMissingImports]
+    import openai
 
     provider = _make_openai_provider()
     for exc_cls in _all_subclasses(openai.APIError):
@@ -524,7 +524,7 @@ def test_openai_map_error_completeness():
 @pytest.mark.anthropic
 def test_anthropic_map_error_completeness():
     """Every anthropic.APIError subclass must be mapped to an LLMError."""
-    import anthropic  # pyright: ignore[reportMissingImports]
+    import anthropic
 
     provider = _make_anthropic_provider()
     for exc_cls in _all_subclasses(anthropic.APIError):
@@ -535,7 +535,7 @@ def test_anthropic_map_error_completeness():
 @pytest.mark.google
 def test_google_map_error_completeness():
     """Every google.genai error must be mapped to an LLMError."""
-    from google.genai import (  # pyright: ignore[reportMissingImports]
+    from google.genai import (
         errors as genai_errors,
     )
 
@@ -548,7 +548,7 @@ def test_google_map_error_completeness():
 
     # google.genai._interactions hierarchy (httpx-based, same shape as openai)
     try:
-        from google.genai import (  # pyright: ignore[reportMissingImports]
+        from google.genai import (
             _interactions as ix,
         )
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -9,5 +9,6 @@
     ],
     "failOnWarnings": false,
     "typeCheckingMode": "recommended",
-    "reportImportCycles": "warning"
+    "reportImportCycles": "warning",
+    "reportUnnecessaryTypeIgnoreComment": "error"
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enable basedpyright’s built-in `reportUnnecessaryTypeIgnoreComment` diagnostic and remove the suppressions it currently flags as unnecessary.

No custom format-time remover — pyright/basedpyright only detect unused `# pyright: ignore` comments; autofix isn’t part of the CLI/Pylance workflow. Enforcement goes through `make typecheck` / `make check`.

## Changes

- Set `reportUnnecessaryTypeIgnoreComment: "error"` in `pyrightconfig.json`
- Drop 12 dead `# pyright: ignore[...]` comments in `giskard-checks` and `giskard-llm`

## Verification

- `make format` — clean
- `make check` — basedpyright `0 errors`
- `make test-unit PACKAGE=giskard-checks` — 757 passed
- `make test-unit PACKAGE=giskard-llm` — 211 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9558e60-4a70-4f8a-8202-c4ee1d2d1931?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9558e60-4a70-4f8a-8202-c4ee1d2d1931&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

