### PR TITLE
ci: enforce detect-secrets in CI 🤖🤖🤖🤖

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,6 +133,15 @@
     }
   ],
   "results": {
+    "AGENTS.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "AGENTS.md",
+        "hashed_secret": "eb071a8890bb7296cd433abd885cb1fa814b3dea",
+        "is_verified": false,
+        "line_number": 59
+      }
+    ],
     "libs/giskard-llm/tests/functional/test_completion.py": [
       {
         "type": "Secret Keyword",
@@ -291,5 +300,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-22T08:27:18Z"
+  "generated_at": "2026-08-29T15:12:01Z"
 }

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,11 @@ install: ## Install project dependencies
 # `make check` red on a tree nobody touched. Pinned for the same reason as
 # LICENSECHECK_VERSION below.
 RUFF_VERSION := 0.16.1
+DETECT_SECRETS_VERSION := 1.5.0
 
 install-tools: ## Install development tools
 	uv tool install ruff==$(RUFF_VERSION)
+	uv tool install detect-secrets==$(DETECT_SECRETS_VERSION)
 	uv tool install vermin
 	uv tool install basedpyright
 	uv tool install pre-commit --with pre-commit-uv
@@ -156,6 +158,9 @@ typecheck: ## Run type checking with basedpyright
 security: ## Check for security vulnerabilities
 	uv run pip-audit --skip-editable
 
+check-secrets: ## Check for secrets not covered by the audited baseline
+	uv tool run detect-secrets==$(DETECT_SECRETS_VERSION) scan --baseline .secrets.baseline
+
 # Run licensecheck INSIDE the synced project env (uv run --with, not uvx): it reads
 # each package's version from the installed env via importlib, so output is pinned to
 # uv.lock instead of whatever PyPI resolves to at runtime. Pinned for reproducibility.
@@ -219,7 +224,7 @@ bump-workspace-pins: ## Rewrite >= pins for PACKAGE to VERSION (used by the rele
 	@test -n "$(VERSION)" || { echo "VERSION is required (e.g. PACKAGE=giskard-checks VERSION=1.0.3)"; exit 1; }
 	uv run python tools/bump_workspace_pins.py "$(PACKAGE)" "$(VERSION)"
 
-check: lint check-format check-compat typecheck security check-licenses check-notices check-extra-pins ## Run all checks
+check: lint check-format check-compat typecheck security check-secrets check-licenses check-notices check-extra-pins ## Run all checks
 
 clean: ## Clean up build artifacts and caches
 	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Add pinned `detect-secrets` tooling and a reusable `check-secrets` Make target.
- Include the target in `make check`, which is the existing CI lint gate.
- Regenerate the baseline with the audited documentation false positive in `AGENTS.md`.

All existing findings are intentional test fixtures or environment-variable references; intentional exceptions use `pragma: allowlist secret`.

## Validation

- `uv tool run detect-secrets==1.5.0 scan --baseline .secrets.baseline`
- `git diff --check`

Full Make targets could not run locally because `make` is unavailable in the environment.