### PR TITLE
chore(ci): disable deployment tracking for tests and enforce base branch for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -55,7 +55,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # checkout repository
-    environment: ci
+    environment:
+      name: ci
+      deployment: false
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -113,7 +115,9 @@ jobs:
   test-llm-functional:
     needs: authorize
     runs-on: ubuntu-latest
-    environment: ci
+    environment:
+      name: ci
+      deployment: false
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -169,7 +173,9 @@ jobs:
   test-checks-functional:
     needs: authorize
     runs-on: ubuntu-latest
-    environment: ci
+    environment:
+      name: ci
+      deployment: false
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -206,7 +212,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # checkout repository
-    environment: ci
+    environment:
+      name: ci
+      deployment: false
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -233,7 +241,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # checkout repository
-    environment: ci
+    environment:
+      name: ci
+      deployment: false
     timeout-minutes: 45
     strategy:
       fail-fast: false

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,6 +2,7 @@ name: Integration Tests
 
 on:
   pull_request_target: # zizmor: ignore[dangerous-triggers] guarded by authorize job, label gate for external PRs, and immutable head.sha checkout
+    branches: [main]
     types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 


### PR DESCRIPTION
## Description

- Disable GitHub deployment creation for CI job
- Enforce `main` target branch on the integration-tests workflow

## Related Issue

None.

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔐 Security fix

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [ ] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been modified)
