### PR TITLE
chore: pin downstream packages to giskard-checks rc1

### DIFF
--- a/libs/giskard-scan/pyproject.toml
+++ b/libs/giskard-scan/pyproject.toml
@@ -7,7 +7,7 @@ license = { text = "Apache Software License 2.0" }
 authors = [{ name = "Giskard R&D", email = "rnd@giskard.ai" }]
 requires-python = ">=3.12"
 dependencies = [
-    "giskard-checks>=1.0.2b6,<2",
+    "giskard-checks>=1.0.2rc1,<2",
     "giskard-agents>=1.0.2rc1,<2",
     "numpy>=2.4.1,<3",
     "huggingface-hub>=1.11.0,<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 
-dependencies = ["giskard-checks>=1.0.2b6,<2"]
+dependencies = ["giskard-checks>=1.0.2rc1,<2"]
 
 requires-python = ">=3.12"
 
@@ -34,7 +34,7 @@ azure = ["giskard-llm[azure]>=1.0.0rc1,<2"]
 litellm = ["giskard-agents[litellm]>=1.0.2rc1,<2"]
 
 # Optional checks dependencies
-regorus = ["giskard-checks[regorus]>=1.0.2b6,<2"]
+regorus = ["giskard-checks[regorus]>=1.0.2rc1,<2"]
 
 # Optional giskard libs
 scan = ["giskard-scan>=1.0.0b4,<2"]
@@ -45,7 +45,7 @@ deepteam = ["giskard-scan[deepteam]>=1.0.0b4,<2"] # Heavy dep, not included by d
 
 # Aggregated packages
 all-llms = ["giskard-llm[all]>=1.0.0rc1,<2"] # Install all native LLM providers
-all-checks = ["giskard-checks[all]>=1.0.2b6,<2"] # Install all optional checks dependencies
+all-checks = ["giskard-checks[all]>=1.0.2rc1,<2"] # Install all optional checks dependencies
 full = ["giskard[all-llms,all-checks,scan,litellm]"]
 
 [project.urls]


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Coding agents

Autonomous agents with no human in the loop must read **[AUTONOMOUS.md](https://github.com/Giskard-AI/giskard-oss/blob/main/AUTONOMOUS.md)** before opening a PR.

**PR title:** agent-opened PRs **must** end the title with **`🤖🤖🤖🤖`** (exactly four robot emojis). Do not omit — that suffix is how the expedited agent PR workflow picks up the PR.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [ ] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been
  modified)
