### PR TITLE
fix(deps): resolve NLTK vulnerability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ security: ## Check for security vulnerabilities
 # each package's version from the installed env via importlib, so output is pinned to
 # uv.lock instead of whatever PyPI resolves to at runtime. Pinned for reproducibility.
 LICENSECHECK_VERSION := 2026.0.8
-LICENSECHECK := uv run --with licensecheck==$(LICENSECHECK_VERSION) licensecheck --license MIT
+LICENSECHECK := uv run --locked --all-extras --with licensecheck==$(LICENSECHECK_VERSION) licensecheck --license MIT
 # Scan scope for the default license/notices gate. Keep this aligned with what
 # `pip install giskard[full]` actually pulls: optional scan extras `garak` and
 # `deepteam` are intentionally omitted here. Their transitive trees are large

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -157,14 +157,14 @@ Find a list of packages below
 - License: MIT License
 - Compatible: True
 
-### boto3-1.43.46
+### boto3-1.43.38
 
 - HomePage: https://github.com/boto/boto3
 - Author: Amazon Web Services
 - License: Apache-2.0
 - Compatible: True
 
-### botocore-1.43.46
+### botocore-1.43.38
 
 - HomePage: https://github.com/boto/botocore
 - Author: Amazon Web Services
@@ -598,7 +598,7 @@ Find a list of packages below
 - License: MIT
 - Compatible: True
 
-### s3transfer-0.19.1
+### s3transfer-0.19.0
 
 - HomePage: https://github.com/boto/s3transfer
 - Author: Amazon Web Services

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -157,14 +157,14 @@ Find a list of packages below
 - License: MIT License
 - Compatible: True
 
-### boto3-1.43.82
+### boto3-1.43.46
 
 - HomePage: https://github.com/boto/boto3
 - Author: Amazon Web Services
 - License: Apache-2.0
 - Compatible: True
 
-### botocore-1.43.82
+### botocore-1.43.46
 
 - HomePage: https://github.com/boto/botocore
 - Author: Amazon Web Services
@@ -444,7 +444,7 @@ Find a list of packages below
 - License: Apache License 2.0
 - Compatible: True
 
-### nltk-3.10.0
+### nltk-3.10.3
 
 - HomePage: https://www.nltk.org/
 - Author: NLTK Team
@@ -598,7 +598,7 @@ Find a list of packages below
 - License: MIT
 - Compatible: True
 
-### s3transfer-0.19.2
+### s3transfer-0.19.1
 
 - HomePage: https://github.com/boto/s3transfer
 - Author: Amazon Web Services

--- a/uv.lock
+++ b/uv.lock
@@ -2818,7 +2818,7 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.10.0"
+version = "3.10.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -2827,9 +2827,9 @@ dependencies = [
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/02/df4f105b28a7c16b0e41423bc09cf0f1b8a305df4ef0b10ca74a2e4c648c/nltk-3.10.0.tar.gz", hash = "sha256:4fbac1d98203cbcd1b5d94a2877fb822300072d80604a5e7fae49d2c5f84e8c1", size = 3089244, upload-time = "2026-07-08T02:39:13.562Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/e6/fe51d2bb1a3b446f59c5c8165999a9fee208bc346af90a7cbf7657bc0d75/nltk-3.10.3.tar.gz", hash = "sha256:bb9327a461c3811c2fa4900e03840401f2126adfb30c0072827c433bd2444ea4", size = 5137152, upload-time = "2026-08-12T23:46:37.258Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/89/a0b0f35e2820d6a99d75ea1c11977ee6d5c9e6658eceb45b0c7620881faa/nltk-3.10.0-py3-none-any.whl", hash = "sha256:54ff84d4916d3ef127e8953bee0023f6a6b320b75d634a19e06ef056d3d244bf", size = 1716144, upload-time = "2026-07-08T02:39:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6d/ebd2af4640b12168fdf0cb74b6118df2f32a2f62ec7e0c06fbfd80706639/nltk-3.10.3-py3-none-any.whl", hash = "sha256:ff9598a8e20518ee0d557745890cc4435b9578489e2dcbc69c4f81fa060caf7c", size = 1798643, upload-time = "2026-08-12T23:44:13.478Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Resolves the vulnerable transitive NLTK release so dependency audits no longer report PYSEC-2026-3726. The lockfile now uses NLTK 3.10.3.

## Related Issue

None.

## Type of Change

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔐 Security fix

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [ ] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been
  modified)

Validation: `uv run pip-audit --skip-editable`, `make format`, `make check`, and `make test-unit PACKAGE=giskard-checks` passed.
