### PR TITLE
chore: pin downstream packages to giskard-checks 1.0.2

### DIFF
--- a/libs/giskard-scan/pyproject.toml
+++ b/libs/giskard-scan/pyproject.toml
@@ -7,7 +7,7 @@ license = { text = "Apache Software License 2.0" }
 authors = [{ name = "Giskard R&D", email = "rnd@giskard.ai" }]
 requires-python = ">=3.12"
 dependencies = [
-    "giskard-checks>=1.0.2rc1,<2",
+    "giskard-checks>=1.0.2,<2",
     "giskard-agents>=1.0.2,<2",
     "numpy>=2.4.1,<3",
     "huggingface-hub>=1.11.0,<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 
-dependencies = ["giskard-checks>=1.0.2rc1,<2"]
+dependencies = ["giskard-checks>=1.0.2,<2"]
 
 requires-python = ">=3.12"
 
@@ -34,7 +34,7 @@ azure = ["giskard-llm[azure]>=1.0.0,<2"]
 litellm = ["giskard-agents[litellm]>=1.0.2,<2"]
 
 # Optional checks dependencies
-regorus = ["giskard-checks[regorus]>=1.0.2rc1,<2"]
+regorus = ["giskard-checks[regorus]>=1.0.2,<2"]
 
 # Optional giskard libs
 scan = ["giskard-scan>=1.0.0rc1,<2"]
@@ -45,7 +45,7 @@ deepteam = ["giskard-scan[deepteam]>=1.0.0rc1,<2"] # Heavy dep, not included by 
 
 # Aggregated packages
 all-llms = ["giskard-llm[all]>=1.0.0,<2"] # Install all native LLM providers
-all-checks = ["giskard-checks[all]>=1.0.2rc1,<2"] # Install all optional checks dependencies
+all-checks = ["giskard-checks[all]>=1.0.2,<2"] # Install all optional checks dependencies
 full = ["giskard[all-llms,all-checks,scan,litellm]"]
 
 [project.urls]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`giskard-checks` **1.0.2** is on PyPI and tagged as [`giskard-checks/v1.0.2`](https://github.com/Giskard-AI/giskard-oss/releases/tag/giskard-checks/v1.0.2) ([Release run](https://github.com/Giskard-AI/giskard-oss/actions/runs/32917005183)).

This PR pins downstream packages to the stable version instead of the RC, matching [#2778](https://github.com/Giskard-AI/giskard-oss/pull/2778):

- `giskard-checks>=1.0.2rc1,<2` → `giskard-checks>=1.0.2,<2` in `giskard-scan` and the root `giskard` dependencies / extras

`uv.lock` is unchanged (workspace sources).

After this merges, the next step is Release for `giskard-scan` (`bump_type=none`, `release_type=stable`, `dry_run=false`).

## Related Issue

Stable lib release cascade: core → llm → agents → checks (this pin) → scan → meta `giskard`.

## Type of Change

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Coding agents

Autonomous agents with no human in the loop must read **[AUTONOMOUS.md](https://github.com/Giskard-AI/giskard-oss/blob/main/AUTONOMOUS.md)** before opening a PR.

**PR title:** agent-opened PRs **must** end the title with **`🤖🤖🤖🤖`** (exactly four robot emojis). Do not omit — that suffix is how the expedited agent PR workflow picks up the PR.

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [x] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been
  modified)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1e0c92e-8399-4b58-9375-18c050a6bab8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1e0c92e-8399-4b58-9375-18c050a6bab8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

