### PR TITLE
chore(deps): require giskard-llm>=1.0.0b6 in direct dependents

### DIFF
--- a/libs/giskard-agents/pyproject.toml
+++ b/libs/giskard-agents/pyproject.toml
@@ -7,7 +7,7 @@ license = { text = "MIT" }
 authors = [{ name = "Giskard R&D", email = "rnd@giskard.ai" }]
 requires-python = ">=3.12"
 dependencies = [
-    "giskard-llm>=1.0.0a1,<2",
+    "giskard-llm>=1.0.0b6,<2",
     "pydantic>=2.11.0,<3",
     "griffe>=1.7.0,<3",
     "typing-extensions>=4.14.0,<5",
@@ -19,11 +19,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-openai = ["giskard-llm[openai]>=1.0.0a1,<2"]
-google = ["giskard-llm[google]>=1.0.0a1,<2"]
-anthropic = ["giskard-llm[anthropic]>=1.0.0a1,<2"]
+openai = ["giskard-llm[openai]>=1.0.0b6,<2"]
+google = ["giskard-llm[google]>=1.0.0b6,<2"]
+anthropic = ["giskard-llm[anthropic]>=1.0.0b6,<2"]
 litellm = ["litellm>=1.83.0,<2"]
-all = ["giskard-llm[all]>=1.0.0a1,<2"]
+all = ["giskard-llm[all]>=1.0.0b6,<2"]
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,10 @@ requires-python = ">=3.12"
 
 [project.optional-dependencies]
 # Native LLM providers
-openai = ["giskard-llm[openai]>=1.0.0b4,<2"]
-google = ["giskard-llm[google]>=1.0.0b4,<2"]
-anthropic = ["giskard-llm[anthropic]>=1.0.0b4,<2"]
-azure = ["giskard-llm[azure]>=1.0.0b4,<2"]
+openai = ["giskard-llm[openai]>=1.0.0b6,<2"]
+google = ["giskard-llm[google]>=1.0.0b6,<2"]
+anthropic = ["giskard-llm[anthropic]>=1.0.0b6,<2"]
+azure = ["giskard-llm[azure]>=1.0.0b6,<2"]
 
 # External LLM providers
 litellm = ["giskard-agents[litellm]>=1.0.2b4,<2"]
@@ -44,7 +44,7 @@ garak = ["giskard-scan[garak]>=1.0.0b2,<2"] # Heavy dep, not included by default
 deepteam = ["giskard-scan[deepteam]>=1.0.0b2,<2"] # Heavy dep, not included by default
 
 # Aggregated packages
-all-llms = ["giskard-llm[all]>=1.0.0b4,<2"] # Install all native LLM providers
+all-llms = ["giskard-llm[all]>=1.0.0b6,<2"] # Install all native LLM providers
 all-checks = ["giskard-checks[all]>=1.0.2b4,<2"] # Install all optional checks dependencies
 full = ["giskard[all-llms,all-checks,scan,litellm]"]
 


### PR DESCRIPTION
## Context

`giskard-llm` `1.0.0b6` was released via [run 31069933410](https://github.com/Giskard-AI/giskard-oss/actions/runs/31069933410) (success, pushed to PyPI, tagged `giskard-llm/v1.0.0b6`).

Direct dependents still declared stale lower bounds, so a PyPI consumer could resolve an old `giskard-llm` missing the fixes shipped since:

- `fix(google): convert Pydantic response_format to the Interactions SDK TextResponseFormatParam` (#2648)
- `fix(llm): warn on unknown Anthropic params; detect bare refusals` (#2647)
- `fix(llm): use .text not .content in _validate_messages to avoid AttributeError on list content` (#2608)

Notably `libs/giskard-agents` was pinned at `>=1.0.0a1` — an **alpha** bound, which allowed resolving a pre-beta `giskard-llm`.

## Change

Bumped every direct `giskard-llm` reference, including the provider extras (each carries its own independent bound):

**`libs/giskard-agents/pyproject.toml`** — `>=1.0.0a1` → `>=1.0.0b6`
- base `giskard-llm` dependency
- `openai`, `google`, `anthropic`, `all` extras

**`pyproject.toml`** (root `giskard` umbrella) — `>=1.0.0b4` → `>=1.0.0b6`
- `openai`, `google`, `anthropic`, `azure`, `all-llms` extras

Upper bound `<2` unchanged throughout.

## Out of scope

- `giskard-checks` and `giskard-scan` have no direct `giskard-llm` dependency.
- Other bounds in the root umbrella (`giskard-agents[litellm]`, `giskard-checks`, `giskard-scan`) are left alone — they follow their own release cycles.

## Verification

- `uv lock --check` — lockfile already consistent, no lock changes needed
- `basedpyright --level error` on `giskard-agents` + `giskard-llm` — 0 errors
- `ruff check libs/` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)