### PR TITLE
chore: pin downstream packages to giskard-llm rc1

### DIFF
--- a/libs/giskard-agents/pyproject.toml
+++ b/libs/giskard-agents/pyproject.toml
@@ -7,7 +7,7 @@ license = { text = "MIT" }
 authors = [{ name = "Giskard R&D", email = "rnd@giskard.ai" }]
 requires-python = ">=3.12"
 dependencies = [
-    "giskard-llm>=1.0.0b6,<2",
+    "giskard-llm>=1.0.0rc1,<2",
     "pydantic>=2.11.0,<3",
     "griffe>=1.7.0,<3",
     "typing-extensions>=4.14.0,<5",
@@ -19,11 +19,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-openai = ["giskard-llm[openai]>=1.0.0b6,<2"]
-google = ["giskard-llm[google]>=1.0.0b6,<2"]
-anthropic = ["giskard-llm[anthropic]>=1.0.0b6,<2"]
+openai = ["giskard-llm[openai]>=1.0.0rc1,<2"]
+google = ["giskard-llm[google]>=1.0.0rc1,<2"]
+anthropic = ["giskard-llm[anthropic]>=1.0.0rc1,<2"]
 litellm = ["litellm>=1.83.0,<2"]
-all = ["giskard-llm[all]>=1.0.0b6,<2"]
+all = ["giskard-llm[all]>=1.0.0rc1,<2"]
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,10 @@ requires-python = ">=3.12"
 
 [project.optional-dependencies]
 # Native LLM providers
-openai = ["giskard-llm[openai]>=1.0.0b6,<2"]
-google = ["giskard-llm[google]>=1.0.0b6,<2"]
-anthropic = ["giskard-llm[anthropic]>=1.0.0b6,<2"]
-azure = ["giskard-llm[azure]>=1.0.0b6,<2"]
+openai = ["giskard-llm[openai]>=1.0.0rc1,<2"]
+google = ["giskard-llm[google]>=1.0.0rc1,<2"]
+anthropic = ["giskard-llm[anthropic]>=1.0.0rc1,<2"]
+azure = ["giskard-llm[azure]>=1.0.0rc1,<2"]
 
 # External LLM providers
 litellm = ["giskard-agents[litellm]>=1.0.2b6,<2"]
@@ -44,7 +44,7 @@ garak = ["giskard-scan[garak]>=1.0.0b4,<2"] # Heavy dep, not included by default
 deepteam = ["giskard-scan[deepteam]>=1.0.0b4,<2"] # Heavy dep, not included by default
 
 # Aggregated packages
-all-llms = ["giskard-llm[all]>=1.0.0b6,<2"] # Install all native LLM providers
+all-llms = ["giskard-llm[all]>=1.0.0rc1,<2"] # Install all native LLM providers
 all-checks = ["giskard-checks[all]>=1.0.2b6,<2"] # Install all optional checks dependencies
 full = ["giskard[all-llms,all-checks,scan,litellm]"]
 


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Coding agents

Autonomous agents with no human in the loop must read **[AUTONOMOUS.md](https://github.com/Giskard-AI/giskard-oss/blob/main/AUTONOMOUS.md)** before opening a PR.

**PR title:** agent-opened PRs **must** end the title with **`🤖🤖🤖🤖`** (exactly four robot emojis). Do not omit — that suffix is how the expedited agent PR workflow picks up the PR.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [ ] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been
  modified)
