### PR TITLE
chore(deps): cap pydantic <2.14 as temporary stopgap

### DIFF
--- a/libs/giskard-agents/pyproject.toml
+++ b/libs/giskard-agents/pyproject.toml
@@ -8,7 +8,9 @@ authors = [{ name = "Giskard R&D", email = "rnd@giskard.ai" }]
 requires-python = ">=3.12"
 dependencies = [
     "giskard-llm>=1.0.0b6,<2",
-    "pydantic>=2.11.0,<3",
+    # TODO(#2719): temporary <2.14 cap. pydantic 2.14 regressed on unhashable
+    # annotations in _generate_schema.match_type. Lift once fixed upstream.
+    "pydantic>=2.11.0,<2.14",
     "griffe>=1.7.0,<3",
     "typing-extensions>=4.14.0,<5",
     "jinja2>=3.1.6,<4",

--- a/libs/giskard-checks/pyproject.toml
+++ b/libs/giskard-checks/pyproject.toml
@@ -7,7 +7,9 @@ license = { text = "MIT" }
 requires-python = ">=3.12"
 dependencies = [
     "jsonpath-ng>=1.7.0,<2",
-    "pydantic>=2.12,<3",
+    # TODO(#2719): temporary <2.14 cap. pydantic 2.14 regressed on unhashable
+    # annotations in _generate_schema.match_type. Lift once fixed upstream.
+    "pydantic>=2.12,<2.14",
     "pydantic-settings>=2.7,<3",
     "giskard-agents>=1.0.2b6,<2",
     "jinja2>=3.1.6,<4",

--- a/libs/giskard-core/pyproject.toml
+++ b/libs/giskard-core/pyproject.toml
@@ -7,7 +7,9 @@ license = { text = "MIT" }
 requires-python = ">=3.12"
 dependencies = [
     "posthog>=7.10.3",
-    "pydantic>=2.11.0,<3",
+    # TODO(#2719): temporary <2.14 cap. pydantic 2.14 regressed on unhashable
+    # annotations in _generate_schema.match_type. Lift once fixed upstream.
+    "pydantic>=2.11.0,<2.14",
 ]
 
 [tool.pytest.ini_options]

--- a/libs/giskard-llm/pyproject.toml
+++ b/libs/giskard-llm/pyproject.toml
@@ -8,7 +8,9 @@ authors = [{ name = "Giskard R&D", email = "rnd@giskard.ai" }]
 requires-python = ">=3.12"
 dependencies = [
     "giskard-core>=1.0.1b6,<2",
-    "pydantic>=2.11.0,<3",
+    # TODO(#2719): temporary <2.14 cap. pydantic 2.14 regressed on unhashable
+    # annotations in _generate_schema.match_type. Lift once fixed upstream.
+    "pydantic>=2.11.0,<2.14",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1414,7 +1414,7 @@ requires-dist = [
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.83.0,<2" },
     { name = "logfire-api", specifier = ">=3.22.0,<5" },
     { name = "numpy", specifier = ">=2.4.1,<3" },
-    { name = "pydantic", specifier = ">=2.11.0,<3" },
+    { name = "pydantic", specifier = ">=2.11.0,<2.14" },
     { name = "tenacity", specifier = ">=9.1.0,<10" },
     { name = "typing-extensions", specifier = ">=4.14.0,<5" },
 ]
@@ -1459,7 +1459,7 @@ requires-dist = [
     { name = "jsonpath-ng", specifier = ">=1.7.0,<2" },
     { name = "jsonschema", specifier = ">=4.23.0,<5" },
     { name = "numpy", specifier = ">=2.4.1,<3" },
-    { name = "pydantic", specifier = ">=2.12,<3" },
+    { name = "pydantic", specifier = ">=2.12,<2.14" },
     { name = "pydantic-settings", specifier = ">=2.7,<3" },
     { name = "regex", specifier = ">=2026.1.15" },
     { name = "rich", specifier = ">=14.2.0,<16" },
@@ -1479,7 +1479,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "posthog", specifier = ">=7.10.3" },
-    { name = "pydantic", specifier = ">=2.11.0,<3" },
+    { name = "pydantic", specifier = ">=2.11.0,<2.14" },
 ]
 
 [[package]]
@@ -1518,7 +1518,7 @@ requires-dist = [
     { name = "giskard-llm", extras = ["openai", "google", "anthropic"], marker = "extra == 'all'", editable = "libs/giskard-llm" },
     { name = "google-genai", marker = "extra == 'google'", specifier = ">=2.0,<3" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.30,<3" },
-    { name = "pydantic", specifier = ">=2.11.0,<3" },
+    { name = "pydantic", specifier = ">=2.11.0,<2.14" },
 ]
 provides-extras = ["openai", "google", "anthropic", "azure", "all"]
 


### PR DESCRIPTION
## What

Tightens the pydantic upper bound from `<3` to `<2.14` in the four libs that constrain it:

- `libs/giskard-core/pyproject.toml` — `>=2.11.0,<2.14`
- `libs/giskard-llm/pyproject.toml` — `>=2.11.0,<2.14`
- `libs/giskard-agents/pyproject.toml` — `>=2.11.0,<2.14`
- `libs/giskard-checks/pyproject.toml` — `>=2.12,<2.14`

Each gets a `TODO(#2719)` comment naming the upstream bug so the cap is removed rather than forgotten. `uv.lock` only records the new specifiers — the resolved version is unchanged (pydantic 2.13.4).

## Why

pydantic 2.14 added an unguarded dict lookup in `_internal/_generate_schema.py` (`match_type`):

```python
if origin is not None and (aliased_obj := typing_objects.DEPRECATED_ALIASES.get(obj)):
```

`.get(obj)` assumes `obj` is hashable. A PEP 695 alias with a **ParamSpec** parameterized by an empty list has `__args__ == ([], ...)`, so hashing it raises `TypeError: unhashable type: 'list'`. In this tree the trigger is `GeneratorType[[], InputType, None]` at `libs/giskard-checks/src/giskard/checks/core/interaction/interact.py:17`, which breaks `import giskard.checks` outright under pydantic 2.14.0b1.

This is an upstream regression, not a giskard bug — it reproduces in eight lines with no giskard import (see #2719). No giskard-side patch would fix it; `discriminated.py` is only the call site in the traceback.

## Scope

Deliberately a stopgap. A hard ceiling on a core dependency shipped in a 1.0 is inherited by every downstream user and can deadlock resolution for anyone needing pydantic 2.14 for another package. `Refs #2719` rather than `Closes` — the issue should stay open until the upstream bug is filed and fixed, at which point the cap is lifted.

The upstream report draft is attached as a comment on #2719 so it is preserved; it has **not** been filed on the pydantic repo yet.

## Testing

- `make check` — clean (basedpyright 0 errors, pip-audit, licensecheck all pass)
- `uv run python -c "import giskard.checks"` — imports cleanly, pydantic 2.13.4
- `uv lock --check` — lockfile consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
