### PR TITLE
feat(checks): accept model strings in set_default_generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ in-place upgrade of the v2 API.
 - Optional, aggregated telemetry. Prompts, outputs, and scenario text are not
   sent. Set `DO_NOT_TRACK=1` or `GISKARD_TELEMETRY_DISABLED=1` before import to
   opt out.
+- `giskard.checks.set_default_generator` accepts a model identifier string
+  (e.g. `"openai/gpt-4o-mini"`) in addition to a `BaseGenerator` instance.
 
 ### Installation
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -157,14 +157,14 @@ Find a list of packages below
 - License: MIT License
 - Compatible: True
 
-### boto3-1.43.78
+### boto3-1.43.79
 
 - HomePage: https://github.com/boto/boto3
 - Author: Amazon Web Services
 - License: Apache-2.0
 - Compatible: True
 
-### botocore-1.43.78
+### botocore-1.43.79
 
 - HomePage: https://github.com/boto/botocore
 - Author: Amazon Web Services

--- a/libs/giskard-checks/README.md
+++ b/libs/giskard-checks/README.md
@@ -191,7 +191,7 @@ API Overview
 - `giskard.checks.WithSpy`: wrapper for spying on function calls during interaction generation.
 
 **Settings**
-- `giskard.checks.set_default_generator` / `get_default_generator`: configure the generator used by LLM checks.
+- `giskard.checks.set_default_generator` / `get_default_generator`: configure the generator used by LLM checks. `set_default_generator` accepts a `BaseGenerator` instance or a model identifier string (e.g. `"openai/gpt-4o-mini"`).
 - Environment variables (or `.env` at the project root), prefixed with `GISKARD_CHECKS_`:
   - `GISKARD_CHECKS_DEFAULT_MODEL` — default LLM model (default: `openai/gpt-4o-mini`).
   - `GISKARD_CHECKS_DEFAULT_EMBEDDING_MODEL` — default embedding model (default: `text-embedding-3-small`).
@@ -455,9 +455,8 @@ Use `UserSimulator` for LLM-powered user personas in multi-turn scenarios. Suppo
 
 ```python
 from giskard.checks import Scenario, UserSimulator, set_default_generator
-from giskard.agents.generators import Generator
 
-set_default_generator(Generator(model="openai/gpt-4o-mini"))
+set_default_generator("openai/gpt-4o-mini")
 
 result = await (
     Scenario("user-simulation")
@@ -473,8 +472,6 @@ LLM-based checks
 ----------------
 
 ```python
-from giskard.agents.generators import Generator
-
 from giskard.checks import (
     Conformity,
     LLMJudge,
@@ -483,7 +480,7 @@ from giskard.checks import (
 )
 
 # Configure the default LLM generator
-set_default_generator(Generator(model="openai/gpt-4o-mini"))
+set_default_generator("openai/gpt-4o-mini")
 
 result = await (
     Scenario("llm-example")

--- a/libs/giskard-checks/src/giskard/checks/settings.py
+++ b/libs/giskard-checks/src/giskard/checks/settings.py
@@ -70,7 +70,7 @@ def set_default_generator(generator: BaseGenerator | str) -> None:
     generator : BaseGenerator or str
         The generator to use as default for all LLM checks. A model
         identifier string (e.g. ``"openai/gpt-4o-mini"``) is wrapped in a
-        :class:`~giskard.agents.generators.Generator`.
+        :class:`~giskard.agents.Generator`.
 
     Examples
     --------
@@ -81,14 +81,12 @@ def set_default_generator(generator: BaseGenerator | str) -> None:
 
     Pass a generator instance when you need extra configuration::
 
-        from giskard.agents.generators import Generator
+        from giskard.agents import Generator
         from giskard.checks import set_default_generator
         set_default_generator(Generator(model="openai/gpt-4o-mini"))
     """
     global _default_generator
     if isinstance(generator, str):
-        from giskard.agents.generators import Generator
-
         _default_generator = Generator(model=generator)
     else:
         _default_generator = generator

--- a/libs/giskard-checks/src/giskard/checks/settings.py
+++ b/libs/giskard-checks/src/giskard/checks/settings.py
@@ -62,16 +62,36 @@ def get_settings() -> GiskardChecksSettings:
     return GiskardChecksSettings()
 
 
-def set_default_generator(generator: BaseGenerator) -> None:
+def set_default_generator(generator: BaseGenerator | str) -> None:
     """Set the default LLM generator for all checks.
 
     Parameters
     ----------
-    generator : BaseGenerator
-        The generator to use as default for all LLM checks.
+    generator : BaseGenerator or str
+        The generator to use as default for all LLM checks. A model
+        identifier string (e.g. ``"openai/gpt-4o-mini"``) is wrapped in a
+        :class:`~giskard.agents.generators.Generator`.
+
+    Examples
+    --------
+    Pass a model identifier::
+
+        from giskard.checks import set_default_generator
+        set_default_generator("openai/gpt-4o-mini")
+
+    Pass a generator instance when you need extra configuration::
+
+        from giskard.agents.generators import Generator
+        from giskard.checks import set_default_generator
+        set_default_generator(Generator(model="openai/gpt-4o-mini"))
     """
     global _default_generator
-    _default_generator = generator
+    if isinstance(generator, str):
+        from giskard.agents.generators import Generator
+
+        _default_generator = Generator(model=generator)
+    else:
+        _default_generator = generator
 
 
 def get_default_generator() -> BaseGenerator:

--- a/libs/giskard-checks/tests/core/test_settings.py
+++ b/libs/giskard-checks/tests/core/test_settings.py
@@ -38,6 +38,16 @@ def test_set_default_generator_overrides_settings(monkeypatch: pytest.MonkeyPatc
     assert get_default_generator() is explicit
 
 
+def test_set_default_generator_accepts_model_string(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("GISKARD_CHECKS_DEFAULT_MODEL", "google/gemini-3.5-flash")
+
+    set_default_generator("azure/gpt-5.6-luna")
+
+    generator = get_default_generator()
+    assert isinstance(generator, Generator)
+    assert generator.model == "azure/gpt-5.6-luna"
+
+
 def test_default_embedding_model_uses_settings(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv(
         "GISKARD_CHECKS_DEFAULT_EMBEDDING_MODEL", "google/gemini-embedding-001"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`set_default_generator` now accepts a model identifier string as well as a `BaseGenerator` instance. A string is wrapped in `giskard.agents.Generator`, so the common case no longer needs a separate import:

```python
from giskard.checks import set_default_generator

set_default_generator("azure/gpt-5.6-luna")
```

Passing a generator instance is unchanged, including identity:

```python
from giskard.agents import Generator
from giskard.checks import set_default_generator

set_default_generator(Generator(model="azure/gpt-5.6-luna"))
```

The string is converted with the existing `giskard.agents.Generator` import. A lazy `from giskard.agents.generators import Generator` is not used because `giskard-checks` may only import that library from the package root.

Also regenerates `THIRD_PARTY_NOTICES.md` (`boto3`/`botocore` 1.43.78 → 1.43.79) so `make check-notices` matches current `licensecheck` output.

## Related Issue

N/A — requested as an API convenience.

## Type of Change

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Coding agents

Autonomous agents with no human in the loop must read **[AUTONOMOUS.md](https://github.com/Giskard-AI/giskard-oss/blob/main/AUTONOMOUS.md)** before opening a PR.

**PR title:** agent-opened PRs **must** end the title with **`🤖🤖🤖🤖`** (exactly four robot emojis). Do not omit — that suffix is how the expedited agent PR workflow picks up the PR.

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [ ] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been modified)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e2261b0-26cb-4eab-9e84-77d45f8acf0b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e2261b0-26cb-4eab-9e84-77d45f8acf0b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

