### PR TITLE
merge(main): resolve #2578 conflicts after scan option API alignment (#2679)

### DIFF
--- a/libs/giskard-scan/README.md
+++ b/libs/giskard-scan/README.md
@@ -1,3 +1,46 @@
 # giskard-scan
 
 Agent vulnerability scanner — red teaming, prompt injection, adversarial scenario generation.
+
+## Scan entrypoints
+
+`quality_scan` and `vulnerability_scan` share the same explicit execution options.
+Pass shared settings by keyword on either entrypoint; each scan adds scan-specific
+options (`knowledge_base` for quality, `commercial_use` for vulnerability).
+
+```python
+from giskard.scan import quality_scan, vulnerability_scan
+
+
+async def echo(inputs: str) -> str:
+    return inputs
+
+
+vulnerability_result = await vulnerability_scan(
+    target=echo,
+    description="Customer support chatbot for an e-commerce store.",
+    languages=["en"],
+    max_scenarios=20,
+    seed=42,
+    group_by="threat-type",
+    parallel=True,
+    max_concurrency=8,
+    return_exception=False,
+    target_mode="multiturn",
+    commercial_use=False,
+)
+
+quality_result = await quality_scan(
+    target=echo,
+    description="Customer support chatbot for an e-commerce store.",
+    languages=["en"],
+    knowledge_base=["Paris is the capital of France."],
+    max_scenarios=20,
+    seed=42,
+    group_by="component",
+    parallel=True,
+    max_concurrency=8,
+    return_exception=False,
+    target_mode="multiturn",
+)
+```

--- a/libs/giskard-scan/src/giskard/scan/quality.py
+++ b/libs/giskard-scan/src/giskard/scan/quality.py
@@ -16,6 +16,7 @@ from .generators.knowledge_base import (
     SycophancyScenarioGenerator,
 )
 from .registry import SuiteGeneratorRegistry
+from .types import resolve_scan_options
 from .utils.knowledge_base import KnowledgeBase, normalize_knowledge_base
 from .utils.recommendation import generate_quality_recommendation
 
@@ -38,6 +39,7 @@ async def quality_scan[InputType, OutputType, TraceType: Trace](  # pyright: ign
     target: Target[InputType, OutputType, TraceType],
     description: str,
     languages: list[str],
+    *,
     knowledge_base: KnowledgeBase | list[str] | None = None,
     max_scenarios: int | None = None,
     seed: int = 42,
@@ -49,40 +51,62 @@ async def quality_scan[InputType, OutputType, TraceType: Trace](  # pyright: ign
 ) -> SuiteResult:
     """Generate and run the standard quality scan suite.
 
-    Builds a suite from the quality scenario generator registry, runs it
-    against the target, prints the grouped report with a recommendation, and
-    returns the suite result.
+    Builds a suite from the quality scenario generator registry, runs it against
+    the target, prints the grouped report with a recommendation, and returns
+    the suite result.
 
-    Args:
-        target: Agent or provider target to evaluate.
-        description: Natural-language description of the agent under test.
-        languages: BCP-47 language codes the agent is expected to handle.
-        knowledge_base: Documents used by knowledge-base quality generators.
-            Raw strings are converted to a :class:`KnowledgeBase`.
-        max_scenarios: Total upper bound on scenarios across all quality
-            generators. ``None`` lets each generator apply its own default.
-        seed: Integer seed used for reproducible scenario generation.
-        group_by: Result annotation key used to group the printed report.
-            ``None`` prints the ungrouped report.
-        parallel: When ``True`` (default), run generated scenarios concurrently
-            against the target. Pass ``False`` for serial execution. This is
-            suite *execution*; scenario *generation* always runs generators
-            concurrently via :func:`~giskard.scan.catalog.generate_suite`.
-        max_concurrency: Cap on concurrent scenarios when ``parallel=True``.
-            ``None`` runs all scenarios at once (provider rate limits become
-            the effective cap). When ``parallel=False``, a valid value has no
-            effect on scheduling, but invalid values are still rejected.
-        return_exception: When ``True``, a scenario whose input generation fails
-            is recorded as an errored result and the scan continues. When
-            ``False`` (default), the failure propagates and aborts the scan.
-        target_mode: Whether the agent under test supports single-turn or
-            multi-turn conversations. ``"singleturn"`` skips generators that
-            are multi-turn by design and caps turn budgets to 1 on others.
-            Defaults to ``"multiturn"``.
+    Parameters
+    ----------
+    target : Target
+        Agent or provider target to evaluate.
+    description : str
+        Natural-language description of the agent under test.
+    languages : list of str
+        BCP-47 language codes the agent is expected to handle.
+    knowledge_base : KnowledgeBase, list of str, or None, optional
+        Documents used by knowledge-base quality generators. Raw strings are
+        converted to a :class:`~giskard.scan.utils.knowledge_base.KnowledgeBase`.
+    max_scenarios : int, optional
+        Total upper bound on scenarios across all quality generators. ``None``
+        lets each generator apply its own default.
+    seed : int, optional
+        Integer seed used for reproducible scenario generation. Defaults to ``42``.
+    group_by : str, optional
+        Result annotation key used to group the printed report. ``None`` prints
+        the ungrouped report. Defaults to ``"component"``.
+    parallel : bool, optional
+        When ``True`` (default), run generated scenarios concurrently against
+        the target. Pass ``False`` for serial execution. This is suite
+        *execution*; scenario *generation* always runs generators concurrently
+        via :func:`~giskard.scan.catalog.generate_suite`.
+    max_concurrency : int, optional
+        Cap on concurrent scenarios when ``parallel=True``. ``None`` runs all
+        scenarios at once (provider rate limits become the effective cap).
+        When ``parallel=False``, a valid value has no effect on scheduling,
+        but invalid values are still rejected.
+    return_exception : bool, optional
+        When ``True``, a scenario whose input generation fails is recorded as an
+        errored result and the scan continues. When ``False`` (default), the
+        failure propagates and aborts the scan.
+    target_mode : {"singleturn", "multiturn"}, optional
+        Whether the agent under test supports single-turn or multi-turn
+        conversations. ``"singleturn"`` skips generators that are multi-turn by
+        design and caps turn budgets to 1 on others. Defaults to ``"multiturn"``.
 
-    Returns:
+    Returns
+    -------
+    SuiteResult
         The completed suite result with a generated quality recommendation.
     """
+    opts = resolve_scan_options(
+        max_scenarios=max_scenarios,
+        seed=seed,
+        group_by=group_by,
+        parallel=parallel,
+        max_concurrency=max_concurrency,
+        return_exception=return_exception,
+    )
+
     knowledge_base = normalize_knowledge_base(
         _warn_if_missing_knowledge_base(knowledge_base)
     )
@@ -91,17 +115,17 @@ async def quality_scan[InputType, OutputType, TraceType: Trace](  # pyright: ign
         description=description,
         languages=languages,
         generators=quality_suite_generator_registry.generators(),
-        max_scenarios=max_scenarios,
-        seed=seed,
+        max_scenarios=opts["max_scenarios"],
+        seed=opts["seed"],
         target_mode=target_mode,
         knowledge_base=knowledge_base,
     )
 
     result: SuiteResult = await suite.run(
         target,
-        parallel=parallel,
-        max_concurrency=max_concurrency,
-        return_exception=return_exception,
+        parallel=opts["parallel"],
+        max_concurrency=opts["max_concurrency"],
+        return_exception=opts["return_exception"],
     )
     try:
         recommendation = await generate_quality_recommendation(result)
@@ -109,7 +133,7 @@ async def quality_scan[InputType, OutputType, TraceType: Trace](  # pyright: ign
         logger.exception("Quality recommendation generation failed")
         recommendation = ""
     quality_result = result.model_copy(update={"recommendation": recommendation})
-    quality_result.print_report(group_by=group_by)
+    quality_result.print_report(group_by=opts["group_by"])
     return quality_result
 
 

--- a/libs/giskard-scan/src/giskard/scan/types.py
+++ b/libs/giskard-scan/src/giskard/scan/types.py
@@ -1,21 +1,15 @@
 from typing import TypedDict
 
 
-class ScanOptions(TypedDict, total=False):
-    """Optional keyword settings for a vulnerability scan.
-
-    Passed to :func:`~giskard.scan.vulnerability.vulnerability_scan` as unpacked
-    keyword arguments. All keys are optional; omitted keys fall back to the
-    defaults documented on each field.
+class SharedScanOptions(TypedDict, total=False):
+    """Optional execution settings shared by quality and vulnerability scans.
 
     Attributes:
-        max_scenarios: Total upper bound on scenarios across all vulnerability
-            generators. ``None`` lets each generator apply its own default.
-            Defaults to ``None``.
+        max_scenarios: Total upper bound on scenarios across all generators.
+            ``None`` lets each generator apply its own default.
         seed: Integer seed used for reproducible scenario generation.
-            Defaults to ``42``.
         group_by: Result annotation key used to group the printed report.
-            ``None`` prints the ungrouped report. Defaults to ``"threat-type"``.
+            ``None`` prints the ungrouped report.
         parallel: When ``True``, run generated scenarios concurrently against
             the target (suite *execution*). Defaults to ``True`` for scans.
             Distinct from scenario *generation*, which always runs generators
@@ -28,11 +22,9 @@ class ScanOptions(TypedDict, total=False):
             the effective cap). When ``parallel=False``, a valid value has no
             effect on scheduling, but invalid values are still rejected.
             Defaults to ``None``.
-        commercial_use: When ``True``, exclude generators whose datasets do not
-            permit commercial use. Defaults to ``False``.
         return_exception: When ``True``, a scenario whose input generation fails
             is recorded as an errored result and the scan continues. When
-            ``False`` (default), the failure propagates and aborts the scan.
+            ``False``, the failure propagates and aborts the scan.
     """
 
     max_scenarios: int | None
@@ -40,20 +32,29 @@ class ScanOptions(TypedDict, total=False):
     group_by: str | None
     parallel: bool
     max_concurrency: int | None
-    commercial_use: bool
     return_exception: bool
 
 
-class ResolvedScanOptions(TypedDict):
-    """``ScanOptions`` with every key resolved (defaults merged in).
+class ScanOptions(SharedScanOptions, total=False):
+    """Optional keyword settings for a vulnerability scan.
 
-    Produced internally by merging caller overrides over the defaults, so all
-    keys are present and can be accessed without ``reportTypedDictNotRequiredAccess``.
+    Extends :class:`SharedScanOptions` with vulnerability-only keys. Prefer
+    passing these keys as explicit keyword arguments to
+    :func:`~giskard.scan.vulnerability.vulnerability_scan`.
 
-    Note: this mirrors :class:`ScanOptions`'s fields rather than subclassing it,
-    because ``total=True`` on a subclass does not re-mark keys inherited from a
-    ``total=False`` parent as required (PEP 655 — ``total`` only sets the default
-    for keys declared in the class body).
+    Attributes:
+        commercial_use: When ``True``, exclude generators whose datasets do not
+            permit commercial use. Defaults to ``False``.
+    """
+
+    commercial_use: bool
+
+
+class ResolvedSharedScanOptions(TypedDict):
+    """Shared scan options with every key resolved.
+
+    Produced by :func:`resolve_scan_options` so all keys are present and can
+    be accessed without ``reportTypedDictNotRequiredAccess``.
     """
 
     max_scenarios: int | None
@@ -61,5 +62,67 @@ class ResolvedScanOptions(TypedDict):
     group_by: str | None
     parallel: bool
     max_concurrency: int | None
-    commercial_use: bool
     return_exception: bool
+
+
+class ResolvedScanOptions(ResolvedSharedScanOptions):
+    """Vulnerability scan options with every key resolved.
+
+    Note: this mirrors :class:`ScanOptions`'s fields rather than subclassing
+    it, because ``total=True`` on a subclass does not re-mark keys inherited
+    from a ``total=False`` parent as required (PEP 655 — ``total`` only sets
+    the default for keys declared in the class body).
+    """
+
+    commercial_use: bool
+
+
+def resolve_scan_options(
+    *,
+    max_scenarios: int | None,
+    seed: int,
+    group_by: str | None,
+    parallel: bool,
+    max_concurrency: int | None,
+    return_exception: bool,
+    commercial_use: bool = False,
+) -> ResolvedScanOptions:
+    """Resolve explicit scan keyword arguments into a complete options dict.
+
+    Parameters
+    ----------
+    max_scenarios : int or None
+        Total upper bound on scenarios across all generators.
+    seed : int
+        Integer seed used for reproducible scenario generation.
+    group_by : str or None
+        Result annotation key used to group the printed report.
+    parallel : bool
+        When ``True``, run generated scenarios concurrently against the target.
+        This is suite *execution*; scenario *generation* always runs generators
+        concurrently in :func:`~giskard.scan.catalog.generate_suite`.
+    max_concurrency : int or None
+        Cap on concurrent scenarios when ``parallel=True``. ``None`` runs all
+        scenarios at once (provider rate limits become the effective cap).
+        When ``parallel=False``, a valid value has no effect on scheduling,
+        but invalid values are still rejected.
+    return_exception : bool
+        When ``True``, record input-generation failures as errored results.
+    commercial_use : bool, optional
+        When ``True``, exclude generators whose datasets do not permit
+        commercial use. Defaults to ``False``.
+
+    Returns
+    -------
+    ResolvedScanOptions
+        Scan options with every key present.
+    """
+    return {
+        "max_scenarios": max_scenarios,
+        "seed": seed,
+        "group_by": group_by,
+        "parallel": parallel,
+        "max_concurrency": max_concurrency,
+        "return_exception": return_exception,
+        "commercial_use": commercial_use,
+    }

--- a/libs/giskard-scan/src/giskard/scan/vulnerability.py
+++ b/libs/giskard-scan/src/giskard/scan/vulnerability.py
@@ -1,5 +1,3 @@
-from typing import Unpack
-
 from giskard.checks import SuiteResult, Target, Trace
 
 from .catalog import generate_suite
@@ -11,7 +9,7 @@ from .generators.goat import GOATAttackScenarioGenerator
 from .generators.huggingface import HuggingFaceDatasetScenarioGenerator
 from .generators.prompt_injection import PromptInjectionScenarioGenerator
 from .registry import SuiteGeneratorRegistry
-from .types import ResolvedScanOptions, ScanOptions
+from .types import resolve_scan_options
 
 VULNERABILITY_GENERATORS = (
     AdversarialScenarioGenerator,
@@ -33,43 +31,78 @@ vulnerability_suite_generator_registry = SuiteGeneratorRegistry()
 for generator in VULNERABILITY_GENERATORS:
     vulnerability_suite_generator_registry.register(generator)
 
-_DEFAULT_SCAN_OPTIONS: ResolvedScanOptions = {
-    "max_scenarios": None,
-    "seed": 42,
-    "group_by": "threat-type",
-    "parallel": True,
-    "max_concurrency": None,
-    "commercial_use": False,
-    "return_exception": False,
-}
-
 
 async def vulnerability_scan[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
     target: Target[InputType, OutputType, TraceType],
     description: str,
     languages: list[str],
+    *,
+    max_scenarios: int | None = None,
+    seed: int = 42,
+    group_by: str | None = "threat-type",
+    parallel: bool = True,
+    max_concurrency: int | None = None,
+    return_exception: bool = False,
     target_mode: TargetMode = "multiturn",
-    **options: Unpack[ScanOptions],
+    commercial_use: bool = False,
 ) -> SuiteResult:
     """Generate and run the standard vulnerability scan suite.
 
     Builds a suite from the vulnerability scenario generator registry, runs it
     against the target, prints the grouped report, and returns the suite result.
 
-    Args:
-        target: Agent or provider target to evaluate.
-        description: Natural-language description of the agent under test.
-        languages: BCP-47 language codes the agent is expected to handle.
-        target_mode: Whether the agent under test supports single-turn or
-            multi-turn conversations. ``"singleturn"`` skips generators that
-            are multi-turn by design and caps turn budgets to 1 on others.
-            Defaults to ``"multiturn"``.
-        **options: Optional scan settings; see :class:`~giskard.scan.types.ScanOptions`.
+    Parameters
+    ----------
+    target : Target
+        Agent or provider target to evaluate.
+    description : str
+        Natural-language description of the agent under test.
+    languages : list of str
+        BCP-47 language codes the agent is expected to handle.
+    max_scenarios : int, optional
+        Total upper bound on scenarios across all vulnerability generators.
+        ``None`` lets each generator apply its own default.
+    seed : int, optional
+        Integer seed used for reproducible scenario generation. Defaults to ``42``.
+    group_by : str, optional
+        Result annotation key used to group the printed report. ``None`` prints
+        the ungrouped report. Defaults to ``"threat-type"``.
+    parallel : bool, optional
+        When ``True`` (default), run generated scenarios concurrently against
+        the target. Pass ``False`` for serial execution. This is suite
+        *execution*; scenario *generation* always runs generators concurrently
+        via :func:`~giskard.scan.catalog.generate_suite`.
+    max_concurrency : int, optional
+        Cap on concurrent scenarios when ``parallel=True``. ``None`` runs all
+        scenarios at once (provider rate limits become the effective cap).
+        When ``parallel=False``, a valid value has no effect on scheduling,
+        but invalid values are still rejected.
+    return_exception : bool, optional
+        When ``True``, a scenario whose input generation fails is recorded as an
+        errored result and the scan continues. When ``False`` (default), the
+        failure propagates and aborts the scan.
+    target_mode : {"singleturn", "multiturn"}, optional
+        Whether the agent under test supports single-turn or multi-turn
+        conversations. ``"singleturn"`` skips generators that are multi-turn by
+        design and caps turn budgets to 1 on others. Defaults to ``"multiturn"``.
+    commercial_use : bool, optional
+        When ``True``, exclude generators whose datasets do not permit
+        commercial use. Defaults to ``False``.
 
-    Returns:
+    Returns
+    -------
+    SuiteResult
         The completed suite result for the vulnerability scan.
     """
-    opts: ResolvedScanOptions = {**_DEFAULT_SCAN_OPTIONS, **options}
+    opts = resolve_scan_options(
+        max_scenarios=max_scenarios,
+        seed=seed,
+        group_by=group_by,
+        parallel=parallel,
+        max_concurrency=max_concurrency,
+        return_exception=return_exception,
+        commercial_use=commercial_use,
+    )
 
     suite = await generate_suite(
         description=description,

--- a/libs/giskard-scan/tests/test_scan_options.py
+++ b/libs/giskard-scan/tests/test_scan_options.py
@@ -1,0 +1,96 @@
+import inspect
+
+import pytest
+from giskard.scan.quality import quality_scan
+from giskard.scan.types import resolve_scan_options
+from giskard.scan.vulnerability import vulnerability_scan
+
+SHARED_SCAN_PARAMETERS = (
+    "max_scenarios",
+    "seed",
+    "group_by",
+    "parallel",
+    "max_concurrency",
+    "return_exception",
+    "target_mode",
+)
+
+SHARED_SCAN_DEFAULTS = (
+    "max_scenarios",
+    "seed",
+    "parallel",
+    "max_concurrency",
+    "return_exception",
+    "target_mode",
+)
+
+
+def test_resolve_scan_options_matches_for_identical_shared_kwargs():
+    quality_opts = resolve_scan_options(
+        max_scenarios=20,
+        seed=7,
+        group_by="custom",
+        parallel=False,
+        max_concurrency=8,
+        return_exception=True,
+    )
+    vulnerability_opts = resolve_scan_options(
+        max_scenarios=20,
+        seed=7,
+        group_by="custom",
+        parallel=False,
+        max_concurrency=8,
+        return_exception=True,
+        commercial_use=False,
+    )
+
+    assert quality_opts == vulnerability_opts
+
+
+def test_scan_entrypoints_expose_shared_explicit_kwargs():
+    quality_params = inspect.signature(quality_scan).parameters
+    vulnerability_params = inspect.signature(vulnerability_scan).parameters
+
+    for name in SHARED_SCAN_PARAMETERS:
+        assert name in quality_params
+        assert name in vulnerability_params
+
+    for name in SHARED_SCAN_DEFAULTS:
+        assert quality_params[name].default == vulnerability_params[name].default
+
+    assert quality_params["group_by"].default == "component"
+    assert vulnerability_params["group_by"].default == "threat-type"
+
+    assert "knowledge_base" in quality_params
+    assert "commercial_use" in vulnerability_params
+    assert "knowledge_base" not in vulnerability_params
+    assert "commercial_use" not in quality_params
+
+
+def test_scan_entrypoints_require_keyword_only_options_after_languages():
+    """Shared options (and scan-specific ones) must not bind positionally.
+
+    Prevents legacy ``vulnerability_scan(target, desc, langs, "singleturn")``
+    from silently binding ``target_mode`` into ``max_scenarios``.
+    """
+    quality_params = inspect.signature(quality_scan).parameters
+    vulnerability_params = inspect.signature(vulnerability_scan).parameters
+
+    for name in SHARED_SCAN_PARAMETERS:
+        assert quality_params[name].kind == inspect.Parameter.KEYWORD_ONLY
+        assert vulnerability_params[name].kind == inspect.Parameter.KEYWORD_ONLY
+
+    assert quality_params["knowledge_base"].kind == inspect.Parameter.KEYWORD_ONLY
+    assert vulnerability_params["commercial_use"].kind == inspect.Parameter.KEYWORD_ONLY
+
+    target = object()
+    description = "desc"
+    languages = ["en"]
+
+    with pytest.raises(TypeError):
+        inspect.signature(vulnerability_scan).bind(
+            target, description, languages, "singleturn"
+        )
+
+    with pytest.raises(TypeError):
+        inspect.signature(quality_scan).bind(target, description, languages, ["doc"])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Stacked helper for [#2578](https://github.com/Giskard-AI/giskard-oss/pull/2578) after [#2679](https://github.com/Giskard-AI/giskard-oss/pull/2679) landed on `main`.

Merges `main` into `feat/garak-scan-integration` and resolves the three content conflicts:

- `quality.py` / `vulnerability.py` — keep #2679’s explicit keyword-only options + `resolve_scan_options()`, preserve #2578’s `DEFAULT_TARGET_MODE` defaults and NumPy docstrings
- `README.md` — keep #2679’s shared scan entrypoints docs and #2578’s third-party scanner docs

Once this merges into `feat/garak-scan-integration`, #2578 should be mergeable with `main` again (conflict simulation against `main` is clean on this branch).

## Related Issue

Unblocks #2578 after #2679.

## Type of Change

- [x] 🥂 Improvement (non-breaking change which improves an existing feature)

## Test plan

- [x] `make format` — clean
- [x] `make check` — clean (ruff, vermin, basedpyright 0 errors, pip-audit, licensecheck)
- [x] `make test-unit PACKAGE=giskard-scan` — `168 passed, 44 skipped, 2 deselected`

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [ ] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been modified)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14720783-d48d-4fc2-a1fc-159c55758c25?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14720783-d48d-4fc2-a1fc-159c55758c25&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

