### PR TITLE
chore(deps): require giskard-checks>=1.0.2b6 in direct dependents

### DIFF
--- a/libs/giskard-scan/pyproject.toml
+++ b/libs/giskard-scan/pyproject.toml
@@ -7,7 +7,7 @@ license = { text = "Apache Software License 2.0" }
 authors = [{ name = "Giskard R&D", email = "rnd@giskard.ai" }]
 requires-python = ">=3.12"
 dependencies = [
-    "giskard-checks>=1.0.2b3,<2",
+    "giskard-checks>=1.0.2b6,<2",
     "giskard-agents>=1.0.2b6,<2",
     "numpy>=2.4.1,<3",
     "huggingface-hub>=1.11.0,<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 
-dependencies = ["giskard-checks>=1.0.2b4,<2"]
+dependencies = ["giskard-checks>=1.0.2b6,<2"]
 
 requires-python = ">=3.12"
 
@@ -34,7 +34,7 @@ azure = ["giskard-llm[azure]>=1.0.0b6,<2"]
 litellm = ["giskard-agents[litellm]>=1.0.2b6,<2"]
 
 # Optional checks dependencies
-regorus = ["giskard-checks[regorus]>=1.0.2b4,<2"]
+regorus = ["giskard-checks[regorus]>=1.0.2b6,<2"]
 
 # Optional giskard libs
 scan = ["giskard-scan>=1.0.0b2,<2"]
@@ -45,7 +45,7 @@ deepteam = ["giskard-scan[deepteam]>=1.0.0b2,<2"] # Heavy dep, not included by d
 
 # Aggregated packages
 all-llms = ["giskard-llm[all]>=1.0.0b6,<2"] # Install all native LLM providers
-all-checks = ["giskard-checks[all]>=1.0.2b4,<2"] # Install all optional checks dependencies
+all-checks = ["giskard-checks[all]>=1.0.2b6,<2"] # Install all optional checks dependencies
 full = ["giskard[all-llms,all-checks,scan,litellm]"]
 
 [project.urls]


### PR DESCRIPTION
## Context

`giskard-checks` `1.0.2b6` was released via [run 31070416694](https://github.com/Giskard-AI/giskard-oss/actions/runs/31070416694) (success, pushed to PyPI, tagged `giskard-checks/v1.0.2b6`).

Direct dependents still declared stale lower bounds, so a PyPI consumer could resolve an old `giskard-checks` missing a substantial batch of fixes, including:

- `fix(checks): structural unevaluable outcomes return ERROR (not silent-green)` (#2693)
- `fix(checks): dot-wildcard/multi-field JSONPath returns scalar vs list depending on match count` (#2605)
- `fix(checks): descendants JSONPath always returns a list` (#2644)
- `fix(checks): include readability in the all extra` (#2705)
- `fix(checks): skip regorus extra on platforms without a wheel` (#2646)

## Change

| File | Reference | Was | Now |
|---|---|---|---|
| `libs/giskard-scan/pyproject.toml` | base dep | `>=1.0.2b3,<2` | `>=1.0.2b6,<2` |
| `pyproject.toml` | base dep | `>=1.0.2b4,<2` | `>=1.0.2b6,<2` |
| `pyproject.toml` | `regorus` extra | `>=1.0.2b4,<2` | `>=1.0.2b6,<2` |
| `pyproject.toml` | `all-checks` extra | `>=1.0.2b4,<2` | `>=1.0.2b6,<2` |

Note that `giskard-checks` is the root umbrella's **base dependency**, so this bump applies to every `pip install giskard`, not only opt-in extras. That matters here because #2705 (readability in the `all` extra) and #2646 (regorus platform markers) change what actually gets installed.

## Verification

- `uv lock --check` — lockfile already consistent, no lock changes needed
- `basedpyright --level error` on `giskard-checks` — 0 errors
- `ruff check libs/` — passes

## Remaining in the release chain

`giskard-scan` is the last lib still unreleased. Once it ships, the root umbrella's `scan` / `garak` / `deepteam` extras (currently `>=1.0.0b2`) will need the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)