### PR TITLE
fix(checks): include readability in the all extra

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -29,6 +29,7 @@ Find a list of packages below
 |✔|click|
 |✔|colorama|
 |✔|cryptography|
+|✔|defusedxml|
 |✔|distro|
 |✔|docstring-parser|
 |✔|fastuuid|
@@ -49,6 +50,7 @@ Find a list of packages below
 |✔|importlib-metadata|
 |✔|jinja2|
 |✔|jiter|
+|✔|joblib|
 |✔|jsonpath-ng|
 |✔|jsonschema|
 |✔|jsonschema-specifications|
@@ -58,6 +60,7 @@ Find a list of packages below
 |✔|markupsafe|
 |✔|mdurl|
 |✔|multidict|
+|✔|nltk|
 |✔|numpy|
 |✔|openai|
 |✔|packaging|
@@ -70,6 +73,7 @@ Find a list of packages below
 |✔|pydantic-core|
 |✔|pydantic-settings|
 |✔|pygments|
+|✔|pyphen|
 |✔|python-dotenv|
 |✔|pyyaml|
 |✔|referencing|
@@ -77,8 +81,10 @@ Find a list of packages below
 |✔|requests|
 |✔|rich|
 |✔|rpds-py|
+|✔|setuptools|
 |✔|sniffio|
 |✔|tenacity|
+|✔|textstat|
 |✔|tiktoken|
 |✔|tokenizers|
 |✔|tqdm|
@@ -192,6 +198,13 @@ Find a list of packages below
 - HomePage:
 - Author: The Python Cryptographic Authority and individual contributors
 - License: Apache-2.0;; BSD-3-Clause
+- Compatible: True
+
+### defusedxml-0.7.1
+
+- HomePage: https://github.com/tiran/defusedxml
+- Author: Christian Heimes
+- License: Python Software Foundation License
 - Compatible: True
 
 ### distro-1.9.0
@@ -334,6 +347,13 @@ Find a list of packages below
 - License: MIT
 - Compatible: True
 
+### joblib-1.5.3
+
+- HomePage:
+- Author: Gael Varoquaux
+- License: BSD-3-Clause
+- Compatible: True
+
 ### jsonpath-ng-1.8.0
 
 - HomePage: https://github.com/h2non/jsonpath-ng
@@ -395,6 +415,13 @@ Find a list of packages below
 - HomePage: https://github.com/aio-libs/multidict
 - Author: Andrew Svetlov
 - License: Apache License 2.0
+- Compatible: True
+
+### nltk-3.10.0
+
+- HomePage: https://www.nltk.org/
+- Author: NLTK Team
+- License: Apache Software License
 - Compatible: True
 
 ### numpy-2.5.0
@@ -481,6 +508,13 @@ Find a list of packages below
 - License: BSD-2-Clause
 - Compatible: True
 
+### pyphen-0.17.2
+
+- HomePage:
+- Author: Guillaume Ayoub
+- License: GNU General Public License v2;; GNU Lesser General Public License v2;; Mozilla Public License 1.1 _MPL 1.1_;; later _GPLv2__;; later _LGPLv2__
+- Compatible: True
+
 ### python-dotenv-1.2.2
 
 - HomePage:
@@ -530,6 +564,13 @@ Find a list of packages below
 - License: MIT
 - Compatible: True
 
+### setuptools-83.0.0
+
+- HomePage:
+- Author: Python Packaging Authority
+- License: MIT
+- Compatible: True
+
 ### sniffio-1.3.1
 
 - HomePage:
@@ -542,6 +583,13 @@ Find a list of packages below
 - HomePage: https://github.com/jd/tenacity
 - Author: Julien Danjou
 - License: Apache Software License
+- Compatible: True
+
+### textstat-0.7.13
+
+- HomePage: https://github.com/textstat/textstat
+- Author: Shivam Bansal, Chaitanya Aggarwal
+- License: MIT
 - Compatible: True
 
 ### tiktoken-0.13.0

--- a/libs/giskard-checks/pyproject.toml
+++ b/libs/giskard-checks/pyproject.toml
@@ -23,7 +23,7 @@ readability = [
     "textstat>=0.7.0",
 ]
 regorus = ["celine-regorus>=0.9.1"]
-all = ["giskard-checks[regorus]"] # Install all optional dependencies
+all = ["giskard-checks[readability,regorus]"] # Install all optional dependencies
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "src"]

--- a/uv.lock
+++ b/uv.lock
@@ -968,6 +968,7 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "celine-regorus" },
+    { name = "textstat" },
 ]
 readability = [
     { name = "textstat" },
@@ -980,7 +981,7 @@ regorus = [
 requires-dist = [
     { name = "celine-regorus", marker = "extra == 'regorus'", specifier = ">=0.9.1" },
     { name = "giskard-agents", editable = "libs/giskard-agents" },
-    { name = "giskard-checks", extras = ["regorus"], marker = "extra == 'all'", editable = "libs/giskard-checks" },
+    { name = "giskard-checks", extras = ["readability", "regorus"], marker = "extra == 'all'", editable = "libs/giskard-checks" },
     { name = "giskard-core", editable = "libs/giskard-core" },
     { name = "jinja2", specifier = ">=3.1.6,<4" },
     { name = "jsonpath-ng", specifier = ">=1.7.0,<2" },


### PR DESCRIPTION
## What

`libs/giskard-checks/pyproject.toml`:

```toml
readability = ["textstat>=0.7.0"]
regorus = ["celine-regorus>=0.9.1"]
all = ["giskard-checks[regorus]"] # Install all optional dependencies
```

`all` omits `readability`, so `pip install giskard-checks[all]` does not install `textstat` and the `Readability` check fails at runtime with "The 'textstat' package is required for the Readability check", despite the comment promising otherwise.

Resolved against the published package:

```
giskard-checks[all]              -> regorus: 1 line,  textstat: 0 lines
giskard-checks[all,readability]  -> regorus: 1 line,  textstat: 1 line
```

Looks like an oversight rather than a decision: `all` landed in #2404, the `readability` extra was added later in #2412, and `all` wasn't updated.

## Fix

```diff
-all = ["giskard-checks[regorus]"] # Install all optional dependencies
+all = ["giskard-checks[readability,regorus]"] # Install all optional dependencies
```

Plus `uv lock` (2 lines) and `make generate-notices`, which `make check` required once textstat entered the `all` extra.

## One thing worth deciding

The notices diff is 48 lines because textstat brings `nltk`, `joblib`, `pyphen`, `defusedxml` and `setuptools` with it, so `[all]` gets noticeably heavier.

There are two defensible fixes and I only picked one:

- **this PR** — fix the extra to match the comment, so `[all]` genuinely means all
- **the alternative** — fix the comment instead, and document that `all` deliberately excludes `readability` to stay light

I went with the first because a check that fails at runtime seems worse than a heavier optional install, but for a project built around "each package carries only the dependencies it needs" the second is a reasonable call. Happy to flip it if you'd prefer.

## Testing

`make check` exits 0. `make test-unit`: 39 / 214 / 117 / 764 / 159 passed across core, llm, agents, checks and scan.

xref: no open PR touches the `all` extra.

## Type of Change

- [x] 🔧 Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I've updated the `uv.lock` running `uv lock`

---

Disclosure: drafted with AI assistance (Claude Code). I reproduced the resolution difference, confirmed the history, and ran the checks myself before submitting.
