### PR TITLE
refactor(checks)!: unify extraction key parameter names

### DIFF
--- a/libs/giskard-checks/README.md
+++ b/libs/giskard-checks/README.md
@@ -360,7 +360,7 @@ result = await (
         StringMatching(
             name="contains_paris",
             keyword="Paris",
-            text_key="trace.last.outputs.answer",
+            key="trace.last.outputs.answer",
         )
     )
     .check(
@@ -405,7 +405,7 @@ result = await (
     .check(
         RegexMatching(
             pattern="test@example.com",
-            text_key="trace.last.outputs",
+            key="trace.last.outputs",
         )
     )
     .run()

--- a/libs/giskard-checks/src/giskard/checks/builtin/comparison.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/comparison.py
@@ -36,7 +36,8 @@ class ComparisonCheck[InputType, OutputType, TraceType: Trace, ExpectedType](  #
     """
 
     key: JSONPathStr = Field(
-        ..., description="The key to extract the actual value from the trace"
+        default="trace.last.outputs",
+        description="The key to extract the actual value from the trace",
     )
     expected_value: ExpectedType | MISSING = Field(
         default=MISSING,
@@ -276,6 +277,7 @@ class LessThan[InputType, OutputType, TraceType: Trace, ExpectedType](  # pyrigh
         The expected value to compare against the extracted values
     key : str
         The key to extract the actual value from the trace
+        (default: "trace.last.outputs")
     """
 
     @override
@@ -319,6 +321,7 @@ class GreaterThan[InputType, OutputType, TraceType: Trace, ExpectedType](  # pyr
         The expected value to compare against the extracted values
     key : str
         The key to extract the actual value from the trace
+        (default: "trace.last.outputs")
     """
 
     @override
@@ -362,6 +365,7 @@ class LessThanEquals[InputType, OutputType, TraceType: Trace, ExpectedType](  # 
         The expected value to compare against the extracted values
     key : str
         The key to extract the actual value from the trace
+        (default: "trace.last.outputs")
     """
 
     @override
@@ -405,6 +409,7 @@ class GreaterThanEquals[InputType, OutputType, TraceType: Trace, ExpectedType]( 
         The expected value to compare against the extracted values
     key : str
         The key to extract the actual value from the trace
+        (default: "trace.last.outputs")
     """
 
     @override
@@ -448,6 +453,7 @@ class Equals[InputType, OutputType, TraceType: Trace, ExpectedType](  # pyright:
         The expected value to compare against the extracted values
     key : str
         The key to extract the actual value from the trace
+        (default: "trace.last.outputs")
     """
 
     @override
@@ -491,6 +497,7 @@ class NotEquals[InputType, OutputType, TraceType: Trace, ExpectedType](  # pyrig
         The expected value to compare against the extracted values
     key : str
         The key to extract the actual value from the trace
+        (default: "trace.last.outputs")
     """
 
     @override

--- a/libs/giskard-checks/src/giskard/checks/builtin/semantic_similarity.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/semantic_similarity.py
@@ -60,13 +60,13 @@ class SemanticSimilarity[InputType, OutputType, TraceType: Trace](  # pyright: i
         (default: 0.95).
     reference_text : str | MISSING
         The reference text to compare the output against. If omitted, extracted
-        from the trace using ``reference_text_key``.
-    reference_text_key : str
+        from the trace using ``reference_key``.
+    reference_key : str
         JSONPath expression to extract the reference text from the trace
         (default: "trace.last.metadata.reference_text").
 
         Can use `trace.last` (preferred) or `trace.interactions[-1]` for JSONPath expressions.
-    actual_answer_key : str
+    key : str
         JSONPath expression to extract the actual answer from the trace
         (default: "trace.last.outputs").
 
@@ -90,11 +90,11 @@ class SemanticSimilarity[InputType, OutputType, TraceType: Trace](  # pyright: i
     reference_text: str | MISSING = Field(
         default=MISSING, description="The reference text to compare the output with"
     )
-    reference_text_key: JSONPathStr = Field(
+    reference_key: JSONPathStr = Field(
         default="trace.last.metadata.reference_text",
         description="The key to extract the reference text from the trace",
     )
-    actual_answer_key: JSONPathStr = Field(
+    key: JSONPathStr = Field(
         default="trace.last.outputs",
         description="The key to extract the actual answer from the trace",
     )
@@ -117,14 +117,14 @@ class SemanticSimilarity[InputType, OutputType, TraceType: Trace](  # pyright: i
         """
         reference_text = provided_or_resolve(
             trace,
-            key=self.reference_text_key,
+            key=self.reference_key,
             value=self.reference_text,
         )
         if isinstance(reference_text, NoMatch):
             return CheckResult.error(
-                message=f"No value found for reference text key '{self.reference_text_key}'.",
+                message=f"No value found for reference text key '{self.reference_key}'.",
                 details={
-                    "reference_text_key": self.reference_text_key,
+                    "reference_key": self.reference_key,
                     "reference_text": reference_text,
                 },
             )
@@ -132,17 +132,17 @@ class SemanticSimilarity[InputType, OutputType, TraceType: Trace](  # pyright: i
             return CheckResult.error(
                 message="No reference text found",
                 details={
-                    "reference_text_key": self.reference_text_key,
+                    "reference_key": self.reference_key,
                     "reference_text": reference_text,
                 },
             )
-        actual_answer = resolve(trace, self.actual_answer_key)
+        actual_answer = resolve(trace, self.key)
         if isinstance(actual_answer, NoMatch):
             return CheckResult.error(
-                message=f"No value found for actual answer key '{self.actual_answer_key}'.",
+                message=f"No value found for actual answer key '{self.key}'.",
                 details={
                     "actual_answer": actual_answer,
-                    "actual_answer_key": self.actual_answer_key,
+                    "key": self.key,
                 },
             )
         if actual_answer is None or actual_answer == "":
@@ -150,16 +150,16 @@ class SemanticSimilarity[InputType, OutputType, TraceType: Trace](  # pyright: i
                 message="No actual answer found",
                 details={
                     "actual_answer": actual_answer,
-                    "actual_answer_key": self.actual_answer_key,
+                    "key": self.key,
                 },
             )
 
         if failure := self._failure_if_collection(
-            "reference text", self.reference_text_key, reference_text
+            "reference text", self.reference_key, reference_text
         ):
             return failure
         if failure := self._failure_if_collection(
-            "actual answer", self.actual_answer_key, actual_answer
+            "actual answer", self.key, actual_answer
         ):
             return failure
 
@@ -209,8 +209,8 @@ class SemanticSimilarity[InputType, OutputType, TraceType: Trace](  # pyright: i
                 "one value."
             ),
             details={
-                "reference_text_key": self.reference_text_key,
-                "actual_answer_key": self.actual_answer_key,
+                "reference_key": self.reference_key,
+                "key": self.key,
                 "value": str(value),
             },
         )

--- a/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
@@ -34,8 +34,8 @@ class TextBasedCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignor
     ----------
     text : str | MISSING
         The text string to search within. If omitted, extracted from
-        trace using ``text_key``.
-    text_key : JSONPathStr
+        trace using ``key``.
+    key : JSONPathStr
         JSONPath expression to extract the text from the trace. Defaults to
         "trace.last.outputs" which extracts the last interaction's outputs.
     """
@@ -44,7 +44,7 @@ class TextBasedCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignor
         default=MISSING,
         description="The text string to search within.",
     )
-    text_key: JSONPathStr = Field(
+    key: JSONPathStr = Field(
         default="trace.last.outputs",
         description="JSONPath expression to extract text from trace.",
     )
@@ -75,7 +75,7 @@ class TextBasedCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignor
             Either (text, target, details) on success, or (None, None, error_result) on failure.
         """
         # Extract text and target
-        text = provided_or_resolve(trace, key=self.text_key, value=self.text)
+        text = provided_or_resolve(trace, key=self.key, value=self.text)
         target = provided_or_resolve(
             trace,
             key=target_key,
@@ -111,7 +111,7 @@ class TextBasedCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignor
                 None,
                 None,
                 CheckResult.error(
-                    message=f"No value found for text key '{self.text_key}'.",
+                    message=f"No value found for text key '{self.key}'.",
                     details=details,
                 ),
             )
@@ -156,8 +156,8 @@ class StringMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignor
     ----------
     text : str | MISSING
         The text string to search within. If omitted, extracted from
-        trace using ``text_key``.
-    text_key : JSONPathStr
+        trace using ``key``.
+    key : JSONPathStr
         JSONPath expression to extract the text from the trace. Defaults to
         "trace.last.outputs" which extracts the last interaction's outputs.
     keyword : str | MISSING
@@ -191,13 +191,13 @@ class StringMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignor
 
         check = StringMatching(
             keyword="Paris",
-            text_key="trace.last.outputs.response"
+            key="trace.last.outputs.response"
         )
 
     Extract both from trace::
 
         check = StringMatching(
-            text_key="trace.last.outputs.answer",
+            key="trace.last.outputs.answer",
             keyword_key="trace.last.inputs.expected_keyword"
         )
     """
@@ -335,8 +335,8 @@ class RegexMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignore
     ----------
     text : str | MISSING
         The text string to search within. If omitted, extracted from
-        trace using ``text_key``.
-    text_key : JSONPathStr
+        trace using ``key``.
+    key : JSONPathStr
         JSONPath expression to extract the text from the trace. Defaults to
         "trace.last.outputs" which extracts the last interaction's outputs.
     pattern : str | MISSING
@@ -380,7 +380,7 @@ class RegexMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignore
     Extract from trace:
 
         check = RegexMatching(
-            text_key="trace.last.outputs.response",
+            key="trace.last.outputs.response",
             pattern_key="trace.last.inputs.expected_pattern"
         )
 

--- a/libs/giskard-checks/tests/builtin/test_regex_matching.py
+++ b/libs/giskard-checks/tests/builtin/test_regex_matching.py
@@ -172,7 +172,7 @@ async def test_regex_exact_whitespace() -> None:
 async def test_regex_with_trace_extraction() -> None:
     """Test regex matching with pattern from trace."""
     check = RegexMatching(
-        text_key="trace.last.outputs.response",
+        key="trace.last.outputs.response",
         pattern_key="trace.last.inputs.expected_pattern",
     )
     interaction = Interaction(
@@ -187,7 +187,7 @@ async def test_regex_with_trace_extraction() -> None:
 async def test_regex_extract_both_from_trace() -> None:
     """Test extracting both text and pattern from trace."""
     check = RegexMatching(
-        text_key="trace.last.outputs.answer",
+        key="trace.last.outputs.answer",
         pattern_key="trace.last.inputs.pattern",
     )
     interaction = Interaction(
@@ -351,7 +351,7 @@ async def test_missing_pattern_in_trace() -> None:
 async def test_missing_text_in_trace() -> None:
     """Test error handling when text cannot be extracted from trace."""
     check = RegexMatching(
-        text_key="trace.last.outputs.nonexistent",
+        key="trace.last.outputs.nonexistent",
         pattern="test",
     )
     result = await check.run(Trace())

--- a/libs/giskard-checks/tests/builtin/test_semantic_similarity.py
+++ b/libs/giskard-checks/tests/builtin/test_semantic_similarity.py
@@ -115,7 +115,7 @@ async def test_run_returns_success() -> None:
         embedding_model=embedding_model,
         threshold=0.95,
         reference_text="Paris is home to the Eiffel Tower.",
-        actual_answer_key="trace.last.outputs.response",
+        key="trace.last.outputs.response",
     )
     interaction = Interaction(
         inputs={"query": "Where is the Eiffel Tower?"},
@@ -142,7 +142,7 @@ async def test_run_returns_failure() -> None:
         embedding_model=embedding_model,
         threshold=0.95,
         reference_text="Tokyo is the capital of Japan.",
-        actual_answer_key="trace.last.outputs.response",
+        key="trace.last.outputs.response",
     )
     interaction = Interaction(
         inputs={"query": "Where is the Eiffel Tower?"},
@@ -167,7 +167,7 @@ async def test_reference_text_from_trace() -> None:
     check = SemanticSimilarity(
         embedding_model=embedding_model,
         threshold=0.90,
-        actual_answer_key="trace.last.outputs.response",
+        key="trace.last.outputs.response",
     )
     interaction = Interaction(
         inputs={"query": "What is AI?"},
@@ -193,7 +193,7 @@ async def test_direct_reference_text_priority() -> None:
         embedding_model=embedding_model,
         threshold=0.85,
         reference_text="Direct reference",
-        actual_answer_key="trace.last.outputs.response",
+        key="trace.last.outputs.response",
     )
     interaction = Interaction(
         inputs={"query": "Test"},
@@ -218,7 +218,7 @@ async def test_custom_actual_answer_key() -> None:
         embedding_model=embedding_model,
         threshold=0.90,
         reference_text="Reference",
-        actual_answer_key="trace.last.outputs.custom_field",
+        key="trace.last.outputs.custom_field",
     )
     interaction = Interaction(
         inputs={"query": "Test"},
@@ -241,8 +241,8 @@ async def test_custom_reference_text_key() -> None:
     check = SemanticSimilarity(
         embedding_model=embedding_model,
         threshold=0.90,
-        reference_text_key="trace.last.metadata.custom_ref",
-        actual_answer_key="trace.last.outputs.response",
+        reference_key="trace.last.metadata.custom_ref",
+        key="trace.last.outputs.response",
     )
     interaction = Interaction(
         inputs={"query": "Test"},
@@ -274,7 +274,7 @@ async def test_threshold_variations() -> None:
         embedding_model=embedding_model,
         threshold=0.5,
         reference_text="Text B",
-        actual_answer_key="trace.last.outputs.response",
+        key="trace.last.outputs.response",
     )
     interaction = Interaction(inputs={}, outputs={"response": "Text A"})
     result = await check_low.run(Trace(interactions=[interaction]))
@@ -285,7 +285,7 @@ async def test_threshold_variations() -> None:
         embedding_model=embedding_model,
         threshold=0.999,
         reference_text="Text B",
-        actual_answer_key="trace.last.outputs.response",
+        key="trace.last.outputs.response",
     )
     result = await check_high.run(Trace(interactions=[interaction]))
     if expected_similarity < 0.999:
@@ -321,7 +321,7 @@ async def test_using_trace_last() -> None:
         embedding_model=embedding_model,
         threshold=0.85,
         reference_text="Reference",
-        actual_answer_key="trace.last.outputs.response",
+        key="trace.last.outputs.response",
     )
     result = await check.run(trace)
 
@@ -366,7 +366,7 @@ async def test_custom_embedding_model_preserved_after_serialization_roundtrip() 
         embedding_model=embedding_model,
         threshold=0.92,
         reference_text="Reference",
-        actual_answer_key="trace.last.outputs.response",
+        key="trace.last.outputs.response",
     )
     roundtrip_check = serialization_roundtrip(check)
 
@@ -393,7 +393,7 @@ async def test_serialization_roundtrip() -> None:
         embedding_model=embedding_model,
         threshold=0.92,
         reference_text="Reference",
-        actual_answer_key="trace.last.outputs.response",
+        key="trace.last.outputs.response",
     )
 
     roundtrip_check = serialization_roundtrip(check)
@@ -426,7 +426,7 @@ async def test_missing_reference_text_in_trace() -> None:
     check = SemanticSimilarity(
         embedding_model=embedding_model,
         threshold=0.85,
-        actual_answer_key="trace.last.outputs.response",
+        key="trace.last.outputs.response",
     )
     interaction = Interaction(
         inputs={},
@@ -443,7 +443,7 @@ async def test_missing_reference_text_in_trace() -> None:
         in result.message
     )
     assert isinstance(result.details["reference_text"], NoMatch)
-    assert "reference_text_key" in result.details
+    assert "reference_key" in result.details
 
 
 async def test_missing_actual_answer_in_trace() -> None:
@@ -458,12 +458,12 @@ async def test_missing_actual_answer_in_trace() -> None:
         embedding_model=embedding_model,
         threshold=0.85,
         reference_text="Reference",
-        actual_answer_key="trace.last.outputs.nonexistent_field",
+        key="trace.last.outputs.nonexistent_field",
     )
     interaction = Interaction(
         inputs={},
         outputs={"response": "Some answer"},
-        # actual_answer_key points to nonexistent field
+        # key points to nonexistent field
     )
     result = await check.run(Trace(interactions=[interaction]))
 
@@ -475,7 +475,7 @@ async def test_missing_actual_answer_in_trace() -> None:
         in result.message
     )
     assert isinstance(result.details["actual_answer"], NoMatch)
-    assert "actual_answer_key" in result.details
+    assert "key" in result.details
 
 
 async def test_both_reference_and_answer_missing() -> None:
@@ -488,8 +488,8 @@ async def test_both_reference_and_answer_missing() -> None:
     check = SemanticSimilarity(
         embedding_model=embedding_model,
         threshold=0.85,
-        actual_answer_key="trace.last.outputs.missing",
-        reference_text_key="trace.last.metadata.missing",
+        key="trace.last.outputs.missing",
+        reference_key="trace.last.metadata.missing",
     )
     interaction = Interaction(
         inputs={},
@@ -543,7 +543,7 @@ async def test_missing_outputs_field_in_interaction() -> None:
         embedding_model=embedding_model,
         threshold=0.85,
         reference_text="Reference",
-        actual_answer_key="trace.last.outputs.response",
+        key="trace.last.outputs.response",
     )
     interaction = Interaction(
         inputs={"query": "test"},
@@ -572,8 +572,8 @@ async def test_missing_metadata_in_interaction() -> None:
     check = SemanticSimilarity(
         embedding_model=embedding_model,
         threshold=0.85,
-        actual_answer_key="trace.last.outputs.response",
-        reference_text_key="trace.last.metadata.reference",
+        key="trace.last.outputs.response",
+        reference_key="trace.last.metadata.reference",
     )
     interaction = Interaction(
         inputs={},
@@ -603,8 +603,8 @@ async def test_invalid_jsonpath_key() -> None:
     check = SemanticSimilarity(
         embedding_model=embedding_model,
         threshold=0.85,
-        actual_answer_key="trace.last.outputs.response",
-        reference_text_key="trace.nonexistent.deeply.nested.field",
+        key="trace.last.outputs.response",
+        reference_key="trace.nonexistent.deeply.nested.field",
     )
     interaction = Interaction(
         inputs={},
@@ -635,7 +635,7 @@ async def test_similarity_at_exact_threshold() -> None:
         embedding_model=embedding_model,
         threshold=1.0,
         reference_text="Text B",
-        actual_answer_key="trace.last.outputs.response",
+        key="trace.last.outputs.response",
     )
     interaction = Interaction(inputs={}, outputs={"response": "Text A"})
     result = await check.run(Trace(interactions=[interaction]))
@@ -661,8 +661,8 @@ async def test_list_valued_key_is_rejected_instead_of_embedding_its_repr():
         ]
     )
     check = SemanticSimilarity(
-        actual_answer_key="trace.last.outputs",
-        reference_text_key="trace.interactions[*].metadata.ref",
+        key="trace.last.outputs",
+        reference_key="trace.interactions[*].metadata.ref",
         threshold=0.5,
         embedding_model=_recording_embedding_model(embedded),
     )
@@ -695,8 +695,8 @@ async def test_dict_valued_actual_answer_key_is_rejected():
         ]
     )
     check = SemanticSimilarity(
-        actual_answer_key="trace.last.outputs",
-        reference_text_key="trace.last.metadata.ref",
+        key="trace.last.outputs",
+        reference_key="trace.last.metadata.ref",
         threshold=0.5,
         embedding_model=_recording_embedding_model(embedded),
     )
@@ -718,8 +718,8 @@ async def test_scalar_key_still_stringifies():
         interactions=[Interaction(inputs="q", outputs="42", metadata={"ref": 42})]
     )
     check = SemanticSimilarity(
-        actual_answer_key="trace.last.outputs",
-        reference_text_key="trace.last.metadata.ref",
+        key="trace.last.outputs",
+        reference_key="trace.last.metadata.ref",
         threshold=0.5,
         embedding_model=_recording_embedding_model(embedded),
     )

--- a/libs/giskard-checks/tests/builtin/test_string_matching.py
+++ b/libs/giskard-checks/tests/builtin/test_string_matching.py
@@ -47,7 +47,7 @@ async def test_case_sensitive_matching() -> None:
 async def test_text_and_keyword_from_trace() -> None:
     """Test extracting both text and keyword from trace."""
     check = StringMatching(
-        text_key="trace.last.outputs.response",
+        key="trace.last.outputs.response",
         keyword_key="trace.last.inputs.expected",
     )
     interaction = Interaction(
@@ -63,7 +63,7 @@ async def test_text_and_keyword_from_trace() -> None:
 async def test_text_from_trace_keyword_direct() -> None:
     """Test extracting text from trace with direct keyword."""
     check = StringMatching(
-        text_key="trace.last.outputs.answer",
+        key="trace.last.outputs.answer",
         keyword="Python",
         case_sensitive=False,
     )
@@ -166,7 +166,7 @@ async def test_missing_keyword_in_trace() -> None:
 async def test_missing_text_in_trace() -> None:
     """Test behavior when text cannot be extracted from trace."""
     check = StringMatching(
-        text_key="trace.last.outputs.nonexistent",
+        key="trace.last.outputs.nonexistent",
         keyword="test",
     )
     result = await check.run(Trace())
@@ -180,14 +180,14 @@ async def test_missing_text_in_trace() -> None:
 
 
 async def test_default_text_key() -> None:
-    """Test that default text_key (trace.last.outputs) works correctly."""
+    """Test that default key (trace.last.outputs) works correctly."""
     check = StringMatching(keyword="response")
     interaction = Interaction(
         inputs={"query": "Test"},
         outputs="This is a response",
     )
     result = await check.run(Trace(interactions=[interaction]))
-    # Default text_key extracts trace.last.outputs which is a dict
+    # Default key extracts trace.last.outputs which is a dict
     # The dict string representation should contain "response"
     assert result.status == CheckStatus.PASS
 
@@ -202,7 +202,7 @@ async def test_empty_trace_with_direct_values() -> None:
 async def test_trace_last_property() -> None:
     """Test using trace.last property for extraction."""
     check = StringMatching(
-        text_key="trace.last.outputs.message",
+        key="trace.last.outputs.message",
         keyword="Alice",
     )
     interaction1 = Interaction(
@@ -223,7 +223,7 @@ async def test_trace_last_property() -> None:
 async def test_multiple_interactions_uses_last() -> None:
     """Test that check uses the last interaction when multiple exist."""
     check = StringMatching(
-        text_key="trace.last.outputs.response",
+        key="trace.last.outputs.response",
         keyword="Second",
     )
     interaction1 = Interaction(


### PR DESCRIPTION
## What

Unifies the parameter name used to point a built-in check at the value it should extract from the trace. Everything now uses `key` for the primary extraction path.

Most checks (`Equals`/`NotEquals`/`LessThan`/`GreaterThan`/…, `JsonValid`, `Readability`, `RegoPolicy`) already used `key`; `StringMatching`/`RegexMatching` and `SemanticSimilarity` were the outliers.

## Rename table

<!-- linear:table-colwidths:200,200,200,200 -->
| Check | Old parameter | New parameter | Serialized field affected |
| -- | -- | -- | -- |
| `StringMatching`, `RegexMatching` (`TextBasedCheck`) | `text_key` | `key` | `text_key` → `key` |
| `SemanticSimilarity` | `actual_answer_key` | `key` | `actual_answer_key` → `key` |
| `SemanticSimilarity` | `reference_text_key` | `reference_key` | `reference_text_key` → `reference_key` |

Also: `ComparisonCheck.key` was a required field; it now defaults to `"trace.last.outputs"`, matching every peer check.

`CheckResult.details` emitted by `SemanticSimilarity` uses the new names too (`key`, `reference_key`).

## Breaking change

These are pydantic field names, so both constructor kwargs and serialized suite JSON change. No aliases or back-compat shims are provided — this is intentional pre-RC breakage. This should go into the same release note as the `ScenarioResult.steps` rename.

## Test plan

* `make format && make check` — clean
* `uv run pytest libs/giskard-checks/tests -q -m "not functional"` — 808 passed, 4 skipped (after merging latest main)
* `uv run pytest libs/giskard-scan/tests libs/giskard-agents/tests -q -m "not functional"` — 299 passed, 46 skipped (after merging latest main; run per-lib)

Closes Giskard-AI/giskard-oss#2728

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)