### PR TITLE
ci: make integration tests more frugal

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -69,11 +69,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Python version coverage lives in Main CI unit tests; integration only needs one.
         python-version: ["3.12"]
         backend:
-          # One job per install layout (giskard-llm vs litellm). The old "both"
-          # cell re-ran the union of these suites without adding coverage.
           - name: giskard-llm
             extras: "giskard-agents[google]"
             pytest_mark: "functional and google"
@@ -86,13 +83,11 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
-          # Deliberate opt-in: this job installs and executes fork-authored
-          # code (make install, pytest) with live provider API keys in scope.
-          # Compensating controls: the `ci` environment requires a reviewer to
-          # approve each run before secrets are injected (server-enforced,
-          # per-run), the authorize job requires a fresh `labeled` event for
-          # external contributors, and the immutable head.sha pin keeps the
-          # reviewed commit identical to the executed one.
+          # This job deliberately runs untrusted fork code with live API keys
+          # in scope. Three controls limit the risk. The CI environment
+          # requires reviewer approval for each run. The authorize job
+          # requires a fresh labeled event for external contributors. The
+          # head.sha pin stops the code from changing after approval.
           allow-unsafe-pr-checkout: true
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
@@ -121,10 +116,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # One cell per distinct provider class or routing path. Drop `gemini`
-        # only — it maps to the same GoogleProvider as `google`. Keep `bare`
-        # (no-configure path), `azure_ai` (AzureAIProvider), and
-        # `azure_foundry_v1` (Foundry base URL + Responses API).
         include:
           - { python-version: "3.12", provider: openai, extras: openai }
           - { python-version: "3.12", provider: bare, extras: openai }
@@ -146,7 +137,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
-          # Deliberate opt-in — see test-agents-functional for the full
+          # Deliberate opt-in. See test-agents-functional for the full
           # rationale and compensating controls.
           allow-unsafe-pr-checkout: true
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -186,7 +177,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
-          # Deliberate opt-in — see test-agents-functional for the full
+          # Deliberate opt-in. See test-agents-functional for the full
           # rationale and compensating controls.
           allow-unsafe-pr-checkout: true
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -213,7 +204,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
-          # Deliberate opt-in — see test-agents-functional for the full
+          # Deliberate opt-in. See test-agents-functional for the full
           # rationale and compensating controls.
           allow-unsafe-pr-checkout: true
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -60,23 +60,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+        # Python version coverage lives in Main CI unit tests; integration only needs one.
+        python-version: ["3.12"]
         backend:
-          # Each backend exercises a different install combination so we
-          # catch dependency regressions in the three supported layouts:
-          # giskard-llm only, litellm only, and both installed together.
-          # Using the top-level giskard-agents extras (not giskard-llm
-          # directly) so the pass-through extras declared in
-          # libs/giskard-agents/pyproject.toml are covered.
+          # One job per install layout (giskard-llm vs litellm). The old "both"
+          # cell re-ran the union of these suites without adding coverage.
           - name: giskard-llm
             extras: "giskard-agents[google]"
             pytest_mark: "functional and google"
           - name: litellm
             extras: "giskard-agents[litellm]"
             pytest_mark: "functional and litellm"
-          - name: both
-            extras: "giskard-agents[google,litellm]"
-            pytest_mark: "functional and (google or litellm)"
     name: agents / ${{ matrix.backend.name }} / ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -118,22 +112,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # One cell per routing prefix we want to exercise end-to-end.
-        # `extras` is the giskard-llm optional-dependency group to install;
-        # aliases share an install (bare/azure_ai reuse openai/azure, gemini reuses google).
+        # One cell per distinct SDK + routing prefix. Alias providers (bare,
+        # gemini, azure_ai, azure_foundry_v1) share installs and are covered
+        # by openai/google/azure respectively.
         include:
           - { python-version: "3.12", provider: openai, extras: openai }
-          - { python-version: "3.12", provider: bare, extras: openai }
           - { python-version: "3.12", provider: google, extras: google }
-          - { python-version: "3.12", provider: gemini, extras: google }
           - { python-version: "3.12", provider: anthropic, extras: anthropic }
           - { python-version: "3.12", provider: azure, extras: azure }
-          - { python-version: "3.12", provider: azure_ai, extras: azure }
-          - {
-              python-version: "3.12",
-              provider: azure_foundry_v1,
-              extras: openai,
-            }
     name: llm / ${{ matrix.provider }} / ${{ matrix.python-version }}
     env:
       PROVIDER: ${{ matrix.provider }}
@@ -155,51 +141,13 @@ jobs:
         run: uv pip install "giskard-llm[$EXTRAS]"
       - name: Run functional tests
         env:
-          OPENAI_API_KEY: ${{ (matrix.provider == 'openai' || matrix.provider == 'bare') && secrets.OPENAI_API_KEY || '' }}
-          GOOGLE_API_KEY: ${{ (matrix.provider == 'google' || matrix.provider == 'gemini') && secrets.GEMINI_API_KEY || '' }}
+          OPENAI_API_KEY: ${{ matrix.provider == 'openai' && secrets.OPENAI_API_KEY || '' }}
+          GOOGLE_API_KEY: ${{ matrix.provider == 'google' && secrets.GEMINI_API_KEY || '' }}
           ANTHROPIC_API_KEY: ${{ matrix.provider == 'anthropic' && secrets.ANTHROPIC_API_KEY || '' }}
           AZURE_API_KEY: ${{ matrix.provider == 'azure' && secrets.AZURE_API_KEY || '' }}
           AZURE_API_BASE: ${{ matrix.provider == 'azure' && secrets.AZURE_API_BASE || '' }}
           AZURE_API_VERSION: ${{ matrix.provider == 'azure' && secrets.AZURE_API_VERSION || '' }}
-          AZURE_AI_API_KEY: ${{ (matrix.provider == 'azure_ai' || matrix.provider == 'azure_foundry_v1') && secrets.AZURE_AI_API_KEY || '' }}
-          AZURE_AI_ENDPOINT: ${{ (matrix.provider == 'azure_ai' || matrix.provider == 'azure_foundry_v1') && secrets.AZURE_AI_ENDPOINT || '' }}
-          AZURE_AI_OPENAI_V1_ENDPOINT: ${{ matrix.provider == 'azure_foundry_v1' && secrets.AZURE_AI_OPENAI_V1_ENDPOINT || '' }}
         run: make test-functional PACKAGE=giskard-llm PROVIDER=$PROVIDER
-
-  test-checks-functional:
-    needs: authorize
-    runs-on: ubuntu-latest
-    environment: ci
-    timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.12", "3.13", "3.14"]
-        provider: [google]
-    name: checks / ${{ matrix.provider }} / ${{ matrix.python-version }}
-    env:
-      PROVIDER: ${{ matrix.provider }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
-          persist-credentials: false
-          # Deliberate opt-in — see test-agents-functional for the full
-          # rationale and compensating controls.
-          allow-unsafe-pr-checkout: true
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        with:
-          enable-cache: true
-          python-version: ${{ matrix.python-version }}
-      - run: make install
-      - name: Install provider SDK
-        run: uv pip install "giskard-llm[$PROVIDER]"
-      - name: Run functional tests
-        env:
-          GOOGLE_API_KEY: ${{ matrix.provider == 'google' && secrets.GEMINI_API_KEY || '' }}
-          GISKARD_CHECKS_DEFAULT_MODEL: "google/gemini-3.5-flash"
-          GISKARD_CHECKS_DEFAULT_EMBEDDING_MODEL: "google/gemini-embedding-001"
-        run: make test-functional PACKAGE=giskard-checks PROVIDER=$PROVIDER
 
   test-scan-garak:
     needs: authorize

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -112,14 +112,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # One cell per distinct SDK + routing prefix. Alias providers (bare,
-        # gemini, azure_ai, azure_foundry_v1) share installs and are covered
-        # by openai/google/azure respectively.
+        # One cell per distinct provider class or routing path. Drop `gemini`
+        # only — it maps to the same GoogleProvider as `google`. Keep `bare`
+        # (no-configure path), `azure_ai` (AzureAIProvider), and
+        # `azure_foundry_v1` (Foundry base URL + Responses API).
         include:
           - { python-version: "3.12", provider: openai, extras: openai }
+          - { python-version: "3.12", provider: bare, extras: openai }
           - { python-version: "3.12", provider: google, extras: google }
           - { python-version: "3.12", provider: anthropic, extras: anthropic }
           - { python-version: "3.12", provider: azure, extras: azure }
+          - { python-version: "3.12", provider: azure_ai, extras: azure }
+          - {
+              python-version: "3.12",
+              provider: azure_foundry_v1,
+              extras: openai,
+            }
     name: llm / ${{ matrix.provider }} / ${{ matrix.python-version }}
     env:
       PROVIDER: ${{ matrix.provider }}
@@ -141,12 +149,15 @@ jobs:
         run: uv pip install "giskard-llm[$EXTRAS]"
       - name: Run functional tests
         env:
-          OPENAI_API_KEY: ${{ matrix.provider == 'openai' && secrets.OPENAI_API_KEY || '' }}
+          OPENAI_API_KEY: ${{ (matrix.provider == 'openai' || matrix.provider == 'bare') && secrets.OPENAI_API_KEY || '' }}
           GOOGLE_API_KEY: ${{ matrix.provider == 'google' && secrets.GEMINI_API_KEY || '' }}
           ANTHROPIC_API_KEY: ${{ matrix.provider == 'anthropic' && secrets.ANTHROPIC_API_KEY || '' }}
           AZURE_API_KEY: ${{ matrix.provider == 'azure' && secrets.AZURE_API_KEY || '' }}
           AZURE_API_BASE: ${{ matrix.provider == 'azure' && secrets.AZURE_API_BASE || '' }}
           AZURE_API_VERSION: ${{ matrix.provider == 'azure' && secrets.AZURE_API_VERSION || '' }}
+          AZURE_AI_API_KEY: ${{ (matrix.provider == 'azure_ai' || matrix.provider == 'azure_foundry_v1') && secrets.AZURE_AI_API_KEY || '' }}
+          AZURE_AI_ENDPOINT: ${{ (matrix.provider == 'azure_ai' || matrix.provider == 'azure_foundry_v1') && secrets.AZURE_AI_ENDPOINT || '' }}
+          AZURE_AI_OPENAI_V1_ENDPOINT: ${{ matrix.provider == 'azure_foundry_v1' && secrets.AZURE_AI_OPENAI_V1_ENDPOINT || '' }}
         run: make test-functional PACKAGE=giskard-llm PROVIDER=$PROVIDER
 
   test-scan-garak:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,15 +3,6 @@ name: Integration Tests
 on:
   pull_request_target: # zizmor: ignore[dangerous-triggers] guarded by authorize job, label gate for external PRs, and immutable head.sha checkout
     types: [opened, synchronize, reopened, labeled]
-    paths:
-      - "libs/giskard-agents/**"
-      - "libs/giskard-llm/**"
-      - "libs/giskard-core/**"
-      - "libs/giskard-scan/**"
-      - ".github/workflows/integration-tests.yml"
-      - "pyproject.toml"
-      - "uv.lock"
-      - "Makefile"
   workflow_dispatch:
 
 permissions: {}
@@ -24,6 +15,10 @@ jobs:
   authorize:
     name: authorize
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read # list changed files
+    outputs:
+      relevant: ${{ steps.changes.outputs.relevant }}
     steps:
       - name: Check authorization
         env:
@@ -59,8 +54,32 @@ jobs:
           echo "::error::External contributors require a maintainer to add the 'safe for build' label."
           exit 1
 
+      # Path filtering lives here rather than in the `paths:` trigger: a
+      # required check that never starts stays "Waiting" forever, whereas a
+      # job skipped by `if:` reports as neutral and unblocks the PR.
+      - name: Detect relevant changes
+        id: changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [[ "$EVENT_NAME" != "pull_request_target" ]]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename')
+          if grep -qE '^(libs/giskard-(agents|llm|core|scan)/|\.github/workflows/integration-tests\.yml$|pyproject\.toml$|uv\.lock$|Makefile$)' <<<"$files"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "No integration-relevant paths changed — skipping test jobs."
+          fi
+
   test-agents-functional:
     needs: authorize
+    if: needs.authorize.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read # checkout repository
@@ -110,6 +129,7 @@ jobs:
 
   test-llm-functional:
     needs: authorize
+    if: needs.authorize.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     environment: ci
     timeout-minutes: 30
@@ -162,6 +182,7 @@ jobs:
 
   test-scan-garak:
     needs: authorize
+    if: needs.authorize.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read # checkout repository
@@ -189,6 +210,7 @@ jobs:
 
   test-scan-deepteam:
     needs: authorize
+    if: needs.authorize.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read # checkout repository

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -58,58 +58,8 @@ jobs:
           echo "::error::External contributors require a maintainer to add the 'safe for build' label."
           exit 1
 
-  detect-changes:
-    needs: authorize
-    name: detect-changes
-    runs-on: ubuntu-latest
-    outputs:
-      agents: ${{ steps.paths.outputs.agents }}
-      llm: ${{ steps.paths.outputs.llm }}
-    steps:
-      - name: Detect integration-relevant paths
-        id: paths
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "agents=true" >> "$GITHUB_OUTPUT"
-            echo "llm=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          agents=false
-          llm=false
-          shared=false
-
-          while IFS= read -r file; do
-            case "$file" in
-              libs/giskard-agents/*)
-                agents=true
-                ;;
-              libs/giskard-llm/*)
-                llm=true
-                agents=true
-                ;;
-              libs/giskard-core/*|.github/workflows/integration-tests.yml|pyproject.toml|uv.lock|Makefile)
-                shared=true
-                ;;
-            esac
-          done < <(
-            gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-              --paginate -q '.[].filename'
-          )
-
-          if [[ "$shared" == true ]]; then
-            agents=true
-            llm=true
-          fi
-
-          echo "agents=$agents" >> "$GITHUB_OUTPUT"
-          echo "llm=$llm" >> "$GITHUB_OUTPUT"
-
   test-agents-functional:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.agents == 'true'
+    needs: authorize
     runs-on: ubuntu-latest
     permissions:
       contents: read # checkout repository
@@ -163,8 +113,7 @@ jobs:
         run: uv run pytest libs/giskard-agents -m "$PYTEST_MARK"
 
   test-llm-functional:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.llm == 'true'
+    needs: authorize
     runs-on: ubuntu-latest
     environment: ci
     timeout-minutes: 30

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,6 +7,7 @@ on:
       - "libs/giskard-agents/**"
       - "libs/giskard-llm/**"
       - "libs/giskard-core/**"
+      - "libs/giskard-scan/**"
       - ".github/workflows/integration-tests.yml"
       - "pyproject.toml"
       - "uv.lock"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,6 +3,14 @@ name: Integration Tests
 on:
   pull_request_target: # zizmor: ignore[dangerous-triggers] guarded by authorize job, label gate for external PRs, and immutable head.sha checkout
     types: [opened, synchronize, reopened, labeled]
+    paths:
+      - "libs/giskard-agents/**"
+      - "libs/giskard-llm/**"
+      - "libs/giskard-core/**"
+      - ".github/workflows/integration-tests.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "Makefile"
   workflow_dispatch:
 
 permissions: {}
@@ -50,8 +58,58 @@ jobs:
           echo "::error::External contributors require a maintainer to add the 'safe for build' label."
           exit 1
 
-  test-agents-functional:
+  detect-changes:
     needs: authorize
+    name: detect-changes
+    runs-on: ubuntu-latest
+    outputs:
+      agents: ${{ steps.paths.outputs.agents }}
+      llm: ${{ steps.paths.outputs.llm }}
+    steps:
+      - name: Detect integration-relevant paths
+        id: paths
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "agents=true" >> "$GITHUB_OUTPUT"
+            echo "llm=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          agents=false
+          llm=false
+          shared=false
+
+          while IFS= read -r file; do
+            case "$file" in
+              libs/giskard-agents/*)
+                agents=true
+                ;;
+              libs/giskard-llm/*)
+                llm=true
+                agents=true
+                ;;
+              libs/giskard-core/*|.github/workflows/integration-tests.yml|pyproject.toml|uv.lock|Makefile)
+                shared=true
+                ;;
+            esac
+          done < <(
+            gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+              --paginate -q '.[].filename'
+          )
+
+          if [[ "$shared" == true ]]; then
+            agents=true
+            llm=true
+          fi
+
+          echo "agents=$agents" >> "$GITHUB_OUTPUT"
+          echo "llm=$llm" >> "$GITHUB_OUTPUT"
+
+  test-agents-functional:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.agents == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read # checkout repository
@@ -105,7 +163,8 @@ jobs:
         run: uv run pytest libs/giskard-agents -m "$PYTEST_MARK"
 
   test-llm-functional:
-    needs: authorize
+    needs: detect-changes
+    if: needs.detect-changes.outputs.llm == 'true'
     runs-on: ubuntu-latest
     environment: ci
     timeout-minutes: 30

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -65,16 +65,25 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
+          # Non-PR events (push, manual dispatch) always run the full suite
           if [[ "$EVENT_NAME" != "pull_request_target" ]]; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          # For PRs, run only when at least one relevant path changed
           files=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename')
-          if grep -qE '^(libs/giskard-(agents|llm|core|scan)/|\.github/workflows/integration-tests\.yml$|pyproject\.toml$|uv\.lock$|Makefile$)' <<<"$files"; then
+          if grep -qE \
+              -e '^libs/giskard-(agents|llm|core|scan)/' \
+              -e '^\.github/workflows/integration-tests\.yml$' \
+              -e '^pyproject\.toml$' \
+              -e '^uv\.lock$' \
+              -e '^Makefile$' \
+              <<<"$files"; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
           else
             echo "relevant=false" >> "$GITHUB_OUTPUT"
-            echo "No integration-relevant paths changed — skipping test jobs."
+            echo "No integration-relevant paths changed. Skipping test jobs."
           fi
 
   test-agents-functional:


### PR DESCRIPTION
## Summary

Shrinks the integration test matrix and skips unrelated PRs to cut live API usage. Closes Giskard-AI/giskard-oss#2695.

### Matrix (phase 1)

* **Python 3.12 only** for integration — Main CI unit tests already cover 3.12–3.14
* **Drop** `gemini` **only** among alias providers — same `GoogleProvider` as `google`; keep `bare` (no-configure path), `azure_ai` (`AzureAIProvider`), and `azure_foundry_v1` (Foundry base URL + Responses API)
* **Drop** `both` **agents backend** — `giskard-llm` and `litellm` jobs already exercise both install layouts
* **Remove dead** `checks` **job** — it ran `make test-functional` but `giskard-checks` uses `@pytest.mark.integration`, so zero tests were collected

**\~21 jobs → 9 jobs** (\~55% fewer API calls when integration runs).

### Path filter (phase 3)

* Path detection lives in the `authorize` job, **not** in a `paths:` trigger — a required check filtered out by `paths:` never starts and stays "Waiting" forever
* `authorize` lists the PR's changed files and outputs `relevant`; the four test jobs are gated with `if: needs.authorize.outputs.relevant == 'true'`, so they report as *skipped* (neutral) on docs-only PRs instead of blocking the merge
* Relevant paths: `libs/giskard-{agents,llm,core,scan}/**`, this workflow, `pyproject.toml`, `uv.lock`, `Makefile`
* `workflow_dispatch` — always runs the full matrix for manual verification

## Test plan

- [ ] Docs-only PR does not trigger integration
- [ ] LLM/agents PR triggers 9 jobs (2 agents + 7 llm)
- [ ] Agents giskard-llm and litellm jobs pass
- [ ] LLM jobs pass for google/anthropic; openai/azure may fail if org credentials are exhausted

## Follow-ups (not in this PR)

* `functional_smoke` tier for PR vs nightly full suite
* Split workflows with per-package `paths` if agents-only PRs should skip llm jobs without shell
* Wire `giskard-checks --run-integration` when a smoke job exists