### PR TITLE
docs: remove beta status from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 <br />
 
 > [!IMPORTANT]
-> **Giskard v3** is a fresh rewrite designed for dynamic, multi-turn testing of AI agents. This release drops heavy dependencies for better efficiency while introducing a more powerful AI vulnerability scanner and enhanced RAG evaluation — both now shipping natively in `giskard-scan` (beta), with no dependency on v2. Only the legacy scan for **tabular/ML models** remains v2-only.
+> **Giskard v3** is a fresh rewrite designed for dynamic, multi-turn testing of AI agents. This release drops heavy dependencies for better efficiency while introducing a more powerful AI vulnerability scanner and enhanced RAG evaluation — both now shipping natively in `giskard-scan`, with no dependency on v2. Only the legacy scan for **tabular/ML models** remains v2-only.
 > **Giskard v2 remains available but is no longer actively maintained.**
 > Follow progress → [Read the v3 Announcement](https://github.com/orgs/Giskard-AI/discussions/2250) · [Roadmap](https://github.com/Giskard-AI/giskard-oss/issues/2252)
 
@@ -53,8 +53,8 @@ Giskard is an open-source Python library for **testing and evaluating agentic sy
 
 | Status         | Package          | Description                                                                                                                                                              |
 | -------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| ✅ Beta        | `giskard-checks` | Testing & evaluation — scenario API, built-in checks, LLM-as-judge                                                                                                       |
-| ✅ Beta        | `giskard-scan`   | Agent vulnerability scanner + RAG/quality evaluation — red teaming, prompt injection, jailbreaks & harmful content (`vulnerability_scan`, successor of [v2 Scan](https://legacy-docs.giskard.ai/en/stable/open_source/scan/index.html)), plus knowledge-base quality eval (`quality_scan`, successor of [v2 RAGET](https://legacy-docs.giskard.ai/en/stable/open_source/testset_generation/index.html)) |
+| ✅ Stable      | `giskard-checks` | Testing & evaluation — scenario API, built-in checks, LLM-as-judge                                                                                                       |
+| ✅ Stable      | `giskard-scan`   | Agent vulnerability scanner + RAG/quality evaluation — red teaming, prompt injection, jailbreaks & harmful content (`vulnerability_scan`, successor of [v2 Scan](https://legacy-docs.giskard.ai/en/stable/open_source/scan/index.html)), plus knowledge-base quality eval (`quality_scan`, successor of [v2 RAGET](https://legacy-docs.giskard.ai/en/stable/open_source/testset_generation/index.html)) |
 
 These build on three foundational libraries — `giskard-core` (shared utilities & telemetry), `giskard-llm` (provider-agnostic LLM routing), and `giskard-agents` (agent & workflow orchestration) — which are pulled in automatically and rarely used directly.
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -157,14 +157,14 @@ Find a list of packages below
 - License: MIT License
 - Compatible: True
 
-### boto3-1.43.81
+### boto3-1.43.82
 
 - HomePage: https://github.com/boto/boto3
 - Author: Amazon Web Services
 - License: Apache-2.0
 - Compatible: True
 
-### botocore-1.43.81
+### botocore-1.43.82
 
 - HomePage: https://github.com/boto/botocore
 - Author: Amazon Web Services

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 
-dependencies = ["giskard-checks>=1.0.2,<2"]
+dependencies = ["giskard-checks>=1.0.3,<2"]
 
 requires-python = ">=3.12"
 
@@ -34,7 +34,7 @@ azure = ["giskard-llm[azure]>=1.0.0,<2"]
 litellm = ["giskard-agents[litellm]>=1.0.2,<2"]
 
 # Optional checks dependencies
-regorus = ["giskard-checks[regorus]>=1.0.2,<2"]
+regorus = ["giskard-checks[regorus]>=1.0.3,<2"]
 
 # Optional giskard libs
 scan = ["giskard-scan>=1.0.0,<2"]
@@ -45,7 +45,7 @@ deepteam = ["giskard-scan[deepteam]>=1.0.0,<2"] # Heavy dep, not included by def
 
 # Aggregated packages
 all-llms = ["giskard-llm[all]>=1.0.0,<2"] # Install all native LLM providers
-all-checks = ["giskard-checks[all]>=1.0.2,<2"] # Install all optional checks dependencies
+all-checks = ["giskard-checks[all]>=1.0.3,<2"] # Install all optional checks dependencies
 full = ["giskard[all-llms,all-checks,scan,litellm]"]
 
 [project.urls]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Remove beta labeling from the root README now that v3 packages ship stable versions (`giskard-checks` / `giskard-scan` at 1.x, meta package at 3.0.0).

- Drop `(beta)` from the v3 callout for `giskard-scan`
- Update the package status table from ✅ Beta to ✅ Stable

## Related Issue

N/A

## Type of Change

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [ ] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been modified)

## Evidence

Regenerated `THIRD_PARTY_NOTICES.md` after the main merge so `check-notices` passes in CI (boto3/botocore 1.43.82). Local `make check` passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f8092c6-f496-410c-b155-3987f496fff5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f8092c6-f496-410c-b155-3987f496fff5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

