### PR TITLE
feat(checks): add SARIF 2.1.0 exporter for GitHub code scanning

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/core/result.py
+++ b/libs/giskard-checks/src/giskard/checks/core/result.py
@@ -670,6 +670,17 @@ class SuiteResult(BaseResult, frozen=True):
 
         return to_junit_xml(self, path=path)
 
+    def to_sarif(self, path: str | Path | None = None) -> str:
+        """Convert the suite result into a SARIF 2.1.0 JSON document.
+
+        The returned string can be uploaded to GitHub code scanning via the
+        ``github/codeql-action/upload-sarif`` action. Only failing and
+        erroring checks become SARIF results.
+        """
+        from ..export.sarif import to_sarif
+
+        return to_sarif(self, path=path)
+
     def to_hub_format(self) -> dict[str, Any]:
         """Convert the suite result into a JSON-serializable Giskard Hub payload.
 

--- a/libs/giskard-checks/src/giskard/checks/export/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/export/__init__.py
@@ -1,4 +1,5 @@
 from .hub import to_hub_format
 from .junit import to_junit_xml
+from .sarif import to_sarif
 
-__all__ = ["to_hub_format", "to_junit_xml"]
+__all__ = ["to_hub_format", "to_junit_xml", "to_sarif"]

--- a/libs/giskard-checks/src/giskard/checks/export/sarif.py
+++ b/libs/giskard-checks/src/giskard/checks/export/sarif.py
@@ -1,0 +1,219 @@
+"""SARIF 2.1.0 exporter for ``SuiteResult``.
+
+SARIF puts each finding in the GitHub Security tab and as a PR annotation,
+with a rule, a level and a stable fingerprint. It answers a different
+question than JUnit: not "did the build pass" but "which findings changed
+across runs, and are any of them new".
+
+Design choices:
+
+* Only ``FAIL`` and ``ERROR`` checks become SARIF results. ``PASS`` and
+  ``SKIP`` are omitted so the Security tab is not swamped by an alert per
+  passing check.
+* Rules are keyed by ``check_kind`` (falling back to ``check_name``), so a
+  single rule covers every instance rather than one rule per scenario.
+* Scenario tags become rule tags, unioned across scenarios that use the
+  same check. This is where an OWASP or MITRE mapping later slots in.
+"""
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from importlib import metadata
+from pathlib import Path
+from typing import Any
+
+from ..core.result import CheckResult, ScenarioResult, SuiteResult
+
+SARIF_SCHEMA_URI = (
+    "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/"
+    "Documents/CommitteeSpecificationDrafts/2.1.0/CSD.2.1.0.json"
+)
+SARIF_VERSION = "2.1.0"
+TOOL_NAME = "giskard-checks"
+TOOL_INFORMATION_URI = "https://github.com/Giskard-AI/giskard-oss"
+
+
+def _tool_version() -> str:
+    try:
+        return metadata.version(TOOL_NAME)
+    except metadata.PackageNotFoundError:
+        return "unknown"
+
+
+def _rule_id(check: CheckResult) -> str:
+    details = check.details if isinstance(check.details, dict) else {}
+    return str(
+        details.get("check_kind") or details.get("check_name") or "unknown_check"
+    )
+
+
+def _rule_name(check: CheckResult) -> str:
+    details = check.details if isinstance(check.details, dict) else {}
+    return str(
+        details.get("check_name") or details.get("check_kind") or "Unknown check"
+    )
+
+
+def _sarif_level(check: CheckResult) -> str:
+    # FAIL is a security-relevant verdict; ERROR is a tooling problem that
+    # did not reach a verdict, so we surface it as a warning rather than
+    # an error to keep the two distinct in the Security tab.
+    if check.failed:
+        return "error"
+    return "warning"
+
+
+def _fingerprint(
+    rule_id: str,
+    scenario_name: str,
+    step_index: int,
+    check_index: int,
+) -> str:
+    digest = hashlib.sha256(
+        f"{rule_id}|{scenario_name}|{step_index}|{check_index}".encode("utf-8")
+    ).hexdigest()
+    return digest[:32]
+
+
+def _location(scenario_name: str, step_index: int, check_index: int) -> dict[str, Any]:
+    return {
+        "logicalLocations": [
+            {
+                "fullyQualifiedName": (
+                    f"{scenario_name}/step_{step_index}/check_{check_index}"
+                ),
+                "kind": "check",
+            }
+        ]
+    }
+
+
+def _build_rule(
+    rule_id: str,
+    rule_name: str,
+    tags: list[str],
+) -> dict[str, Any]:
+    rule: dict[str, Any] = {
+        "id": rule_id,
+        "name": rule_name,
+        "shortDescription": {"text": rule_name},
+        "fullDescription": {
+            "text": f"Giskard check '{rule_name}' evaluated against a scenario."
+        },
+        "defaultConfiguration": {"level": "warning"},
+    }
+    if tags:
+        rule["properties"] = {"tags": tags}
+    return rule
+
+
+def _build_result(
+    rule_id: str,
+    check: CheckResult,
+    scenario: ScenarioResult[Any],
+    step_index: int,
+    check_index: int,
+) -> dict[str, Any]:
+    message_text = check.message or (
+        f"{rule_id} did not pass in scenario {scenario.scenario_name!r}."
+    )
+    sarif_result: dict[str, Any] = {
+        "ruleId": rule_id,
+        "level": _sarif_level(check),
+        "message": {"text": message_text},
+        "locations": [_location(scenario.scenario_name, step_index, check_index)],
+        "partialFingerprints": {
+            "giskardCheck/v1": _fingerprint(
+                rule_id, scenario.scenario_name, step_index, check_index
+            )
+        },
+    }
+    properties: dict[str, Any] = {
+        "scenario": scenario.scenario_name,
+        "status": check.status.value,
+    }
+    if scenario.tags:
+        properties["scenarioTags"] = list(scenario.tags)
+    if check.metrics:
+        properties["metrics"] = {m.name: m.value for m in check.metrics}
+    sarif_result["properties"] = properties
+    return sarif_result
+
+
+def _iter_reportable(result: SuiteResult):
+    for scenario in result.results:
+        for step_index, step in enumerate(scenario.steps, start=1):
+            for check_index, check in enumerate(step.results, start=1):
+                if check.failed or check.errored:
+                    yield scenario, step_index, check_index, check
+
+
+def to_sarif(result: SuiteResult, path: str | Path | None = None) -> str:
+    """Serialize a ``SuiteResult`` to a SARIF 2.1.0 JSON string.
+
+    Parameters
+    ----------
+    result : SuiteResult
+        The suite result to export.
+    path : str or Path, optional
+        When provided, the SARIF document is also written to this file
+        (parent directories are created).
+
+    Returns
+    -------
+    str
+        The SARIF document as a JSON string.
+    """
+    rules_by_id: dict[str, dict[str, Any]] = {}
+    rule_tags: dict[str, set[str]] = {}
+    sarif_results: list[dict[str, Any]] = []
+
+    for scenario, step_index, check_index, check in _iter_reportable(result):
+        rule_id = _rule_id(check)
+        rule_tags.setdefault(rule_id, set()).update(scenario.tags)
+        if rule_id not in rules_by_id:
+            rules_by_id[rule_id] = _build_rule(rule_id, _rule_name(check), [])
+        sarif_results.append(
+            _build_result(rule_id, check, scenario, step_index, check_index)
+        )
+
+    for rule_id, rule in rules_by_id.items():
+        tags = sorted(rule_tags.get(rule_id, set()))
+        if tags:
+            rule.setdefault("properties", {})["tags"] = tags
+
+    document: dict[str, Any] = {
+        "$schema": SARIF_SCHEMA_URI,
+        "version": SARIF_VERSION,
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": TOOL_NAME,
+                        "version": _tool_version(),
+                        "informationUri": TOOL_INFORMATION_URI,
+                        "rules": list(rules_by_id.values()),
+                    }
+                },
+                "invocations": [
+                    {
+                        "executionSuccessful": True,
+                        "endTimeUtc": datetime.now(timezone.utc)
+                        .isoformat(timespec="seconds")
+                        .replace("+00:00", "Z"),
+                    }
+                ],
+                "results": sarif_results,
+            }
+        ],
+    }
+
+    serialized = json.dumps(document, ensure_ascii=False, indent=2, default=str)
+
+    if path is not None:
+        output_path = Path(path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(serialized, encoding="utf-8")
+
+    return serialized

--- a/libs/giskard-checks/tests/export/test_sarif.py
+++ b/libs/giskard-checks/tests/export/test_sarif.py
@@ -1,0 +1,229 @@
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import jsonschema
+import pytest
+from giskard.checks import (
+    CheckResult,
+    CheckStatus,
+    Metric,
+    ScenarioResult,
+    SuiteResult,
+    Trace,
+)
+from giskard.checks.export.sarif import to_sarif
+from giskard.checks.scenarios.suite import Suite
+
+SARIF_SCHEMA_URL = (
+    "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/"
+    "sarif-2.1/schema/sarif-schema-2.1.0.json"
+)
+
+
+def _sample_suite_result() -> SuiteResult:
+    from giskard.checks import TestCaseResult
+
+    return SuiteResult(
+        results=[
+            ScenarioResult(
+                scenario_name="scenario_pass",
+                steps=[
+                    TestCaseResult(
+                        results=[
+                            CheckResult(
+                                status=CheckStatus.PASS,
+                                message="grounded",
+                                details={
+                                    "check_name": "Groundedness",
+                                    "check_kind": "groundedness",
+                                },
+                            ),
+                        ],
+                        duration_ms=100,
+                    )
+                ],
+                duration_ms=100,
+                final_trace=Trace(),
+                tags=["threat-type:hallucination"],
+            ),
+            ScenarioResult(
+                scenario_name="scenario_fail",
+                steps=[
+                    TestCaseResult(
+                        results=[
+                            CheckResult(
+                                status=CheckStatus.FAIL,
+                                message="answer is not grounded",
+                                metrics=[Metric(name="confidence", value=0.2)],
+                                details={
+                                    "check_name": "Groundedness",
+                                    "check_kind": "groundedness",
+                                },
+                            )
+                        ],
+                        duration_ms=120,
+                    )
+                ],
+                duration_ms=120,
+                final_trace=Trace(),
+                tags=[
+                    "threat-type:hallucination",
+                    "owasp:llm-top-10-2025:LLM09",
+                ],
+            ),
+            ScenarioResult(
+                scenario_name="scenario_error",
+                steps=[
+                    TestCaseResult(
+                        results=[
+                            CheckResult(
+                                status=CheckStatus.ERROR,
+                                message="judge crashed",
+                                details={
+                                    "check_name": "LLMJudge",
+                                    "check_kind": "llm_judge",
+                                },
+                            )
+                        ],
+                        duration_ms=150,
+                    )
+                ],
+                duration_ms=150,
+                final_trace=Trace(),
+                tags=["threat-type:prompt-injection"],
+            ),
+            ScenarioResult(
+                scenario_name="scenario_skip",
+                steps=[
+                    TestCaseResult(
+                        results=[
+                            CheckResult(
+                                status=CheckStatus.SKIP,
+                                message="no retrieved context",
+                                details={
+                                    "check_name": "ContextRelevance",
+                                    "check_kind": "context_relevance",
+                                },
+                            )
+                        ],
+                        duration_ms=50,
+                    )
+                ],
+                duration_ms=50,
+                final_trace=Trace(),
+            ),
+        ],
+        duration_ms=420,
+        suite=Suite(name="test"),
+    )
+
+
+def test_to_sarif_only_reports_failures_and_errors() -> None:
+    document = json.loads(to_sarif(_sample_suite_result()))
+
+    assert document["version"] == "2.1.0"
+    assert "$schema" in document
+    assert len(document["runs"]) == 1
+    run = document["runs"][0]
+
+    assert run["tool"]["driver"]["name"] == "giskard-checks"
+
+    result_rule_ids = [r["ruleId"] for r in run["results"]]
+    assert result_rule_ids == ["groundedness", "llm_judge"]
+
+
+def test_to_sarif_maps_fail_to_error_and_error_to_warning() -> None:
+    document = json.loads(to_sarif(_sample_suite_result()))
+    results_by_scenario = {
+        r["properties"]["scenario"]: r for r in document["runs"][0]["results"]
+    }
+
+    assert results_by_scenario["scenario_fail"]["level"] == "error"
+    assert results_by_scenario["scenario_error"]["level"] == "warning"
+
+
+def test_to_sarif_deduplicates_rules_by_check_kind() -> None:
+    document = json.loads(to_sarif(_sample_suite_result()))
+    rules = document["runs"][0]["tool"]["driver"]["rules"]
+
+    rule_ids = [rule["id"] for rule in rules]
+    assert rule_ids == ["groundedness", "llm_judge"]
+    assert len(rule_ids) == len(set(rule_ids))
+
+
+def test_to_sarif_unions_scenario_tags_onto_rule() -> None:
+    document = json.loads(to_sarif(_sample_suite_result()))
+    rules_by_id = {
+        rule["id"]: rule for rule in document["runs"][0]["tool"]["driver"]["rules"]
+    }
+
+    assert rules_by_id["groundedness"]["properties"]["tags"] == [
+        "owasp:llm-top-10-2025:LLM09",
+        "threat-type:hallucination",
+    ]
+    assert rules_by_id["llm_judge"]["properties"]["tags"] == [
+        "threat-type:prompt-injection"
+    ]
+
+
+def test_to_sarif_includes_stable_partial_fingerprint() -> None:
+    doc_a = json.loads(to_sarif(_sample_suite_result()))
+    doc_b = json.loads(to_sarif(_sample_suite_result()))
+
+    prints_a = [r["partialFingerprints"] for r in doc_a["runs"][0]["results"]]
+    prints_b = [r["partialFingerprints"] for r in doc_b["runs"][0]["results"]]
+    assert prints_a == prints_b
+    assert all("giskardCheck/v1" in p for p in prints_a)
+
+
+def test_to_sarif_writes_file(tmp_path: Path) -> None:
+    output_path = tmp_path / "giskard.sarif"
+    serialized = to_sarif(_sample_suite_result(), path=output_path)
+
+    assert output_path.exists()
+    on_disk = json.loads(output_path.read_text(encoding="utf-8"))
+    assert json.loads(serialized) == on_disk
+
+
+def test_suite_result_convenience_method_matches_function() -> None:
+    suite_result = _sample_suite_result()
+
+    from_method = json.loads(suite_result.to_sarif())
+    from_function = json.loads(to_sarif(suite_result))
+
+    assert from_method["runs"][0]["results"] == from_function["runs"][0]["results"]
+
+
+def test_to_sarif_handles_empty_suite_result() -> None:
+    empty = SuiteResult(results=[], duration_ms=0, suite=Suite(name="empty"))
+    document = json.loads(to_sarif(empty))
+
+    run = document["runs"][0]
+    assert run["results"] == []
+    assert run["tool"]["driver"]["rules"] == []
+
+
+def test_to_sarif_omits_metrics_when_absent() -> None:
+    document = json.loads(to_sarif(_sample_suite_result()))
+    results_by_scenario = {
+        r["properties"]["scenario"]: r for r in document["runs"][0]["results"]
+    }
+
+    assert results_by_scenario["scenario_fail"]["properties"]["metrics"] == {
+        "confidence": 0.2
+    }
+    assert "metrics" not in results_by_scenario["scenario_error"]["properties"]
+
+
+@pytest.mark.integration
+def test_to_sarif_validates_against_official_schema() -> None:
+    try:
+        with urllib.request.urlopen(SARIF_SCHEMA_URL, timeout=10) as response:
+            schema = json.loads(response.read())
+    except (urllib.error.URLError, TimeoutError) as exc:
+        pytest.skip(f"Could not fetch SARIF schema: {exc}")
+
+    document = json.loads(to_sarif(_sample_suite_result()))
+    jsonschema.validate(instance=document, schema=schema)


### PR DESCRIPTION
Closes #2716.

## Summary

Adds `to_sarif()` alongside the existing JUnit and Hub exporters so a `SuiteResult` can be uploaded to GitHub code scanning:

```python
result = await suite.run(agent)
result.to_sarif("giskard.sarif")
```

```yaml
- uses: github/codeql-action/upload-sarif@v3
  with:
    sarif_file: giskard.sarif
```

Output validates against the official SARIF 2.1.0 schema (`test_to_sarif_validates_against_official_schema`, network-gated behind `--run-integration`).

## Design points from the issue

The issue author asked for a second opinion on three design decisions before opening a PR. I've made a call on each — happy to change any of them:

1. **Only failures and errors become results.** `PASS` and `SKIP` are omitted so the Security tab isn't buried under an alert per passing check. Matches the issue's proposal.
2. **Rules keyed by `check_kind`** (falling back to `check_name`), so one rule covers every instance of a given check rather than one rule per scenario.
3. **Scenario tags become rule tags, unioned across scenarios that touched the same rule.** This is the point the author most wanted feedback on; the union felt like the least-surprising default and leaves an OWASP/MITRE mapping able to slot in later as-is. Per-result `scenarioTags` are also emitted under `result.properties` so nothing is lost if a downstream consumer wants the raw per-scenario tagging.

Two extra choices I had to make:

- **Level mapping**: `FAIL → error`, `ERROR → warning`. `ERROR` is a tooling failure that didn't reach a verdict, so surfacing it as a warning keeps it distinct from a confirmed security failure in the Security tab.
- **Locations**: `logicalLocations` with `fullyQualifiedName = <scenario>/step_<i>/check_<j>`, since checks don't map to source lines. GitHub renders these without a `physicalLocation`. If you'd rather I emit a synthetic file URI for prettier PR annotations, easy to add.

## Implementation

- New file `libs/giskard-checks/src/giskard/checks/export/sarif.py` — mirrors `junit.py` in shape, no new dependencies.
- New method `SuiteResult.to_sarif(path=None)` next to `to_junit_xml()`.
- Exported from `giskard.checks.export`.

## Tests

`libs/giskard-checks/tests/export/test_sarif.py` — 10 tests covering:
- Only `FAIL`/`ERROR` reported (2 results, not 4).
- `FAIL → error`, `ERROR → warning`.
- Rule deduplication by `check_kind`.
- Scenario-tag union onto rules (deterministic, sorted).
- Stable `partialFingerprints` across runs.
- File-write path + return-value round-trip.
- `SuiteResult.to_sarif()` convenience method equivalence.
- Empty `SuiteResult` produces a valid empty document.
- Metrics propagated when present, omitted when absent.
- **Schema validation against the official SARIF 2.1.0 schema** (integration-marked; runs under `--run-integration`).

`make test-unit PACKAGE=giskard-checks` → **957 passed, 5 skipped**.

## Test plan

- [ ] `make test-unit PACKAGE=giskard-checks`
- [ ] `uv run pytest libs/giskard-checks/tests/export/test_sarif.py --run-integration` (needs network for the schema fetch)
- [ ] Optional: run against a real `SuiteResult` and upload to `codeql-action/upload-sarif@v3` in a scratch repo to confirm the Security tab rendering.