### PR TITLE
fix(agents): preserve api_base generation parameter

### DIFF
--- a/libs/giskard-agents/src/giskard/agents/generators/_types.py
+++ b/libs/giskard-agents/src/giskard/agents/generators/_types.py
@@ -18,6 +18,8 @@ class GenerationParams(BaseModel):
         List of tools available to the model.
     timeout : float | int | None, optional
         Maximum time in seconds to wait for the completion request.
+    api_base : str | None, optional
+        Base URL for OpenAI-compatible completion endpoints.
     """
 
     temperature: float = Field(default=1.0)
@@ -25,6 +27,7 @@ class GenerationParams(BaseModel):
     response_format: type[BaseModel] | None = Field(default=None)
     tools: list[Tool] = Field(default_factory=list)
     timeout: float | int | None = Field(default=None)
+    api_base: str | None = Field(default=None)
 
     def merge(self, overrides: "GenerationParams | None") -> "GenerationParams":
         """Return a copy with *overrides*' explicitly-set fields applied on top.

--- a/libs/giskard-agents/tests/test_litellm_generator.py
+++ b/libs/giskard-agents/tests/test_litellm_generator.py
@@ -71,6 +71,16 @@ async def test_litellm_generator_forwards_params(mock_acompletion: Any) -> None:
     assert kwargs["max_tokens"] == 50
 
 
+async def test_litellm_generator_forwards_api_base(mock_acompletion: Any) -> None:
+    """Custom OpenAI-compatible endpoints survive params serialization."""
+    generator = LiteLLMGenerator(model="openai/test-model").with_params(
+        api_base="http://127.0.0.1:1234/v1"
+    )
+    await generator.complete(messages=_USER_MESSAGE)
+
+    assert mock_acompletion.call_args.kwargs["api_base"] == "http://127.0.0.1:1234/v1"
+
+
 async def test_litellm_generator_sanitizes_response_format_schema_name(
     mock_acompletion: Any,
 ) -> None:


### PR DESCRIPTION
## Summary

- add `api_base` to `GenerationParams`
- preserve custom OpenAI-compatible endpoints for both generator adapters

Closes #2802.

## Validation

- `uv run --directory libs/giskard-agents ruff check src/giskard/agents/generators/_types.py tests/test_litellm_generator.py` — passed
- `git diff --check` — passed
- `uv run --frozen pytest libs/giskard-agents/tests/test_litellm_generator.py -q` — blocked during conftest import because the frozen environment lacks `posthog`
