### PR TITLE
fix(checks): reject empty text matchers 🤖🤖🤖🤖

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
@@ -109,6 +109,16 @@ class TextBasedCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignor
                 ),
             )
 
+        if matcher == "":
+            return (
+                None,
+                None,
+                CheckResult.error(
+                    message=f"Value for {matcher_name} must not be empty.",
+                    details=details,
+                ),
+            )
+
         # Validate text
         if isinstance(text, NoMatch):
             return (

--- a/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
@@ -109,12 +109,12 @@ class TextBasedCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignor
                 ),
             )
 
-        if matcher == "":
+        if not matcher.strip():
             return (
                 None,
                 None,
                 CheckResult.error(
-                    message=f"Value for {matcher_name} must not be empty.",
+                    message=f"Value for {matcher_name} must not be empty or whitespace-only.",
                     details=details,
                 ),
             )

--- a/libs/giskard-checks/tests/builtin/test_regex_matching.py
+++ b/libs/giskard-checks/tests/builtin/test_regex_matching.py
@@ -303,6 +303,15 @@ async def test_empty_pattern_from_trace_returns_error() -> None:
     assert "pattern must not be empty" in result.message.lower()
 
 
+async def test_whitespace_only_pattern_returns_error() -> None:
+    """Test that a whitespace-only regex pattern is rejected."""
+    check = RegexMatching(text="The capital of France is Paris.", pattern=" ")
+    result = await check.run(Trace())
+    assert result.status == CheckStatus.ERROR
+    assert result.message is not None
+    assert "pattern must not be empty" in result.message.lower()
+
+
 async def test_missing_pattern_validation() -> None:
     """Test that either pattern or pattern_key must be provided."""
     with pytest.raises(ValueError, match="pattern"):

--- a/libs/giskard-checks/tests/builtin/test_regex_matching.py
+++ b/libs/giskard-checks/tests/builtin/test_regex_matching.py
@@ -278,14 +278,29 @@ async def test_literal_special_chars_not_escaped() -> None:
 
 
 async def test_empty_pattern_regex_mode() -> None:
-    """Test behavior with empty pattern in regex mode."""
+    """Test that an empty pattern is rejected instead of matching every text."""
     check = RegexMatching(
         text="Hello",
         pattern="",
     )
     result = await check.run(Trace())
-    # Empty regex matches any string
-    assert result.status == CheckStatus.PASS
+    assert result.status == CheckStatus.ERROR
+    assert result.message is not None
+    assert "pattern must not be empty" in result.message.lower()
+
+
+async def test_empty_pattern_from_trace_returns_error() -> None:
+    """Test that an empty pattern extracted from a trace is rejected."""
+    check = RegexMatching(
+        text="Hello",
+        pattern_key="trace.last.inputs.pattern",
+    )
+    result = await check.run(
+        Trace(interactions=[Interaction(inputs={"pattern": ""}, outputs={})])
+    )
+    assert result.status == CheckStatus.ERROR
+    assert result.message is not None
+    assert "pattern must not be empty" in result.message.lower()
 
 
 async def test_missing_pattern_validation() -> None:

--- a/libs/giskard-checks/tests/builtin/test_string_matching.py
+++ b/libs/giskard-checks/tests/builtin/test_string_matching.py
@@ -329,11 +329,26 @@ async def test_empty_text() -> None:
 
 
 async def test_empty_keyword() -> None:
-    """Test behavior with empty keyword."""
+    """Test that an empty keyword is rejected instead of matching every text."""
     check = StringMatching(text="Hello", keyword="")
     result = await check.run(Trace())
-    # Empty string should be found in any text
-    assert result.status == CheckStatus.PASS
+    assert result.status == CheckStatus.ERROR
+    assert result.message is not None
+    assert "keyword must not be empty" in result.message.lower()
+
+
+async def test_empty_keyword_from_trace_returns_error() -> None:
+    """Test that an empty keyword extracted from a trace is rejected."""
+    check = StringMatching(
+        text="Hello",
+        keyword_key="trace.last.inputs.keyword",
+    )
+    result = await check.run(
+        Trace(interactions=[Interaction(inputs={"keyword": ""}, outputs={})])
+    )
+    assert result.status == CheckStatus.ERROR
+    assert result.message is not None
+    assert "keyword must not be empty" in result.message.lower()
 
 
 async def test_unicode_e_acute_nfc_nfd_matching() -> None:

--- a/libs/giskard-checks/tests/builtin/test_string_matching.py
+++ b/libs/giskard-checks/tests/builtin/test_string_matching.py
@@ -351,6 +351,15 @@ async def test_empty_keyword_from_trace_returns_error() -> None:
     assert "keyword must not be empty" in result.message.lower()
 
 
+async def test_whitespace_only_keyword_returns_error() -> None:
+    """Test that a whitespace-only keyword is rejected."""
+    check = StringMatching(text="The capital of France is Paris.", keyword=" ")
+    result = await check.run(Trace())
+    assert result.status == CheckStatus.ERROR
+    assert result.message is not None
+    assert "keyword must not be empty" in result.message.lower()
+
+
 async def test_unicode_e_acute_nfc_nfd_matching() -> None:
     """Test that 'é' (U+00E9) matches 'é' (U+0065 U+0301) with NFC normalization."""
     # U+00E9 is the composed form (NFC)


### PR DESCRIPTION
## Description

Reject empty keyword and pattern values before text matching. This prevents Python substring matching and regex search from treating empty matchers as universal matches. The shared validation path covers both direct values and values resolved from a trace.

## Related Issue

Fixes #2785

## Type of Change

- [x] 🔧 Bug fix (non-breaking change which fixes an issue)

## Coding agents

I have read `AUTONOMOUS.md` and followed its PR requirements.

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [x] I've written tests for the changed behavior.
- [x] I've written the docstring in NumPy format for modified methods and classes where applicable.
- [x] No lockfile update is needed because `pyproject.toml` was not modified.

## Validation

- `uv run --frozen --directory libs/giskard-checks pytest tests/builtin/test_string_matching.py tests/builtin/test_regex_matching.py -m "not functional" -q` (63 passed)
- `uv run --frozen ruff format --check .`
- `uv run --frozen ruff check .`
- `uv tool run basedpyright --level error libs/giskard-checks/src libs/giskard-checks/tests`
- `git diff --check`

The full `giskard-checks` unit suite ran 935 passed / 16 skipped / 3 failed. The failures are existing RegoPolicy tests that require `celine-regorus`; that optional dependency intentionally has no Windows wheel, so it cannot be installed on this host.