### PR TITLE
fix(release): tag the meta package as vX.Y.Z

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,15 @@ jobs:
 
           NEW_VERSION=$(uv version --short)
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "tag=$PACKAGE/v$NEW_VERSION" >> $GITHUB_OUTPUT
+
+          # The meta package is tagged vX.Y.Z, continuing the scheme used up to
+          # v2.19.2, so downstream packagers that scrape tags keep matching it.
+          # Workspace members are namespaced to keep their version lines distinct.
+          if [ "$PACKAGE" = "giskard" ]; then
+            echo "tag=v$NEW_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "tag=$PACKAGE/v$NEW_VERSION" >> $GITHUB_OUTPUT
+          fi
 
       - name: Update lockfile
         run: uv lock


### PR DESCRIPTION
Fixes Giskard-AI/giskard-oss#2717

## Problem

The v3 monorepo migration namespaced every release tag by package, so the `giskard` meta package started shipping as `giskard/vX.Y.Z` instead of the `vX.Y.Z` format used through [v2.19.2](<https://github.com/Giskard-AI/giskard-oss/tree/v2.19.2>).

As [@noraj reported](<https://github.com/Giskard-AI/giskard-oss/issues/2717#issuecomment-5302609452>), Linux distribution packagers scrape GitHub tags to detect new versions, and the prefix silently broke them — see the [BlackArch `PKGBUILD`](<https://github.com/Zen1th53/blackarch/blob/d4ba74689c410ceaa210645ecd668d93aa85c781/packages/giskard/PKGBUILD#L20-L29>), whose version check no longer matches anything.

## Fix

Branch the tag name on the package being released, in the step that computes it — so `Create tag` and `Create GitHub Release` both pick up the right value with no further changes.

<!-- linear:table-colwidths:400,400 -->
| Package | Tag |
| -- | -- |
| `giskard` (meta) | `v3.0.0b4` |
| `giskard-core` | `giskard-core/v1.0.1b7` |
| `giskard-llm` | `giskard-llm/v1.0.0b7` |
| `giskard-agents` | `giskard-agents/v1.0.2b7` |
| `giskard-checks` | `giskard-checks/v1.0.2b7` |
| `giskard-scan` | `giskard-scan/v1.0.0b5` |

Workspace members keep their prefix — they need it, since their version lines overlap and would collide in a flat namespace. The flat `v*` namespace now consistently means *a release of the giskard distribution*, continuous from `v0.1.0` through `v2.19.2` to today.

## Already applied manually

The tag state has been migrated to match, so the next release lands in a consistent namespace:

* Backfilled `v3.0.0b3` → `14a67cd` (the only 3.x version on PyPI)
* Re-pointed the `giskard v3.0.0b3` GitHub Release onto that bare tag, assets and notes intact
* Deleted the legacy `giskard/v3.0.0b2` and `giskard/v3.0.0b3` tags, and the `giskard/v3.0.0b2` Release (b2 was never published to PyPI)

## Verification

* Workflow YAML parses; tag naming simulated for all six packages, output matches the table above
* `zizmor --persona=regular` reports no new findings (the one `github-app` finding is pre-existing on `main`, at an untouched step)
* No other file in the repo references the `giskard/v*` format

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)