### PR TITLE
fix(scan): anchor optional-extra collection ignores to the lib root

### DIFF
--- a/libs/giskard-scan/conftest.py
+++ b/libs/giskard-scan/conftest.py
@@ -1,0 +1,56 @@
+"""Keep optional-extra integration ``src`` trees out of collection when the extra is absent.
+
+Why this file exists
+--------------------
+``addopts`` used to carry ``--ignore=src/giskard/scan/integrations/{garak,lidar,deepteam}``,
+but pytest resolves a *relative* ``--ignore`` against the invocation CWD rather than the
+rootdir. Those flags therefore only bit when pytest was started from inside
+``libs/giskard-scan``. Run from the repo root (``pytest libs/giskard-scan``, which is what
+``make test-unit-minimal`` and ``make test-garak`` both do) they resolved to nothing, the
+ignores silently missed, and ``--doctest-modules`` imported every ``src`` module --
+``ModuleNotFoundError: No module named 'garak'``.
+
+``collect_ignore_glob`` is resolved relative to *this conftest's own directory*, so the
+rule now holds for every invocation shape: repo root, lib chdir, a direct ``src`` path, or
+an IDE runner. The three ``--ignore`` flags have been dropped from ``addopts`` because this
+fully subsumes them -- keeping both would leave two mechanisms for one policy, one of them
+CWD-dependent and silently broken.
+
+The gate is conditional, which the unconditional ``--ignore`` flags could never express:
+skip a tree only when its extra is *missing*. That is what lets one rule serve both
+``make test-unit`` (extra absent -> skip) and ``make test-garak`` / ``test-lidar`` /
+``test-deepteam`` (extra installed -> collect and run).
+
+Only ``src`` trees are listed. The matching ``tests/integrations/<extra>`` trees must keep
+collecting in every environment: they assert lazy-import safety and fail-fast behaviour and
+are written to pass with the extra absent.
+
+Notes for future maintainers
+----------------------------
+- ``find_spec`` is an *availability* oracle, not an importability check: a half-installed
+  extra makes it return non-None, this file declines to ignore, and collection fails on the
+  real import error. That is deliberate -- it is the same oracle used by ``_adapter.py``'s
+  ``garak_available()``, by giskard-checks' ``require_optional_dependency``, and by the
+  ``block_garak_import`` fixture, which monkeypatches ``find_spec`` specifically.
+- This assumes each extra's *import name* equals its *directory name* under
+  ``integrations/``. True for garak, lidar and deepteam today; an integration whose import
+  name diverges from its directory would be silently mis-gated in either direction.
+- Root cause behind the blast radius: ``--doctest-modules`` imports every ``src`` module,
+  bypassing the package's lazy boundary (``__init__`` -> ``_adapter.py``, which imports
+  ``TargetGenerator`` inside a function). The garak modules are exceptional because a
+  *base class* cannot be deferred into a function body the way ``_adapter.py`` defers its
+  imports. Narrowing ``--doctest-modules`` to modules that actually have doctests (the
+  integration trees currently have none) is the real long-term fix and is tracked
+  separately -- it is a larger change than this one.
+"""
+
+import importlib.util
+
+# Extras whose src tree needs its optional dependency importable at module scope.
+_OPTIONAL_EXTRAS = ("garak", "lidar", "deepteam")
+
+collect_ignore_glob: list[str] = [
+    f"src/giskard/scan/integrations/{_extra}/*"
+    for _extra in _OPTIONAL_EXTRAS
+    if importlib.util.find_spec(_extra) is None
+]

--- a/libs/giskard-scan/pyproject.toml
+++ b/libs/giskard-scan/pyproject.toml
@@ -38,7 +38,10 @@ include = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--doctest-modules --ignore=src/giskard/scan/integrations/garak --ignore=src/giskard/scan/integrations/lidar --ignore=src/giskard/scan/integrations/deepteam"
+# Optional-extra src trees are excluded by conftest.py's collect_ignore_glob, not by
+# relative --ignore flags here: pytest resolves those against the invocation CWD, so they
+# silently missed whenever pytest ran from the repo root. See conftest.py.
+addopts = "--doctest-modules"
 asyncio_mode = "auto"
 pythonpath = ["src"]
 markers = [

--- a/libs/giskard-scan/tests/integrations/garak/test_garak_lazy_load.py
+++ b/libs/giskard-scan/tests/integrations/garak/test_garak_lazy_load.py
@@ -5,9 +5,18 @@
 - The run test verifies GarakScanAdapter fails fast with a helpful ImportError
   when garak is absent.
 
+- The collection-gate tests pin the contract in ``libs/giskard-scan/conftest.py``,
+  which keeps the optional-extra ``src`` trees out of ``--doctest-modules`` collection
+  when the extra is absent. Those trees are skipped rather than fixed, so without these
+  tests a broken gate would fail loudly only in whichever CI job happens to run from the
+  wrong CWD.
+
 The ``block_garak_import`` fixture lives in conftest.py; see it for how the
 sys.modules purge works and why later tests must patch via the live module.
 """
+
+import importlib.util
+from pathlib import Path
 
 import pytest
 
@@ -44,3 +53,72 @@ async def test_garak_adapter_run_raises_import_error_when_garak_absent(
 
     with pytest.raises(ImportError, match="giskard-scan\\[garak\\]"):
         await GarakScanAdapter().run(target=lambda p: "ok")
+
+
+def _lib_conftest_namespace() -> tuple[tuple[str, ...], list[str]]:
+    """Execute the lib-root conftest in isolation, returning (extras, ignore globs).
+
+    Loaded by path rather than imported: pytest has already imported the real one as a
+    plugin, and importing a second copy under a different name would shadow it.
+    """
+    conftest_path = Path(__file__).parents[3] / "conftest.py"
+    namespace: dict[str, object] = {"__file__": str(conftest_path)}
+    exec(compile(conftest_path.read_text(), str(conftest_path), "exec"), namespace)
+
+    extras = namespace["_OPTIONAL_EXTRAS"]
+    ignored = namespace["collect_ignore_glob"]
+    assert isinstance(extras, tuple)
+    assert isinstance(ignored, list)
+    return tuple(str(extra) for extra in extras), [str(pattern) for pattern in ignored]
+
+
+def test_lib_conftest_ignores_src_tree_of_every_absent_extra() -> None:
+    """Absent extras must have their src tree excluded from collection.
+
+    This is what stops ``--doctest-modules`` from importing modules whose optional
+    dependency is missing, regardless of the CWD pytest was invoked from.
+    """
+    extras, ignored = _lib_conftest_namespace()
+
+    for extra in extras:
+        pattern = f"src/giskard/scan/integrations/{extra}/*"
+        if importlib.util.find_spec(extra) is None:
+            assert pattern in ignored, (
+                f"{extra} is not installed but its src tree is still collected; "
+                "--doctest-modules will import it and fail"
+            )
+        else:
+            assert pattern not in ignored, (
+                f"{extra} is installed but its src tree is excluded; "
+                f"make test-{extra} would silently collect nothing"
+            )
+
+
+def test_lib_conftest_extras_match_integration_directories() -> None:
+    """The gate assumes each extra's import name equals its directory name."""
+    extras = set(_lib_conftest_namespace()[0])
+
+    integrations_dir = Path(__file__).parents[3] / "src/giskard/scan/integrations"
+    on_disk = {
+        path.name
+        for path in integrations_dir.iterdir()
+        if path.is_dir() and not path.name.startswith("_")
+    }
+
+    assert extras <= on_disk, (
+        f"conftest gates extras with no integration directory: {sorted(extras - on_disk)}"
+    )
+
+
+def test_garak_package_imports_without_garak_installed(
+    block_garak_import: None,
+) -> None:
+    """The public surface must import with garak absent -- no importorskip.
+
+    Pins the lazy boundary the conftest gate relies on: ``__init__`` pulls only from
+    ``_adapter.py``, which imports ``TargetGenerator`` inside a function body.
+    """
+    from giskard.scan.integrations.garak import GarakScanAdapter, garak_available
+
+    assert GarakScanAdapter is not None
+    assert garak_available() is False


### PR DESCRIPTION
## Problem

`libs/giskard-scan/pyproject.toml` excluded its optional-extra `src` trees with relative flags:

```toml
addopts = "--doctest-modules --ignore=src/giskard/scan/integrations/garak --ignore=.../lidar --ignore=.../deepteam"
```

**pytest resolves a relative `--ignore` against the invocation CWD, not the rootdir.** Those flags only bit when pytest started from inside `libs/giskard-scan`. Run from the repo root they resolved to nothing, the ignores silently missed, and `--doctest-modules` imported every `src` module:

```
$ uv run pytest libs/giskard-scan -m "not functional"
ERROR src/giskard/scan/integrations/garak/_bridge.py
ERROR src/giskard/scan/integrations/garak/_generator.py
ERROR src/giskard/scan/integrations/garak/_judge_generator.py
E   ModuleNotFoundError: No module named 'garak'
!!!!!! Interrupted: 3 errors during collection !!!!!!
```

Those three modules import garak at module level, and two use garak classes as **base classes** — which cannot be deferred into a function body the way `_adapter.py` defers its imports.

## Fix

Replace the three `--ignore` flags with `collect_ignore_glob` in a lib-root `conftest.py`.

pytest resolves `collect_ignore_glob` **relative to the conftest's own directory**, so the rule now holds for every invocation shape: repo root, lib chdir, a direct `src` path, or an IDE runner. Keeping both mechanisms would leave two rules for one policy, one of them CWD-dependent and silently broken — so the flags are dropped.

The gate is conditional on `importlib.util.find_spec`, which the unconditional flags could never express: a tree is skipped only when its extra is **actually missing**. One rule now serves both `make test-unit` (extra absent → skip) and `make test-garak` / `test-lidar` / `test-deepteam` (extra installed → collect and run).

### This is a collection fix, not a runtime one

The package already degrades correctly without the extras:

```
$ uv run python -c "from giskard.scan.integrations.garak import GarakScanAdapter, garak_available; print(garak_available())"
False
```

`__init__` pulls only from `_adapter.py`, which imports `TargetGenerator` **inside a function**, so the three modules are never reached at package-import time. `--doctest-modules` was bypassing that lazy boundary by importing each `src` module directly.

**No `src` module is modified**, so `isinstance` stability, `from X import Y` syntax, and `GiskardJudgeGenerator`'s load-bearing `OpenAICompatible` base are preserved by construction rather than by careful engineering.

Three alternative designs were evaluated, including restructuring the modules for true lazy loading via PEP 562 `__getattr__` and via a try/except placeholder base. Both were rejected after they were found to introduce defects that manifest **only when garak IS installed** — `__getattr__` does not rescue bare global lookups in function bodies, and a placeholder base is silently bypassed by `GiskardJudgeGenerator`'s deliberate `super().__init__()` skip. Restructuring load-bearing subclassing to fix a collection-layer bug was judged the wrong trade.

## Tests

Three regression tests pin the contract in `test_garak_lazy_load.py`, which already owns the import-safety/lazy-load contract:

- every **absent** extra is ignored, and every **present** extra is **not** ignored — a broken gate would otherwise make `make test-garak` silently collect nothing
- the gated extras match the integration directories on disk
- the public surface still imports with garak absent

## Verification

Verified with garak both absent and installed. Both invocation forms now agree exactly:

| Command | Result |
|---|---|
| `uv run pytest libs/giskard-scan -m "not functional"` (repo root — previously 3 errors) | 171 passed, 44 skipped, 2 deselected |
| `uv run --directory libs/giskard-scan pytest tests src -m "not functional"` | 171 passed, 44 skipped, 2 deselected |
| `make test-unit PACKAGE=giskard` | exit 0 |

171 = the 168 baseline + the 3 new regression tests.

## Follow-up

`Makefile`'s `pytest-each-lib` comment cites the `--ignore` mechanism this PR removes. It is accurate until this merges, and is left to a follow-up to keep this PR independent of #2764.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
