### PR TITLE
fix(checks): address review findings on SKIP reporting

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/core/result.py
+++ b/libs/giskard-checks/src/giskard/checks/core/result.py
@@ -1,11 +1,12 @@
 """Result models for checks, test cases, scenarios and suites.
 
 ``CheckStatus`` has four states: ``PASS``, ``FAIL``, ``ERROR`` and ``SKIP``.
-ERROR and SKIP mean *no verdict was reached* and are never coerced into pass or
-fail: branch on ``status`` (or the explicit ``failed`` / ``errored`` /
-``skipped`` properties) rather than on ``not passed``, keep the four states
-distinct in aggregations and exports, and exclude SKIP from pass-rate
-denominators.
+ERROR and SKIP mean *no verdict was reached*: branch on ``status`` (or the
+explicit ``failed`` / ``errored`` / ``skipped`` properties) rather than on
+``not passed``, keep the four states distinct in exports, and exclude SKIP
+from pass-rate denominators. Rollups still use priority (ERROR > FAIL >
+all-SKIP > PASS), so a mix of PASS and SKIP remains PASS — only an all-SKIP
+collection becomes SKIP.
 """
 
 from collections import defaultdict
@@ -509,14 +510,16 @@ class TestCaseResult(BaseResult, frozen=True):
         return [result for result in self.results if result.failed or result.errored]
 
     def format_failures(self) -> list[str]:
-        """Format failed check results into a list of readable error messages.
+        """Format non-passing check results into readable messages (FAIL, ERROR, and SKIP).
 
         Returns
         -------
         list[str]
             List of formatted messages for every check that did not reach a PASS
             verdict, including skipped checks. Each message includes the check
-            name/kind, its status and the reason.
+            name/kind, its status and the reason. This is the diagnostic
+            superset used by ``assert_passed``; ``failures_and_errors``
+            intentionally excludes SKIP.
         """
         failure_messages: list[str] = []
         if self.error is not None:

--- a/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
@@ -80,9 +80,15 @@ def _skipped_check_results_for_step[InputType, OutputType, TraceType: Trace[Any,
 ) -> list[CheckResult]:
     # A step carrying no checks still has to yield one SKIP result: an empty
     # result list would make TestCaseResult.status report PASS, turning a step
-    # that never ran into a green one.
+    # that never ran into a green one. Synthetic details keep format_failures
+    # from labeling it "Unknown check".
     if not step.checks:
-        return [CheckResult.skip(message=message)]
+        return [
+            CheckResult.skip(
+                message=message,
+                details={"check_kind": "step", "check_name": "step"},
+            )
+        ]
 
     return [
         CheckResult.skip(

--- a/libs/giskard-checks/tests/core/test_scenario.py
+++ b/libs/giskard-checks/tests/core/test_scenario.py
@@ -389,6 +389,11 @@ class TestScenarioNormalCases:
         assert not result.steps[1].passed
         assert len(result.steps[1].results) == 1
         assert result.steps[1].results[0].skipped
+        assert result.steps[1].results[0].details.get("check_name") == "step"
+        failures = result.steps[1].format_failures()
+        assert len(failures) == 1
+        assert "step SKIPPED:" in failures[0]
+        assert "Unknown check" not in failures[0]
         assert result.failed
 
     async def test_skipped_step_without_checks_after_error_reports_skip(self):
@@ -408,6 +413,7 @@ class TestScenarioNormalCases:
         assert result.steps[0].errored
         assert result.steps[1].skipped
         assert not result.steps[1].passed
+        assert result.steps[1].results[0].details.get("check_name") == "step"
         assert result.errored
 
     async def test_trace_accumulation_across_components(self):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to the code review of #2759.

## Changes

1. **Module docstring** — documents real rollup priority (ERROR > FAIL > all-SKIP > PASS), so PASS+SKIP mixes are no longer described as “never coerced into pass.”
2. **`format_failures` docstring** — summary mentions FAIL/ERROR/SKIP and notes that `failures_and_errors` intentionally excludes SKIP.
3. **Checkless skipped steps** — synthetic `check_name`/`check_kind` of `"step"` so `format_failures` / `assert_passed` no longer say `Unknown check SKIPPED`. Tests assert the label.

## Out of scope (review decision gates)

- Deepteam `score=None` → SKIP release note (#2) — belongs on #2759 / release notes.
- Rebase onto `main` for #2753 `pass_rate=None` — still needed on #2759 before merge.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2490a2a-a483-4d47-96de-a3c9f65a3ad1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2490a2a-a483-4d47-96de-a3c9f65a3ad1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

