### PR TITLE
feat(checks): add safe run_sync() convenience methods 🤖🤖🤖🤖

### DIFF
--- a/libs/giskard-checks/README.md
+++ b/libs/giskard-checks/README.md
@@ -88,18 +88,15 @@ scenario = (
 )
 ```
 
-The `run()` method is async. In a script, wrap it with `asyncio.run()`:
+Use `run_sync()` in a script without a running event loop. In notebooks and
+other async contexts, await `run()` directly:
 
 ```python
-import asyncio
+# Script / no running event loop
+result = scenario.run_sync()
 
-
-async def main():
-    result = await scenario.run()
-    print(result)
-
-
-asyncio.run(main())
+# Notebook, pytest async test, or async function
+result = await scenario.run()
 ```
 
 Running Multiple Scenarios with Suite

--- a/libs/giskard-checks/src/giskard/checks/core/_run_sync.py
+++ b/libs/giskard-checks/src/giskard/checks/core/_run_sync.py
@@ -1,0 +1,23 @@
+"""Shared support for synchronous wrappers around async run methods."""
+
+import asyncio
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+
+def run_sync[**P, T](
+    run: Callable[P, Coroutine[Any, Any, T]],
+    /,
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> T:
+    """Run an async callable when the current thread has no active event loop."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(run(*args, **kwargs))
+
+    raise RuntimeError(
+        "run_sync() cannot be called while an asyncio event loop is running; "
+        "use await obj.run(...) instead."
+    )

--- a/libs/giskard-checks/src/giskard/checks/core/scenario.py
+++ b/libs/giskard-checks/src/giskard/checks/core/scenario.py
@@ -1,8 +1,9 @@
-from typing import Any, ClassVar, Self
+from typing import Any, ClassVar, Self, overload
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.experimental.missing_sentinel import MISSING
 
+from ._run_sync import run_sync as _run_sync
 from .check import Check
 from .input_generator import InputGenerator
 from .interaction import Interact, InteractionSpec, Trace
@@ -324,6 +325,49 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
         """
         self.tags = tags
         return self
+
+    @overload
+    def run_sync(
+        self,
+        target: Target[InputType, OutputType, TraceType] | MISSING,
+        /,
+        return_exception: bool = False,
+        multiple_runs: int | None = None,
+    ) -> ScenarioResult[TraceType]: ...
+
+    @overload
+    def run_sync(
+        self,
+        *,
+        target: Target[InputType, OutputType, TraceType] | MISSING = MISSING,
+        return_exception: bool = False,
+        multiple_runs: int | None = None,
+    ) -> ScenarioResult[TraceType]: ...
+
+    def run_sync(self, *args: Any, **kwargs: Any) -> ScenarioResult[TraceType]:
+        """Execute the scenario synchronously.
+
+        Parameters
+        ----------
+        target : Target | MISSING, optional
+            SUT used to replace ``MISSING`` outputs on ``Interact`` specs.
+        return_exception : bool, default False
+            If True, return results when exceptions occur instead of raising.
+        multiple_runs : int | None, optional
+            Optional override for the maximum number of scenario executions.
+
+        Returns
+        -------
+        ScenarioResult[TraceType]
+            The scenario execution result.
+
+        Raises
+        ------
+        RuntimeError
+            If called while an asyncio event loop is already running. In that
+            case, use ``await scenario.run(...)`` instead.
+        """
+        return _run_sync(self.run, *args, **kwargs)
 
     async def run(
         self,

--- a/libs/giskard-checks/src/giskard/checks/core/testcase.py
+++ b/libs/giskard-checks/src/giskard/checks/core/testcase.py
@@ -1,14 +1,16 @@
 """Test case model and runner integration.
 
 `TestCase` binds a concrete `Trace` with a sequence of `Check`s and delegates
-execution to a `TestCaseRunner`. It offers a single `run()` method that returns a
-`TestCaseResult` summarizing the outcomes.
+execution to a `TestCaseRunner`. Its async `run()` and synchronous `run_sync()`
+methods return a `TestCaseResult` summarizing the outcomes.
 """
 
 from collections.abc import Sequence
+from typing import Any, overload
 
 from pydantic import BaseModel, Field
 
+from ._run_sync import run_sync as _run_sync
 from .check import Check
 from .interaction import Trace
 from .result import TestCaseResult
@@ -46,6 +48,33 @@ class TestCase[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
 
         runner = get_runner()
         return await runner.run(self, return_exception)
+
+    @overload
+    def run_sync(self, return_exception: bool, /) -> TestCaseResult: ...
+
+    @overload
+    def run_sync(self, *, return_exception: bool = False) -> TestCaseResult: ...
+
+    def run_sync(self, *args: Any, **kwargs: Any) -> TestCaseResult:
+        """Execute the test case synchronously.
+
+        Parameters
+        ----------
+        return_exception : bool, default False
+            If True, return results when exceptions occur instead of raising.
+
+        Returns
+        -------
+        TestCaseResult
+            The test case execution result.
+
+        Raises
+        ------
+        RuntimeError
+            If called while an asyncio event loop is already running. In that
+            case, use ``await test_case.run(...)`` instead.
+        """
+        return _run_sync(self.run, *args, **kwargs)
 
     async def assert_passed(self) -> None:
         """Run the test case and assert that it passed.

--- a/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
@@ -2,7 +2,7 @@ import asyncio
 import time
 from collections.abc import Iterable, Iterator
 from contextlib import contextmanager, nullcontext
-from typing import Any, Generic, Self, TypeVar
+from typing import Any, Generic, Self, TypeVar, overload
 
 from giskard.core import telemetry_capture, telemetry_run_context, telemetry_tag
 from pydantic import BaseModel, Field
@@ -22,6 +22,7 @@ from rich.progress import (
 from rich.text import Text
 
 from .._telemetry_props import suite_shape_properties
+from ..core._run_sync import run_sync as _run_sync
 from ..core.interaction import Trace
 from ..core.result import (
     STATUS_SUMMARY_ORDER,
@@ -161,6 +162,57 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
         """
         self.scenarios.append(scenario)
         return self
+
+    @overload
+    def run_sync(
+        self,
+        target: Target[InputType, OutputType, Trace[Any, Any]] | MISSING,
+        /,
+        return_exception: bool = False,
+        parallel: bool = False,
+        max_concurrency: int | None = None,
+        verbose: bool = True,
+    ) -> SuiteResult: ...
+
+    @overload
+    def run_sync(
+        self,
+        *,
+        target: Target[InputType, OutputType, Trace[Any, Any]] | MISSING = (MISSING),
+        return_exception: bool = False,
+        parallel: bool = False,
+        max_concurrency: int | None = None,
+        verbose: bool = True,
+    ) -> SuiteResult: ...
+
+    def run_sync(self, *args: Any, **kwargs: Any) -> SuiteResult:
+        """Run all scenarios in the suite synchronously.
+
+        Parameters
+        ----------
+        target : Target | MISSING, optional
+            Override target for all scenarios in the suite.
+        return_exception : bool, default False
+            If True, return results when exceptions occur instead of raising.
+        parallel : bool, default False
+            If True, run scenarios concurrently while preserving result order.
+        max_concurrency : int | None, optional
+            Maximum concurrent scenarios when ``parallel=True``.
+        verbose : bool, default True
+            If True, display execution progress.
+
+        Returns
+        -------
+        SuiteResult
+            The aggregated suite result.
+
+        Raises
+        ------
+        RuntimeError
+            If called while an asyncio event loop is already running. In that
+            case, use ``await suite.run(...)`` instead.
+        """
+        return _run_sync(self.run, *args, **kwargs)
 
     async def run(
         self,

--- a/libs/giskard-checks/tests/core/test_run_sync.py
+++ b/libs/giskard-checks/tests/core/test_run_sync.py
@@ -1,0 +1,140 @@
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import AsyncMock
+
+import pytest
+from giskard.checks import (
+    Scenario,
+    ScenarioResult,
+    Suite,
+    SuiteResult,
+    TestCase,
+    Trace,
+)
+from giskard.checks import TestCaseResult as CaseResult
+
+
+def _make_scenario():
+    return Scenario("sync scenario")
+
+
+def _make_suite():
+    return Suite(name="sync suite")
+
+
+def _make_test_case():
+    return TestCase(name="sync test case", trace=Trace(interactions=[]), checks=[])
+
+
+def _echo_target(inputs):
+    return inputs
+
+
+@pytest.mark.parametrize(
+    ("factory", "expected_type", "kwargs"),
+    [
+        pytest.param(_make_scenario, ScenarioResult, {}, id="scenario"),
+        pytest.param(_make_suite, SuiteResult, {"verbose": False}, id="suite"),
+        pytest.param(_make_test_case, CaseResult, {}, id="test-case"),
+    ],
+)
+def test_run_sync_executes(factory, expected_type, kwargs):
+    result = factory().run_sync(**kwargs)
+
+    assert isinstance(result, expected_type)
+
+
+@pytest.mark.parametrize(
+    ("factory", "args", "kwargs"),
+    [
+        pytest.param(
+            _make_scenario,
+            (_echo_target,),
+            {"return_exception": True, "multiple_runs": 2},
+            id="scenario",
+        ),
+        pytest.param(
+            _make_suite,
+            (_echo_target,),
+            {
+                "return_exception": True,
+                "parallel": True,
+                "max_concurrency": 2,
+                "verbose": False,
+            },
+            id="suite",
+        ),
+        pytest.param(
+            _make_test_case,
+            (),
+            {"return_exception": True},
+            id="test-case",
+        ),
+    ],
+)
+def test_run_sync_forwards_arguments_and_result(monkeypatch, factory, args, kwargs):
+    runnable = factory()
+    expected = object()
+    run = AsyncMock(return_value=expected)
+    monkeypatch.setattr(type(runnable), "run", run)
+
+    result = runnable.run_sync(*args, **kwargs)
+
+    assert result is expected
+    run.assert_awaited_once_with(*args, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [_make_scenario, _make_suite, _make_test_case],
+    ids=["scenario", "suite", "test-case"],
+)
+def test_run_sync_propagates_exception(monkeypatch, factory):
+    runnable = factory()
+    expected = ValueError("run failed")
+    run = AsyncMock(side_effect=expected)
+    monkeypatch.setattr(type(runnable), "run", run)
+
+    with pytest.raises(ValueError) as exc_info:
+        runnable.run_sync()
+
+    assert exc_info.value is expected
+    run.assert_awaited_once_with()
+
+
+@pytest.mark.parametrize(
+    ("factory", "expected_type", "kwargs"),
+    [
+        pytest.param(_make_scenario, ScenarioResult, {}, id="scenario"),
+        pytest.param(_make_suite, SuiteResult, {"verbose": False}, id="suite"),
+        pytest.param(_make_test_case, CaseResult, {}, id="test-case"),
+    ],
+)
+def test_run_sync_works_in_non_main_thread(factory, expected_type, kwargs):
+    runnable = factory()
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        result = executor.submit(runnable.run_sync, **kwargs).result(timeout=5)
+
+    assert isinstance(result, expected_type)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [_make_scenario, _make_suite, _make_test_case],
+    ids=["scenario", "suite", "test-case"],
+)
+async def test_run_sync_rejects_active_event_loop(monkeypatch, factory):
+    runnable = factory()
+    run = AsyncMock()
+    monkeypatch.setattr(type(runnable), "run", run)
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"^run_sync\(\) cannot be called while an asyncio event loop is running; "
+            r"use await obj\.run\(\.\.\.\) instead\.$"
+        ),
+    ):
+        runnable.run_sync()
+
+    run.assert_not_called()


### PR DESCRIPTION
## Description

- Add a shared internal helper that safely runs async callables from synchronous contexts.
- Add `run_sync()` to `Scenario`, `Suite`, and `TestCase` with exact argument forwarding and typed overloads.
- Reject calls from active event loops before creating a coroutine, with guidance to use `await obj.run(...)`.
- Document synchronous and asynchronous usage and cover all supported types with focused tests.

This pull request was implemented autonomously with assistance from OpenAI Codex (GPT-5).

## Related Issue

Closes #2782

## Type of Change

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Verification

- `make format`
- `make check`
- `make test-unit PACKAGE=giskard-checks` (963 passed, 4 skipped)
- `make test-examples` (4 passed)

The unit suite retains one pre-existing pytest collection warning from `tests/scenarios/test_testcase.py`.

## Coding agents

The autonomous contribution instructions in `AUTONOMOUS.md` were followed. OpenAI Codex (GPT-5) performed the implementation, tests, review, commit, and PR preparation.

## Checklist

- [x] Read the `CODE_OF_CONDUCT.md` document.
- [x] Read the `CONTRIBUTING.md` guide.
- [x] Written tests for all new methods and classes.
- [x] Written NumPy-format docstrings for all methods created or modified.
- [ ] Updated `uv.lock` (not applicable: no `pyproject.toml` changes).