### PR TITLE
chore: update third-party notices for boto3 1.43.80

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -157,14 +157,14 @@ Find a list of packages below
 - License: MIT License
 - Compatible: True
 
-### boto3-1.43.78
+### boto3-1.43.80
 
 - HomePage: https://github.com/boto/boto3
 - Author: Amazon Web Services
 - License: Apache-2.0
 - Compatible: True
 
-### botocore-1.43.78
+### botocore-1.43.80
 
 - HomePage: https://github.com/boto/botocore
 - Author: Amazon Web Services


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The [giskard-core stable Release run](https://github.com/Giskard-AI/giskard-oss/actions/runs/32915118816) failed at `make check` / `check-notices`: generated notices listed `boto3`/`botocore` **1.43.80** while `THIRD_PARTY_NOTICES.md` still had **1.43.78**.

This PR regenerates notices with `make generate-notices` so Release can be re-run on `main`.

No package versions or lockfile changes.

## Related Issue

Unblocks the stable lib release cascade (core 1.0.1 first).

## Type of Change

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Coding agents

Autonomous agents with no human in the loop must read **[AUTONOMOUS.md](https://github.com/Giskard-AI/giskard-oss/blob/main/AUTONOMOUS.md)** before opening a PR.

**PR title:** agent-opened PRs **must** end the title with **`🤖🤖🤖🤖`** (exactly four robot emojis). Do not omit — that suffix is how the expedited agent PR workflow picks up the PR.

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [ ] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been
  modified)

After this merges, re-dispatch [Release](https://github.com/Giskard-AI/giskard-oss/actions/workflows/release.yml) on `main`: `package=giskard-core`, `bump_type=none`, `release_type=stable`, `dry_run=false`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1e0c92e-8399-4b58-9375-18c050a6bab8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1e0c92e-8399-4b58-9375-18c050a6bab8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

