### PR TITLE
fix(checks): AllOf no longer short-circuits on SKIP

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/builtin/composition.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/composition.py
@@ -14,8 +14,9 @@ class AllOf[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportM
     """Passes only when **all** inner checks pass (short-circuits on first failure).
 
     Runs each check in order. The first failing or erroring check stops
-    evaluation and its result is returned immediately. If all checks pass,
-    a combined success result is returned.
+    evaluation and its result is returned immediately. Skipped checks do not
+    stop evaluation. If all checks pass, a combined success result is returned;
+    if every check was skipped, a skip result is returned.
 
     Attributes
     ----------
@@ -40,6 +41,8 @@ class AllOf[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportM
     async def run(self, trace: TraceType) -> CheckResult:
         """Run all checks in order, short-circuiting on the first failure.
 
+        Skipped checks are not treated as failures and do not stop evaluation.
+
         Parameters
         ----------
         trace : TraceType
@@ -48,16 +51,34 @@ class AllOf[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportM
         Returns
         -------
         CheckResult
-            The first non-passing result, or a combined success if all pass.
+            The first failing or erroring result, a skip if every check was
+            skipped, or a combined success otherwise.
         """
         passed_messages: list[str] = []
+        skipped_messages: list[str] = []
+        all_skipped = True
 
         for check in self.checks:
             result = await check.run(trace)
+            if result.skipped:
+                if result.message:
+                    skipped_messages.append(result.message)
+                continue
             if not result.passed:
                 return result
+            all_skipped = False
             if result.message:
                 passed_messages.append(result.message)
+
+        if all_skipped and self.checks:
+            return CheckResult.skip(
+                message="All checks were skipped."
+                + (
+                    f" Details: {'; '.join(skipped_messages)}"
+                    if skipped_messages
+                    else ""
+                ),
+            )
 
         return CheckResult.success(
             message="; ".join(passed_messages)

--- a/libs/giskard-checks/tests/builtin/test_composition.py
+++ b/libs/giskard-checks/tests/builtin/test_composition.py
@@ -116,6 +116,38 @@ class TestAllOf:
         assert result.status == CS.ERROR
         assert result.errored
 
+    async def test_skip_then_fail_returns_failure(self):
+        """A skipped check does not mask a later failure."""
+        check = AllOf(checks=[_skip_fn_check("skipped"), _failing_fn_check("boom")])
+        result = await check.run(Trace())
+
+        assert result.failed
+        assert "boom" in (result.message or "")
+
+    async def test_skip_then_pass_returns_success(self):
+        """A skipped check does not prevent an overall pass."""
+        check = AllOf(checks=[_skip_fn_check("skipped"), _passing_fn_check("ok")])
+        result = await check.run(Trace())
+
+        assert result.passed
+        assert "ok" in (result.message or "")
+
+    async def test_all_skipped_returns_skip(self):
+        """When every check is skipped, the result is a skip."""
+        check = AllOf(checks=[_skip_fn_check("a"), _skip_fn_check("b")])
+        result = await check.run(Trace())
+
+        assert result.status == CS.SKIP
+        assert result.skipped
+
+    async def test_skip_then_error_returns_error(self):
+        """An erroring check after a skip still short-circuits."""
+        check = AllOf(checks=[_skip_fn_check("skipped"), _error_fn_check("boom")])
+        result = await check.run(Trace())
+
+        assert result.status == CS.ERROR
+        assert result.errored
+
     async def test_single_check_pass(self):
         """Single passing check returns success."""
         check = AllOf(checks=[_passing_fn_check("only")])

--- a/libs/giskard-checks/tests/builtin/test_composition.py
+++ b/libs/giskard-checks/tests/builtin/test_composition.py
@@ -133,12 +133,26 @@ class TestAllOf:
         assert "ok" in (result.message or "")
 
     async def test_all_skipped_returns_skip(self):
-        """When every check is skipped, the result is a skip."""
+        """When every check is skipped, the result is a skip with composed details."""
         check = AllOf(checks=[_skip_fn_check("a"), _skip_fn_check("b")])
         result = await check.run(Trace())
 
         assert result.status == CS.SKIP
         assert result.skipped
+        assert result.message == "All checks were skipped. Details: a; b"
+
+    async def test_all_skipped_without_messages(self):
+        """All-skipped with empty inner messages omits the Details suffix."""
+
+        async def _skip_no_msg(trace: Trace[Any, Any]) -> CheckResult:
+            return CheckResult.skip()
+
+        check = AllOf(checks=[FnCheck(fn=_skip_no_msg), FnCheck(fn=_skip_no_msg)])
+        result = await check.run(Trace())
+
+        assert result.status == CS.SKIP
+        assert result.skipped
+        assert result.message == "All checks were skipped."
 
     async def test_skip_then_error_returns_error(self):
         """An erroring check after a skip still short-circuits."""


### PR DESCRIPTION
## Problem

`AllOf.run()` short-circuited on `if not result.passed`, so a SKIP from any inner check ended the loop and was returned as the composite result — masking a real FAIL from a later check.

## Behavior change

- SKIP no longer short-circuits: evaluation continues with the remaining checks.
- FAIL and ERROR still short-circuit and are returned immediately.
- SKIP is returned only when *every* inner check skipped.
- All-pass-with-some-skips now returns PASS (with the passing checks' messages).

This mirrors the tri-state `all_skipped` handling already used by the sibling `AnyOf`.

## Tests

Four cases added to `TestAllOf`: skip+fail → FAIL, skip+pass → PASS, all-skipped → SKIP, skip+error → ERROR. Full giskard-checks unit suite passes (798 passed, 4 skipped), plus `make format && make check`.

Closes #2723

🤖 Generated with [Claude Code](https://claude.com/claude-code)