### PR TITLE
docs(agents): document Cursor Cloud dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,14 @@ giskard-oss — behavioral config for interactive coding assistants with a human
 – Simplicity First: make every change as simple as possible; prefer deleting lines over adding them
 – No Laziness: find root causes; no band-aids, no temporary fixes; senior developer standards
 – Minimal Impact: only touch what's necessary; no side effects; no reformatting untouched lines
+
+## Cursor Cloud specific instructions
+
+Non-obvious context for cloud agents (dependencies are already installed by the startup `uv sync`; `uv` is on `PATH` for login shells via `~/.bashrc`).
+
+– This repo is a `uv` workspace monorepo of pure Python libraries (`libs/giskard-*`). There is no server, daemon, or CLI to start — "running" the product means importing the libraries from Python or running `pytest`. Standard commands live in the root `Makefile` (`make help`).
+– Import namespace is `giskard.<sublib>` (e.g. `import giskard.checks`), not `giskard_checks`.
+– `make setup` includes a `pre-commit-install` step that fails in this environment with `Cowardly refusing to install hooks with core.hooksPath set`. This is expected (the VM sets a global `core.hooksPath`) and does not affect lint/test/build/run. Use `make install` + `make install-tools` instead of full `make setup`; git hooks are not needed to validate work.
+– Lint/test/build/run all work without secrets: `make lint`, `make test-unit [PACKAGE=<lib>]`, and importing the libs. Unit tests exclude anything marked `functional`.
+– Functional/integration tests are excluded by default and require live LLM provider API keys (e.g. `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `ANTHROPIC_API_KEY`); `giskard-scan` may also reach Hugging Face Hub. Do not expect these to run without those secrets and network access.
+– `make check` runs `security` (`pip-audit`) and license checks (`check-licenses`/`check-notices`) that reach the network (PyPI / license metadata); if offline these steps can fail even when the code is fine.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,11 +51,11 @@ giskard-oss — behavioral config for interactive coding assistants with a human
 
 ## Cursor Cloud specific instructions
 
-Non-obvious context for cloud agents (dependencies are already installed by the startup `uv sync`; `uv` is on `PATH` for login shells via `~/.bashrc`).
+Non-obvious context for cloud agents (startup refresh is `make install` then `make install-tools`; `uv` is on `PATH` for login shells via `~/.bashrc`).
 
-– This repo is a `uv` workspace monorepo of pure Python libraries (`libs/giskard-*`). There is no server, daemon, or CLI to start — "running" the product means importing the libraries from Python or running `pytest`. Standard commands live in the root `Makefile` (`make help`).
+– This repo is a `uv` workspace monorepo of pure Python libraries (`libs/giskard-*`). There is no server, daemon, or CLI to start — "running" the product means importing the libraries from Python or running `pytest`. Prefer Makefile targets over raw `uv`/`pytest` (`make help`).
 – Import namespace is `giskard.<sublib>` (e.g. `import giskard.checks`), not `giskard_checks`.
-– `make setup` includes a `pre-commit-install` step that fails in this environment with `Cowardly refusing to install hooks with core.hooksPath set`. This is expected (the VM sets a global `core.hooksPath`) and does not affect lint/test/build/run. Use `make install` + `make install-tools` instead of full `make setup`; git hooks are not needed to validate work.
+– Do not run full `make setup` in this VM: its `pre-commit-install` step fails with `Cowardly refusing to install hooks with core.hooksPath set`. That is expected (global `core.hooksPath`) and harmless — use `make install` + `make install-tools` instead; git hooks are not needed to validate work.
 – Lint/test/build/run all work without secrets: `make lint`, `make test-unit [PACKAGE=<lib>]`, and importing the libs. Unit tests exclude anything marked `functional`.
 – Functional/integration tests are excluded by default and require live LLM provider API keys (e.g. `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `ANTHROPIC_API_KEY`); `giskard-scan` may also reach Hugging Face Hub. Do not expect these to run without those secrets and network access.
 – `make check` runs `security` (`pip-audit`) and license checks (`check-licenses`/`check-notices`) that reach the network (PyPI / license metadata); if offline these steps can fail even when the code is fine.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Sets up and verifies the cloud development environment for the `giskard-oss` `uv` workspace monorepo, and documents non-obvious startup caveats for future cloud agents.

Environment work performed in this session (no product code changed):
- Installed `uv` and ran `make install` + `make install-tools` (deps + ruff/vermin/basedpyright/pre-commit).
- Configured the VM startup update script to:
  ```
  make install
  make install-tools
  ```
  Prefer Makefile targets over raw `uv sync` so deps and pinned tool versions stay in sync with the repo; deliberately omit `make setup` / `pre-commit-install` (fails in this VM because `core.hooksPath` is set globally).
- Verified `make lint`, `make test-unit` (all five libraries), and an end-to-end `giskard.checks` eval.

The only file change is `AGENTS.md`, adding a `## Cursor Cloud specific instructions` section covering:
- Pure-library monorepo — no server/daemon to run; import namespace is `giskard.<sublib>`.
- Prefer Makefile targets; do not run full `make setup` in this VM.
- Lint/test/build/run work without secrets; functional/integration tests need live LLM API keys (and network for Hugging Face Hub in `giskard-scan`).
- `make check` includes network-dependent `pip-audit` and license checks.

## Related Issue

N/A — development environment setup.

## Type of Change

- [x] 📚 Examples / docs / tutorials / dependencies update

## Coding agents

Autonomous agent PR. Title ends with 🤖🤖🤖🤖 per `AUTONOMOUS.md` / PR template.

## Checklist

- [x] I've read the `CODE_OF_CONDUCT.md` document.
- [x] I've read the `CONTRIBUTING.md` guide.
- [ ] I've written tests for all new methods and classes that I created. (N/A — docs only)
- [ ] I've written the docstring in NumPy format for all the methods and classes that I created or modified. (N/A — docs only)
- [ ] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been modified). (N/A — `pyproject.toml` unchanged)

## Verification evidence

```
=== make lint ===
All checks passed!

=== make test-unit (all libs, unit only) ===
giskard-core:   39 passed
giskard-llm:   214 passed, 7 skipped
giskard-agents: 117 passed, 2 skipped
giskard-checks: 764 passed, 4 skipped
giskard-scan:  159 passed

=== hello-world: giskard.checks eval end-to-end ===
[scenario] 'capital-of-france' passed=True duration_ms=15
[suite]    'qa-suite' pass_rate=100%
HELLO WORLD OK: giskard-checks evaluated the agent end-to-end.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc61139a-936a-4501-beed-62901bd86b60?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc61139a-936a-4501-beed-62901bd86b60&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

