### PR TITLE
fix(checks): Toxicity errors on unresolvable output_key

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/judges/toxicity.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/toxicity.py
@@ -7,6 +7,8 @@ from pydantic.experimental.missing_sentinel import MISSING
 from ..core import Trace
 from ..core.check import Check
 from ..core.extraction import JSONPathStr, provided_or_resolve
+from ..core.result import CheckResult
+from ._inputs import ResolvableInput, error_if_unresolved
 from .base import BaseLLMCheck
 
 ToxicityCategory = Literal[
@@ -99,6 +101,21 @@ class Toxicity[InputType, OutputType, TraceType: Trace](  # pyright: ignore[repo
     def get_prompt(self) -> TemplateReference:
         """Return the bundled prompt template for toxicity evaluation."""
         return TemplateReference(template_name="giskard.checks::judges/toxicity.j2")
+
+    @override
+    async def run(self, trace: TraceType) -> CheckResult:
+        """Return ERROR when ``output_key`` does not resolve; else run the judge.
+
+        Guarding here—before ``super().run()``—means a misconfigured key costs no
+        judge call, and ERROR (rather than FAIL) keeps ``Not(...)`` from
+        laundering a broken key into a green result.
+        """
+        if early := error_if_unresolved(
+            trace,
+            ResolvableInput("output", self.output_key, self.output),
+        ):
+            return early
+        return await super().run(trace)
 
     @override
     async def get_inputs(self, trace: Trace[InputType, OutputType]) -> dict[str, Any]:

--- a/libs/giskard-checks/tests/builtin/test_toxicity.py
+++ b/libs/giskard-checks/tests/builtin/test_toxicity.py
@@ -215,3 +215,37 @@ async def test_check_is_serialisable() -> None:
     reconstructed = Check.model_validate(data)
     assert isinstance(reconstructed, Toxicity)
     assert reconstructed.categories == ["hate_speech"]
+
+
+async def test_unresolvable_output_key_returns_error() -> None:
+    """An unresolvable ``output_key`` errors instead of silently passing."""
+    generator = MockGenerator(passed=True, reason="Judge must not run.")
+    check = Toxicity(
+        generator=generator,
+        output_key="trace.last.metadata.does_not_exist",
+    )
+    trace = Trace(interactions=[Interaction(inputs="Hi", outputs="Hello.")])
+
+    result = await check.run(trace)
+
+    assert result.status == CheckStatus.ERROR
+    assert "output key" in (result.message or "")
+    assert "trace.last.metadata.does_not_exist" in (result.message or "")
+    assert len(generator.calls) == 0
+
+
+async def test_not_does_not_invert_unresolved_output_key_error() -> None:
+    """``Not(...)`` must leave the ERROR uninverted, not launder it into PASS."""
+    from giskard.checks import Not
+
+    generator = MockGenerator(passed=True, reason="Judge must not run.")
+    check = Toxicity(
+        generator=generator,
+        output_key="trace.last.metadata.does_not_exist",
+    )
+    trace = Trace(interactions=[Interaction(inputs="Hi", outputs="Hello.")])
+
+    result = await Not(check=check).run(trace)
+
+    assert result.status == CheckStatus.ERROR
+    assert len(generator.calls) == 0

--- a/libs/giskard-checks/tests/builtin/test_toxicity.py
+++ b/libs/giskard-checks/tests/builtin/test_toxicity.py
@@ -249,3 +249,19 @@ async def test_not_does_not_invert_unresolved_output_key_error() -> None:
 
     assert result.status == CheckStatus.ERROR
     assert len(generator.calls) == 0
+
+
+async def test_directly_provided_output_bypasses_broken_key() -> None:
+    """A direct ``output`` takes priority, so ``output_key`` is never resolved."""
+    generator = MockGenerator(passed=True, reason="Clean.")
+    check = Toxicity(
+        generator=generator,
+        output="Directly provided text.",
+        output_key="trace.last.metadata.does_not_exist",
+    )
+
+    result = await check.run(Trace())
+
+    assert result.status == CheckStatus.PASS
+    assert result.details["inputs"]["output"] == "Directly provided text."
+    assert len(generator.calls) == 1


### PR DESCRIPTION
## Problem

`Toxicity.get_inputs()` wrapped `provided_or_resolve(...)` in `str(...)`. When `output_key` did not resolve, the resulting `NoMatch` was stringified into the placeholder `"No match for key: ..."` and handed to the judge, which reasonably scored that harmless text as non-toxic. A misconfigured or drifted `output_key` therefore produced a permanent, silent PASS — the worst failure mode for a safety check.

## Fix

Guard in `Toxicity.run()` with the existing shared helper `_inputs.error_if_unresolved`, before dispatching to the judge — exactly matching the three sibling judges that already do this (`contradiction.py`, `answer_relevance.py`, `groundedness.py`). Consequences:

- Returns **ERROR**, not FAIL, so `Not(...)` cannot invert a broken key into a green result.
- The judge call is skipped entirely, so a misconfiguration costs no tokens.
- Directly-provided `output` still takes priority and bypasses the key, unchanged.

## Conformity

Confirmed, per the issue: `Conformity` has no unresolvable-key path. Its only field is `rule`, and `get_inputs()` passes the whole `trace` object to the template rather than extracting via a JSONPath key — there is nothing that can resolve to `NoMatch`. No change needed there.

## Tests

Two cases added to `tests/builtin/test_toxicity.py`, mirroring the sibling judges' existing unresolvable-key tests: a bad `output_key` returns `CheckStatus.ERROR` with the offending key in the message and zero generator calls, and `Not(...)` leaves that ERROR uninverted.

`make format && make check` clean; `uv run pytest libs/giskard-checks/tests -q -m "not functional"` → 796 passed, 4 skipped.

Scope is deliberately minimal (`toxicity.py` + its test file); the broader judge sweep is left to #2750/#2753/#2725.

Closes #2724

🤖 Generated with [Claude Code](https://claude.com/claude-code)
