### PR TITLE
refactor(checks)!: drop builtin judge re-exports

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
@@ -1,16 +1,5 @@
 """Built-in check implementations and helpers."""
 
-# Import judge checks from new location and re-export for backward compatibility
-from ..judges import (
-    AnswerRelevance,
-    BaseLLMCheck,
-    Conformity,
-    Groundedness,
-    LLMCheckResult,
-    LLMJudge,
-    Toxicity,
-)
-
 # Import comparison checks (staying in builtin)
 from .comparison import (
     Equals,
@@ -47,12 +36,5 @@ __all__ = [
     "LessThanEquals",
     "GreaterThan",
     "GreaterThanEquals",
-    "AnswerRelevance",
-    "Groundedness",
-    "Conformity",
-    "LLMJudge",
     "SemanticSimilarity",
-    "Toxicity",
-    "BaseLLMCheck",
-    "LLMCheckResult",
 ]


### PR DESCRIPTION
Closes #2729

Implements Option 1 from the issue: delete the backward-compatibility shim in `giskard.checks.builtin` rather than keeping a deprecated alias.

## What changed

`libs/giskard-checks/src/giskard/checks/builtin/__init__.py` no longer re-imports the judge checks from `giskard.checks.judges`, and the corresponding `__all__` entries are removed. The canonical home (`giskard.checks.judges`, re-exported from `giskard.checks`) is untouched.

## Removed import paths (for release notes)

These no longer resolve:

- `giskard.checks.builtin.AnswerRelevance`
- `giskard.checks.builtin.BaseLLMCheck`
- `giskard.checks.builtin.Conformity`
- `giskard.checks.builtin.Groundedness`
- `giskard.checks.builtin.LLMCheckResult`
- `giskard.checks.builtin.LLMJudge`
- `giskard.checks.builtin.Toxicity`

Migration: import from `giskard.checks` (or `giskard.checks.judges`) instead.

```python
# before
from giskard.checks.builtin import Groundedness, LLMJudge

# after
from giskard.checks import Groundedness, LLMJudge
```

## Internal usages

None. A repo-wide grep across `src`, `tests`, docs and examples found no internal import of these symbols through `giskard.checks.builtin` — every call site already uses the canonical path. No migration commits were needed.

## Verification

- `make format && make check` — green (ruff, vermin, basedpyright 0 errors, pip-audit, licensecheck)
- `uv run pytest libs/giskard-checks/tests -q -m "not functional"` — 794 passed, 4 skipped

Out of scope: check parameter renames (#2728) are a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)