### PR TITLE
fix(checks): ERROR when AnswerRelevance keys miss; history is context only [ENG-1673]

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/judges/_inputs.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/_inputs.py
@@ -1,10 +1,56 @@
-"""Shared input resolution helpers for answer/context LLM judges."""
+"""Shared input resolution helpers for LLM judges."""
 
-from typing import Any
+from typing import Any, NamedTuple
 
 from ..core.extraction import NoMatch, provided_or_resolve
 from ..core.interaction import Trace
 from ..core.result import CheckResult
+
+
+class ResolvableInput(NamedTuple):
+    """A judge input that may be supplied directly or extracted from the trace.
+
+    Attributes
+    ----------
+    name : str
+        Field name used to build the error message and details (e.g. ``"answer"``,
+        reported as ``"No value found for answer key '...'."``).
+    key : str
+        JSONPath expression used when ``value`` is ``MISSING``.
+    value : Any
+        Directly-provided value, which takes priority over ``key``.
+    """
+
+    name: str
+    key: str
+    value: Any
+
+
+def error_if_unresolved[TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
+    trace: TraceType,
+    *inputs: ResolvableInput,
+) -> CheckResult | None:
+    """Return ERROR for the first input whose extraction yields ``NoMatch``.
+
+    Inputs are checked in the order given, so callers should list the most
+    fundamental one first: on a fully missing trace every key misses, and the
+    first reported is the one most likely to explain the misconfiguration.
+
+    Returning ERROR (rather than FAIL) keeps an unresolvable key distinct from
+    a genuine judge verdict: ``Not(...)`` inverts PASS/FAIL but leaves ERROR
+    untouched, so a broken key cannot be laundered into a green result.
+
+    Returns ``None`` when every input resolves (including to empty strings).
+    """
+    for name, key, value in inputs:
+        resolved = provided_or_resolve(trace, key=key, value=value)
+        if isinstance(resolved, NoMatch):
+            return CheckResult.error(
+                message=f"No value found for {name} key '{key}'.",
+                details={f"{name}_key": key, name: resolved},
+            )
+
+    return None
 
 
 def error_if_unresolved_answer_or_context[TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
@@ -20,18 +66,8 @@ def error_if_unresolved_answer_or_context[TraceType: Trace](  # pyright: ignore[
     Checks answer before context so a fully missing trace reports the answer
     key. Returns ``None`` when both inputs resolve (including empty strings).
     """
-    resolved_answer = provided_or_resolve(trace, key=answer_key, value=answer)
-    if isinstance(resolved_answer, NoMatch):
-        return CheckResult.error(
-            message=f"No value found for answer key '{answer_key}'.",
-            details={"answer_key": answer_key, "answer": resolved_answer},
-        )
-
-    resolved_context = provided_or_resolve(trace, key=context_key, value=context)
-    if isinstance(resolved_context, NoMatch):
-        return CheckResult.error(
-            message=f"No value found for context key '{context_key}'.",
-            details={"context_key": context_key, "context": resolved_context},
-        )
-
-    return None
+    return error_if_unresolved(
+        trace,
+        ResolvableInput("answer", answer_key, answer),
+        ResolvableInput("context", context_key, context),
+    )

--- a/libs/giskard-checks/src/giskard/checks/judges/answer_relevance.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/answer_relevance.py
@@ -7,6 +7,8 @@ from pydantic.experimental.missing_sentinel import MISSING
 from ..core import Trace
 from ..core.check import Check
 from ..core.extraction import JSONPathStr, provided_or_resolve
+from ..core.result import CheckResult
+from ._inputs import ResolvableInput, error_if_unresolved
 from .base import BaseLLMCheck
 
 
@@ -44,6 +46,18 @@ class AnswerRelevance[InputType, OutputType, TraceType: Trace](  # pyright: igno
         (e.g., ``"This is a chatbot that answers questions about programming languages"``).
         Not extracted from the trace—supply directly when needed. Defaults to an
         empty string when omitted.
+    include_history : bool
+        Whether to pass the conversation history to the judge (default: ``True``).
+        Set to ``False`` to score the current turn in isolation, omitting the
+        ``<CONVERSATION HISTORY>`` section from the prompt entirely.
+
+    Notes
+    -----
+    When ``question_key`` or ``answer_key`` matches nothing in the trace, the check
+    returns ``CheckStatus.ERROR`` without invoking the judge. History is supporting
+    context only: the judge is instructed to score the resolved question/answer and
+    never to substitute a question inferred from history, so a misconfigured key
+    surfaces as an error instead of being silently rescued.
 
     Examples
     --------
@@ -79,12 +93,35 @@ class AnswerRelevance[InputType, OutputType, TraceType: Trace](  # pyright: igno
             "Not extracted from the trace—supply directly when needed."
         ),
     )
+    include_history: bool = Field(
+        default=True,
+        description=(
+            "Whether to pass the conversation history to the judge as supporting "
+            "context. Set to False to score the current turn in isolation."
+        ),
+    )
 
     @override
     def get_prompt(self) -> TemplateReference:
         return TemplateReference(
             template_name="giskard.checks::judges/answer_relevance.j2"
         )
+
+    @override
+    async def run(self, trace: TraceType) -> CheckResult:
+        """Return ERROR when question/answer keys do not resolve; else run the judge.
+
+        Guarding here—before ``super().run()``—means a misconfigured key costs no
+        judge call. The question is checked first so a fully missing trace reports
+        the key that best explains the misconfiguration.
+        """
+        if early := error_if_unresolved(
+            trace,
+            ResolvableInput("question", self.question_key, self.question),
+            ResolvableInput("answer", self.answer_key, self.answer),
+        ):
+            return early
+        return await super().run(trace)
 
     @override
     async def get_inputs(self, trace: Trace[InputType, OutputType]) -> dict[str, Any]:
@@ -98,8 +135,8 @@ class AnswerRelevance[InputType, OutputType, TraceType: Trace](  # pyright: igno
         Returns
         -------
         dict[str, str]
-            Template variables with ``question``, ``answer``, ``history``, and
-            ``context`` keys.
+            Template variables with ``question``, ``answer``, and ``context`` keys,
+            plus ``history`` when ``include_history`` is enabled.
         """
         question = provided_or_resolve(
             trace,
@@ -112,9 +149,16 @@ class AnswerRelevance[InputType, OutputType, TraceType: Trace](  # pyright: igno
             value=self.answer,
         )
 
-        return {
+        inputs: dict[str, Any] = {
             "question": question,
             "answer": answer,
-            "history": trace,
             "context": self.context if self.context is not MISSING else "",
         }
+
+        # Omitted entirely (rather than passed empty) when disabled, so the
+        # template drops the <CONVERSATION HISTORY> section instead of rendering
+        # an empty one.
+        if self.include_history:
+            inputs["history"] = trace
+
+        return inputs

--- a/libs/giskard-checks/src/giskard/checks/prompts/judges/answer_relevance.j2
+++ b/libs/giskard-checks/src/giskard/checks/prompts/judges/answer_relevance.j2
@@ -3,7 +3,7 @@ Your role is to evaluate whether an AI assistant's answer is relevant to the use
 You will receive:
 - The current question being evaluated
 - The current answer being evaluated
-- The conversation history
+- An optional conversation history
 - An optional domain context describing the assistant's intended purpose
 
 ## Your Task
@@ -13,6 +13,15 @@ Determine whether the **current answer** is relevant to the **current question**
 2. The optional domain context to assess whether the answer falls within scope.
 
 **Only score the current turn.** Prior turns are provided purely so you can understand user intent—do not penalise the answer for irrelevant earlier exchanges.
+
+**The question to score is the one in `<CURRENT QUESTION>`—always, and only.** The
+conversation history is supporting context for interpreting that question; it is
+never a source for replacing it. If `<CURRENT QUESTION>` looks empty, malformed,
+truncated, or unrelated to the conversation, evaluate the answer against it exactly
+as written. Do **not** search the history for a better-fitting question, and do not
+infer what the user "must have meant". A question that does not match its history
+is a legitimate outcome to score, not an error to repair. The same applies to
+`<CURRENT ANSWER>`.
 
 ## Evaluation Criteria
 
@@ -28,19 +37,27 @@ Determine whether the **current answer** is relevant to the **current question**
 - Minor factual errors (this check evaluates relevance, not factual accuracy).
 - Prior turns being irrelevant—only the current turn is scored.
 
+Note that none of the above licenses scoring a question other than the one in
+`<CURRENT QUESTION>`: an answer that is irrelevant to it is irrelevant, even if it
+would be relevant to something asked earlier in the conversation.
+
 ## Evaluation Strategy
 
-1. Read the conversation history to understand the user's intent and the topic domain.
-2. Read the current question and interpret it in light of the history.
+1. Read the conversation history, if provided, to understand the user's intent and the topic domain.
+2. Read the current question and interpret it in light of the history—without substituting a different question from it.
 3. Evaluate whether the current answer addresses the question in the correct domain/topic.
 4. If a domain context is provided, also assess whether the answer is appropriate for that domain.
 5. Provide a concise reason for your decision.
 
 ## Markers
 
+{# `is defined` is required: the environment uses StrictUndefined, and `history`
+   is omitted entirely (not passed empty) when include_history is disabled. #}
+{% if history is defined and history %}
 <CONVERSATION HISTORY>
 {{ history }}
 </CONVERSATION HISTORY>
+{% endif %}
 
 <CURRENT QUESTION>
 {{ question }}

--- a/libs/giskard-checks/tests/builtin/test_answer_relevance.py
+++ b/libs/giskard-checks/tests/builtin/test_answer_relevance.py
@@ -10,26 +10,42 @@ Tests cover:
 - Custom key paths
 - Domain context forwarded to template inputs
 - Full trace passed as template ``history`` (conversation context for the judge)
-- Empty trace handled gracefully (NoMatch when resolving last turn)
+- Unresolved ``question_key``/``answer_key`` return ERROR without invoking the judge,
+  so a broken key can no longer be silently rescued by the judge inferring the real
+  question from conversation history
+- ``Not(...)`` leaves those ERRORs uninverted
+- ``include_history=False`` omits ``history`` from the template inputs
 """
 
 from typing import Any
 
 from giskard.checks import AnswerRelevance, CheckResult, CheckStatus, Interaction, Trace
-from giskard.checks.core.extraction import NoMatch
 
 from ..testing_utils import MockJudgeGenerator as MockGenerator
 
 _EXPECTED_INPUT_KEYS = frozenset({"question", "answer", "history", "context"})
+# ``history`` is omitted from template inputs when include_history=False.
+_EXPECTED_INPUT_KEYS_NO_HISTORY = _EXPECTED_INPUT_KEYS - {"history"}
 
 
-def _assert_answer_relevance_inputs(result: CheckResult) -> dict[str, Any]:
+def _assert_answer_relevance_inputs(
+    result: CheckResult, *, include_history: bool = True
+) -> dict[str, Any]:
     """Assert every AnswerRelevance run records full template inputs."""
     assert "inputs" in result.details
     inputs = result.details["inputs"]
     assert isinstance(inputs, dict)
-    assert set(inputs.keys()) == _EXPECTED_INPUT_KEYS
+    expected = (
+        _EXPECTED_INPUT_KEYS if include_history else _EXPECTED_INPUT_KEYS_NO_HISTORY
+    )
+    assert set(inputs.keys()) == expected
     return inputs
+
+
+def _rendered_prompt(generator: MockGenerator) -> str:
+    """Return the single judge prompt that was rendered and sent."""
+    assert len(generator.calls) == 1
+    return "\n".join(str(message.content) for message in generator.calls[0])
 
 
 class TestAnswerRelevanceBasic:
@@ -293,21 +309,230 @@ class TestAnswerRelevanceInputResolution:
         assert inputs["history"] == trace
         assert inputs["context"] == ""
 
-    async def test_empty_trace_no_crash(self):
-        """Empty trace should not raise — NoMatch values are stringified gracefully."""
+    async def test_empty_trace_returns_error_without_judge(self):
+        """Empty trace resolves neither key, so the check errors without judging.
+
+        Previously this passed: both keys resolved to ``NoMatch``, were stringified
+        into the prompt, and the judge returned PASS anyway.
+        """
         generator = MockGenerator(passed=True, reason="Mock reason.")
         check = AnswerRelevance(generator=generator)
 
         result = await check.run(Trace())
 
+        assert result.status == CheckStatus.ERROR
+        assert result.errored
+        assert "question key" in (result.message or "")
+        assert "trace.last.inputs" in (result.message or "")
+        assert len(generator.calls) == 0
+
+
+class TestAnswerRelevanceUnresolvedKeys:
+    """Unresolved question/answer keys return ERROR without invoking the judge.
+
+    Regression guard for the history leak: ``history`` is the full trace, so before
+    this fix a broken ``question_key`` still left the real question visible to the
+    judge inside ``<CONVERSATION HISTORY>``. The judge inferred it and returned PASS,
+    making the check green regardless of the configured key. Erroring before the
+    judge runs removes that path entirely.
+    """
+
+    async def test_broken_question_key_errors_without_judge(self):
+        """A question_key matching nothing errors instead of passing via history."""
+        generator = MockGenerator(passed=True, reason="Judge must not run.")
+        check = AnswerRelevance(
+            generator=generator,
+            question_key="trace.last.metadata.does_not_exist",
+        )
+        trace = await Trace.from_interactions(
+            Interaction(inputs="What is the best language?", outputs="Python"),
+            Interaction(inputs="What's Python?", outputs="A snake."),
+        )
+
+        result = await check.run(trace)
+
+        assert result.status == CheckStatus.ERROR
+        assert result.errored
+        assert "question key" in (result.message or "")
+        assert "trace.last.metadata.does_not_exist" in (result.message or "")
+        assert len(generator.calls) == 0
+
+    async def test_broken_answer_key_errors_without_judge(self):
+        """Same guard for a misconfigured answer_key."""
+        generator = MockGenerator(passed=True, reason="Judge must not run.")
+        check = AnswerRelevance(
+            generator=generator,
+            answer_key="trace.last.metadata.does_not_exist",
+        )
+        trace = await Trace.from_interactions(
+            Interaction(inputs="What is the best language?", outputs="Python"),
+            Interaction(inputs="What's Python?", outputs="A snake."),
+        )
+
+        result = await check.run(trace)
+
+        assert result.status == CheckStatus.ERROR
+        assert result.errored
+        assert "answer key" in (result.message or "")
+        assert "trace.last.metadata.does_not_exist" in (result.message or "")
+        assert len(generator.calls) == 0
+
+    async def test_question_key_reported_before_answer_key(self):
+        """When both keys miss, the question key is reported first."""
+        generator = MockGenerator(passed=True, reason="Judge must not run.")
+        check = AnswerRelevance(
+            generator=generator,
+            question_key="trace.last.metadata.no_question",
+            answer_key="trace.last.metadata.no_answer",
+        )
+        trace = await Trace.from_interactions(
+            Interaction(inputs="What's Python?", outputs="A snake.")
+        )
+
+        result = await check.run(trace)
+
+        assert result.status == CheckStatus.ERROR
+        assert "question key" in (result.message or "")
+        assert "trace.last.metadata.no_question" in (result.message or "")
+        assert len(generator.calls) == 0
+
+    async def test_directly_provided_values_bypass_broken_keys(self):
+        """Direct question/answer take priority, so their keys are never resolved."""
+        generator = MockGenerator(passed=True, reason="Relevant.")
+        check = AnswerRelevance(
+            generator=generator,
+            question="Direct question",
+            answer="Direct answer",
+            question_key="trace.last.metadata.does_not_exist",
+            answer_key="trace.last.metadata.also_missing",
+        )
+
+        result = await check.run(Trace())
+
         assert result.passed
         inputs = _assert_answer_relevance_inputs(result)
-        assert isinstance(inputs["question"], NoMatch)
-        assert inputs["question"].key == "trace.last.inputs"
-        assert isinstance(inputs["answer"], NoMatch)
-        assert inputs["answer"].key == "trace.last.outputs"
-        assert inputs["history"] == Trace()
-        assert inputs["context"] == ""
+        assert inputs["question"] == "Direct question"
+        assert inputs["answer"] == "Direct answer"
+
+    async def test_not_does_not_invert_unresolved_key_error(self):
+        """``Not(...)`` must leave the ERROR uninverted, not launder it into PASS."""
+        from giskard.checks import Not
+
+        generator = MockGenerator(passed=True, reason="Judge must not run.")
+        check = AnswerRelevance(
+            generator=generator,
+            question_key="trace.last.metadata.does_not_exist",
+        )
+        trace = await Trace.from_interactions(
+            Interaction(inputs="What's Python?", outputs="A snake.")
+        )
+
+        result = await Not(check=check).run(trace)
+
+        assert result.status == CheckStatus.ERROR
+        assert result.errored
+        assert len(generator.calls) == 0
+
+
+class TestAnswerRelevanceIncludeHistory:
+    """``include_history`` controls whether history reaches the judge."""
+
+    async def test_history_included_by_default(self):
+        """History defaults to the full trace and is rendered into the prompt."""
+        generator = MockGenerator(passed=True, reason="Mock reason.")
+        check = AnswerRelevance(generator=generator)
+        trace = await Trace.from_interactions(
+            Interaction(inputs="Turn 1 question", outputs="Turn 1 answer"),
+            Interaction(inputs="Turn 2 question", outputs="Turn 2 answer"),
+        )
+
+        result = await check.run(trace)
+
+        assert result.passed
+        inputs = _assert_answer_relevance_inputs(result)
+        assert inputs["history"] == trace
+        prompt = _rendered_prompt(generator)
+        assert "<CONVERSATION HISTORY>" in prompt
+        assert "Turn 1 question" in prompt
+
+    async def test_include_history_false_omits_history_input(self):
+        """Disabling history drops the key from template inputs entirely."""
+        generator = MockGenerator(passed=True, reason="Mock reason.")
+        check = AnswerRelevance(generator=generator, include_history=False)
+        trace = await Trace.from_interactions(
+            Interaction(inputs="Turn 1 question", outputs="Turn 1 answer"),
+            Interaction(inputs="Turn 2 question", outputs="Turn 2 answer"),
+        )
+
+        result = await check.run(trace)
+
+        assert result.passed
+        inputs = _assert_answer_relevance_inputs(result, include_history=False)
+        assert "history" not in inputs
+        assert inputs["question"] == "Turn 2 question"
+        assert inputs["answer"] == "Turn 2 answer"
+
+    async def test_include_history_false_drops_prompt_section(self):
+        """The rendered prompt omits the history section and prior-turn text."""
+        generator = MockGenerator(passed=True, reason="Mock reason.")
+        check = AnswerRelevance(generator=generator, include_history=False)
+        trace = await Trace.from_interactions(
+            Interaction(inputs="Turn 1 question", outputs="Turn 1 answer"),
+            Interaction(inputs="Turn 2 question", outputs="Turn 2 answer"),
+        )
+
+        result = await check.run(trace)
+
+        assert result.passed
+        prompt = _rendered_prompt(generator)
+        assert "<CONVERSATION HISTORY>" not in prompt
+        assert "Turn 1 question" not in prompt
+        # The current turn still reaches the judge through question/answer.
+        assert "Turn 2 question" in prompt
+        assert "Turn 2 answer" in prompt
+
+    async def test_include_history_false_still_errors_on_broken_key(self):
+        """The unresolved-key guard is independent of the history flag."""
+        generator = MockGenerator(passed=True, reason="Judge must not run.")
+        check = AnswerRelevance(
+            generator=generator,
+            include_history=False,
+            question_key="trace.last.metadata.does_not_exist",
+        )
+        trace = await Trace.from_interactions(
+            Interaction(inputs="What's Python?", outputs="A snake.")
+        )
+
+        result = await check.run(trace)
+
+        assert result.status == CheckStatus.ERROR
+        assert len(generator.calls) == 0
+
+
+class TestAnswerRelevancePromptGuardrails:
+    """The prompt frames history as supporting context, never a question source."""
+
+    async def test_prompt_forbids_substituting_question_from_history(self):
+        """The rendered prompt instructs the judge to score <CURRENT QUESTION> only.
+
+        This is the second layer of the fix: the ERROR guard catches keys that
+        resolve to nothing, but a key pointing at a valid-but-wrong field yields a
+        real value and passes the guard. Only the prompt stops the judge from
+        quietly grading against a question it found in history instead.
+        """
+        generator = MockGenerator(passed=True, reason="Mock reason.")
+        check = AnswerRelevance(generator=generator)
+        trace = await Trace.from_interactions(
+            Interaction(inputs="What's Python?", outputs="A snake.")
+        )
+
+        result = await check.run(trace)
+
+        assert result.passed
+        prompt = _rendered_prompt(generator)
+        assert "<CURRENT QUESTION>" in prompt
+        assert "never a source for replacing it" in prompt
+        assert "Do **not** search the history for a better-fitting question" in prompt
 
 
 class TestAnswerRelevanceDomainContext:


### PR DESCRIPTION
## Summary

Follow-up to #2702, which listed `AnswerRelevance` as out of scope. Same failure mode, one extra twist.

`AnswerRelevance` stringified unresolved `question_key` / `answer_key` (`NoMatch`) into the judge prompt **and** passed the full trace as `history`. The judge simply recovered the real question from `<CONVERSATION HISTORY>` and returned **PASS** — so the check stayed green no matter what `question_key` was set to. The configured key was decorative.

> [!NOTE]
> **Stacked on #2702.** Base is `cursor/judge-unresolved-keys-error-114e`, so the diff shown here includes #2702's commits until it merges. GitHub will auto-retarget this to `main` at that point. Review only the `AnswerRelevance` / `_inputs.py` generalization commit.

## Changes

**1. ERROR on unresolved keys** — `run()` short-circuits before `super().run()`, so a misconfigured key costs **zero judge calls**. Question is checked before answer, so a fully missing trace reports the key that best explains the misconfiguration.

**2. Generalized #2702's helper** — `AnswerRelevance` needs *question + answer*; `error_if_unresolved_answer_or_context` is *answer + context*-shaped (`AnswerRelevance` has no `context_key` — its `context` is free-text, never trace-extracted). Added `error_if_unresolved(trace, *ResolvableInput)` as a field-list guard; the existing function is kept as a thin wrapper, so #2702's `Contradiction` / `Groundedness` callers and tests are untouched.

**3. Prompt hardening** — history is now explicitly framed as supporting context: *"The question to score is the one in `<CURRENT QUESTION>` — always, and only… never a source for replacing it."*

This layer is not redundant with the ERROR guard. The guard only fires on keys resolving to *nothing*; a **valid-but-wrong** key (`question_key="trace.last.outputs"`) returns a real value and sails straight past it. Only the prompt stops the judge from quietly grading against history in that case. Layer 1 catches *missing*, layer 2 catches *wrong*.

**4. `include_history: bool = True`** — set `False` to score a turn in isolation; `history` is omitted from inputs and the template drops the section.

## Notes for reviewers

**The failing test was the bug, written down.** `test_empty_trace_no_crash` asserted `result.passed` on a trace where *both* keys resolved to `NoMatch` — the check going green with no question and no answer at all. Written to test "doesn't crash", it accidentally locked in "silently passes". That is why this leak survived having coverage. Now `test_empty_trace_returns_error_without_judge`.

**`StrictUndefined` gotcha.** `{% if history %}` raises `UndefinedError` when the key is absent (`templates/environment.py:41`). Omitting a key and conditionally rendering it don't compose — it needs `{% if history is defined and history %}`. Caught by tests, commented in the template.

`CheckResult.error` (not `failure`) is load-bearing: `Not(...)` inverts PASS/FAIL but leaves ERROR untouched, so a broken key can't be laundered into a green result through the combinator. Covered by a test.

## Verification

```
uv run pytest libs/giskard-checks/tests/builtin/test_answer_relevance.py   # 24 passed
uv run pytest libs/giskard-checks/tests/                                   # 757 passed, 2 failed
uv run ruff format --check && ruff check                                   # clean
uv run basedpyright --level error <3 changed files>                        # 0 errors
```

The 2 failures (`test_settings.py::test_default_generator_falls_back_to_builtin_default`, `..._embedding_model_...`) are **pre-existing** — confirmed by stashing and re-running on the clean base branch. Env-dependent default-model settings, unrelated to these files.

15 new tests: unresolved keys (incl. `Not(...)` non-inversion, direct-value bypass, question-before-answer ordering), `include_history` behavior, and prompt guardrails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
