### PR TITLE
chore(giskard-checks): drop unused uses_ambient_env marker

### DIFF
--- a/libs/giskard-checks/pyproject.toml
+++ b/libs/giskard-checks/pyproject.toml
@@ -31,9 +31,7 @@ addopts = "--doctest-modules"
 asyncio_mode = "auto"
 pythonpath = ["src"]
 markers = [
-    "integration: integration tests that are skipped unless --run-integration is provided",
-    "uses_ambient_env: opt out of the GISKARD_* environment isolation fixture",
-]
+    "integration: integration tests that are skipped unless --run-integration is provided",]
 
 [tool.ruff.lint]
 select = ["E", "W", "I", "F"]

--- a/libs/giskard-checks/tests/conftest.py
+++ b/libs/giskard-checks/tests/conftest.py
@@ -8,22 +8,13 @@ GISKARD_ENV_PREFIX = "GISKARD_"
 
 
 @pytest.fixture(autouse=True)
-def isolate_giskard_env(
-    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
-):
+def isolate_giskard_env(monkeypatch: pytest.MonkeyPatch):
     """Isolate tests from ambient ``GISKARD_*`` configuration.
 
     Removes every ``GISKARD_``-prefixed environment variable and disables the
     ``.env`` file lookup so that tests observe the built-in defaults regardless
     of the developer's local environment (see issue #2734).
-
-    Tests that genuinely depend on the ambient environment can opt out with the
-    ``uses_ambient_env`` marker.
     """
-    if request.node.get_closest_marker("uses_ambient_env"):
-        yield
-        return
-
     for name in [k for k in os.environ if k.startswith(GISKARD_ENV_PREFIX)]:
         monkeypatch.delenv(name, raising=False)
 


### PR DESCRIPTION
Removes the `uses_ambient_env` opt-out marker introduced in #2749 — it has no users. The `GISKARD_*` env isolation fixture behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)