### PR TITLE
fix(giskard-checks): catch TimeoutError in RegexMatching.run()

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
@@ -457,6 +457,14 @@ class RegexMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignore
 
         try:
             matched = regex.search(pattern, text, timeout=self.match_timeout_seconds)
+        except TimeoutError:
+            return CheckResult.error(
+                message=(
+                    f"Regex matching exceeded timeout of "
+                    f"{self.match_timeout_seconds}s for pattern '{pattern}'."
+                ),
+                details=details,
+            )
         except regex.error as e:
             return CheckResult.error(
                 message=f"Invalid regex pattern '{pattern}': {str(e)}",

--- a/libs/giskard-checks/tests/builtin/test_regex_matching.py
+++ b/libs/giskard-checks/tests/builtin/test_regex_matching.py
@@ -368,5 +368,7 @@ async def test_regex_redos_bounded_by_timeout() -> None:
         pattern="(x+)+$",
         match_timeout_seconds=0.5,
     )
-    with pytest.raises(TimeoutError):
-        _ = await check.run(Trace())
+    result = await check.run(Trace())
+    assert result.status == CheckStatus.ERROR
+    assert result.message is not None
+    assert "timeout" in result.message.lower()


### PR DESCRIPTION
## Description

`RegexMatching.run()` called `regex.search(pattern, text, timeout=self.match_timeout_seconds)` but only caught `regex.error`. When the search hits its timeout, the `regex` library raises a bare `TimeoutError`, which was left uncaught. That exception then propagates up through `TestCaseRunner._run_check()` and, since `Scenario.run()` defaults to `return_exception=False`, aborts scenario execution entirely instead of surfacing as a normal check result.

This behavior was introduced intentionally in #2381 (which added the timeout to mitigate ReDoS) — the commit explicitly chose to let `TimeoutError` propagate, and the regression test was written to assert that (`pytest.raises(TimeoutError)`). This PR changes that: a timeout now returns `CheckResult.error` with a clear message, consistent with how invalid regex patterns are already handled in the same function.

### Fix
- `RegexMatching.run()` now catches `TimeoutError` in addition to `regex.error` and returns `CheckResult.error`.

### Tests
- Updated `test_regex_redos_bounded_by_timeout` to assert the graceful `CheckResult.error` outcome instead of asserting the propagating exception. Verified red (fails against pre-fix code with raw `TimeoutError`) → green.
- Full `giskard-checks` suite: 805 passed, 4 skipped.
- `basedpyright --level error` on touched files: 0 errors.

## Related Issue

Reported in [GHSA-7rwv-f9p2-g8rm](https://github.com/Giskard-AI/giskard-oss/security/advisories/GHSA-7rwv-f9p2-g8rm). Reclassified from security advisory to bug fix: `giskard-checks` is a testing framework where the regex pattern is authored by the person writing the test, not supplied by an untrusted third party at runtime, so there's no trust boundary being crossed. The underlying inconsistency (one exception type from `regex.search` caught, its sibling not) is still worth fixing on its own merits.

## Type of Change

- [x] 🔧 Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I've read the `CODE_OF_CONDUCT.md` document.
- [x] I've read the `CONTRIBUTING.md` guide.
- [x] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in NumPy format for all the methods and classes that I created or modified. (n/a — no new public methods/classes)
- [ ] I've updated the `uv.lock` running `uv lock`. (n/a — no `pyproject.toml` changes)