### PR TITLE
feat(telemetry): measure scan and hub export

### DIFF
--- a/libs/giskard-checks/README.md
+++ b/libs/giskard-checks/README.md
@@ -20,7 +20,7 @@ pip install giskard-checks
 
 Requires Python >= 3.12.
 
-**Telemetry:** This package depends on `giskard-core`, which may send **optional, aggregated usage analytics** when you run scenarios, suites, or test cases (no prompts, outputs, or scenario text). See **[Telemetry](../giskard-core/README.md#telemetry)** in the `giskard-core` README for what is collected and how to opt out (`DO_NOT_TRACK`, `GISKARD_TELEMETRY_DISABLED`, `GISKARD_TELEMETRY_DISABLE_GEOIP`, or `disable_telemetry()`).
+**Telemetry:** This package depends on `giskard-core`, which may send **optional, aggregated usage analytics** when you run scenarios, suites, or test cases, or export a result to the Hub format (no prompts, outputs, or scenario text). See **[Telemetry](../giskard-core/README.md#telemetry)** in the `giskard-core` README for what is collected and how to opt out (`DO_NOT_TRACK`, `GISKARD_TELEMETRY_DISABLED`, `GISKARD_TELEMETRY_DISABLE_GEOIP`, or `disable_telemetry()`).
 
 **Dependencies:**
 - `pydantic>=2.12` - Core data validation and serialization

--- a/libs/giskard-checks/src/giskard/checks/export/hub.py
+++ b/libs/giskard-checks/src/giskard/checks/export/hub.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from giskard.core import scoped_telemetry, telemetry_capture
+from giskard.core import scoped_telemetry, telemetry_capture, telemetry_tag
 
 from ..core.result import SuiteResult
 
@@ -23,6 +23,9 @@ def to_hub_format(result: SuiteResult) -> dict[str, Any]:
     dict[str, Any]
         JSON-serializable representation of the suite result
     """
+    telemetry_tag("giskard_component", "export")
+    telemetry_tag("giskard_operation", "to_hub_format")
+    payload = result.model_dump(mode="json", fallback=str)
     telemetry_capture(
         "checks_hub_exported",
         properties={
@@ -35,4 +38,4 @@ def to_hub_format(result: SuiteResult) -> dict[str, Any]:
             "has_recommendation": bool(result.recommendation),
         },
     )
-    return result.model_dump(mode="json", fallback=str)
+    return payload

--- a/libs/giskard-checks/src/giskard/checks/export/hub.py
+++ b/libs/giskard-checks/src/giskard/checks/export/hub.py
@@ -2,9 +2,12 @@
 
 from typing import Any
 
+from giskard.core import scoped_telemetry, telemetry_capture
+
 from ..core.result import SuiteResult
 
 
+@scoped_telemetry
 def to_hub_format(result: SuiteResult) -> dict[str, Any]:
     """Convert a SuiteResult into a JSON-serializable Giskard Hub payload.
 
@@ -20,4 +23,16 @@ def to_hub_format(result: SuiteResult) -> dict[str, Any]:
     dict[str, Any]
         JSON-serializable representation of the suite result
     """
+    telemetry_capture(
+        "checks_hub_exported",
+        properties={
+            "integration": "giskard-checks",
+            "scenario_count": len(result.results),
+            "passed_count": result.passed_count,
+            "failed_count": result.failed_count,
+            "errored_count": result.errored_count,
+            "skipped_count": result.skipped_count,
+            "has_recommendation": bool(result.recommendation),
+        },
+    )
     return result.model_dump(mode="json", fallback=str)

--- a/libs/giskard-checks/tests/export/test_hub.py
+++ b/libs/giskard-checks/tests/export/test_hub.py
@@ -18,10 +18,27 @@ def test_to_hub_format_pass_rate_null_when_empty() -> None:
 
 def test_to_hub_format_emits_aggregate_paid_intent_telemetry(monkeypatch) -> None:
     events: list[tuple[str, dict[str, object]]] = []
+    tags: list[tuple[str, str]] = []
+    call_order: list[str] = []
+    original_model_dump = SuiteResult.model_dump
+
+    def model_dump_spy(self, *args, **kwargs):
+        call_order.append("model_dump")
+        return original_model_dump(self, *args, **kwargs)
+
+    monkeypatch.setattr(SuiteResult, "model_dump", model_dump_spy)
     monkeypatch.setattr(
         hub_module,
         "telemetry_capture",
-        lambda event, *, properties: events.append((event, properties)),
+        lambda event, *, properties: (
+            call_order.append("telemetry_capture"),
+            events.append((event, properties)),
+        ),
+    )
+    monkeypatch.setattr(
+        hub_module,
+        "telemetry_tag",
+        lambda key, value: tags.append((key, value)),
     )
 
     result = SuiteResult(
@@ -29,6 +46,11 @@ def test_to_hub_format_emits_aggregate_paid_intent_telemetry(monkeypatch) -> Non
     )
     to_hub_format(result)
 
+    assert call_order == ["model_dump", "telemetry_capture"]
+    assert tags == [
+        ("giskard_component", "export"),
+        ("giskard_operation", "to_hub_format"),
+    ]
     assert events == [
         (
             "checks_hub_exported",

--- a/libs/giskard-checks/tests/export/test_hub.py
+++ b/libs/giskard-checks/tests/export/test_hub.py
@@ -1,6 +1,7 @@
 """Tests for Hub format export."""
 
 from giskard.checks.core.result import SuiteResult
+from giskard.checks.export import hub as hub_module
 from giskard.checks.export.hub import to_hub_format
 
 
@@ -13,3 +14,33 @@ def test_to_hub_format_pass_rate_null_when_empty() -> None:
     payload = to_hub_format(SuiteResult(results=[], duration_ms=0))
     assert "pass_rate" in payload
     assert payload["pass_rate"] is None
+
+
+def test_to_hub_format_emits_aggregate_paid_intent_telemetry(monkeypatch) -> None:
+    events: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        hub_module,
+        "telemetry_capture",
+        lambda event, *, properties: events.append((event, properties)),
+    )
+
+    result = SuiteResult(
+        results=[], duration_ms=123, recommendation="private recommendation"
+    )
+    to_hub_format(result)
+
+    assert events == [
+        (
+            "checks_hub_exported",
+            {
+                "integration": "giskard-checks",
+                "scenario_count": 0,
+                "passed_count": 0,
+                "failed_count": 0,
+                "errored_count": 0,
+                "skipped_count": 0,
+                "has_recommendation": True,
+            },
+        )
+    ]
+    assert "private recommendation" not in repr(events)

--- a/libs/giskard-core/README.md
+++ b/libs/giskard-core/README.md
@@ -21,7 +21,7 @@ pip install giskard-core
 
 ### What we collect
 
-Installed versions of `giskard-core`, `giskard-checks`, and `giskard-agents` (each the package version or `not_installed`), a coarse **environment** label (`ci`, `colab`, `kaggle`, or `local`), and when you run **giskard-checks** flows, aggregated non-content metrics such as step counts, counts of checks by `kind`, booleans (e.g. custom trace type or target present), durations, and pass/fail/skip-style outcomes. **Scenario names, prompts, model outputs, trace content, and exception messages are not sent.**
+Installed versions of Giskard libraries (each the package version or `not_installed`), a coarse **environment** label (`ci`, `colab`, `kaggle`, or `local`), and aggregated non-content metrics for Checks runs, Scan runs, and Hub-format exports. These metrics include counts, fixed feature modes, booleans, durations, and pass/fail/error/skip-style outcomes. **Descriptions, language values, scenario and check names, prompts, model outputs, recommendations, trace content, file paths, and exception messages are not sent.**
 
 If an error propagates through the telemetry context, a single event may record **`exception_type`** (the Python class name only), not the exception string or traceback.
 

--- a/libs/giskard-core/README.md
+++ b/libs/giskard-core/README.md
@@ -21,7 +21,7 @@ pip install giskard-core
 
 ### What we collect
 
-Installed versions of Giskard libraries (each the package version or `not_installed`), a coarse **environment** label (`ci`, `colab`, `kaggle`, or `local`), and aggregated non-content metrics for Checks runs, Scan runs, and Hub-format exports. These metrics include counts, fixed feature modes, booleans, durations, and pass/fail/error/skip-style outcomes. **Descriptions, language values, scenario and check names, prompts, model outputs, recommendations, trace content, file paths, and exception messages are not sent.**
+Installed versions of Giskard libraries (each the package version or `not_installed`), a coarse **environment** label (`ci`, `colab`, `kaggle`, or `local`), and aggregated non-content metrics for Checks runs, Scan runs, and Hub-format exports. These metrics include counts, counts of checks by `kind` (including custom kind identifiers you register), fixed feature modes, booleans, durations, and pass/fail/error/skip-style outcomes. **Descriptions, language values, scenario names, prompts, model outputs, recommendations, trace content, file paths, and exception messages are not sent.**
 
 If an error propagates through the telemetry context, a single event may record **`exception_type`** (the Python class name only), not the exception string or traceback.
 

--- a/libs/giskard-scan/README.md
+++ b/libs/giskard-scan/README.md
@@ -2,6 +2,12 @@
 
 Agent vulnerability scanner — red teaming, prompt injection, adversarial scenario generation.
 
+**Telemetry:** This package depends on `giskard-core`, which may send optional,
+aggregated scan lifecycle metrics (scan type, fixed execution modes, counts,
+durations, and outcomes). Descriptions, language values, generated scenarios,
+prompts, outputs, recommendations, and other user content are never included.
+See [Telemetry](../giskard-core/README.md#telemetry) for details and opt-outs.
+
 ## Scan entrypoints
 
 `quality_scan` and `vulnerability_scan` share the same explicit execution options.

--- a/libs/giskard-scan/src/giskard/scan/_telemetry.py
+++ b/libs/giskard-scan/src/giskard/scan/_telemetry.py
@@ -1,0 +1,32 @@
+"""Privacy-boundary helpers for scan analytics."""
+
+from typing import Any
+
+
+def safe_target_mode(value: Any) -> str:
+    """Return only a fixed target-mode label."""
+    return (
+        value
+        if type(value) is str and value in ("singleturn", "multiturn")
+        else "unknown"
+    )
+
+
+def safe_bool(value: Any) -> bool | None:
+    """Return booleans without coercing arbitrary caller-owned objects."""
+    return value if type(value) is bool else None
+
+
+def scenario_budget(value: Any) -> str:
+    """Bucket a requested scenario limit so it cannot carry identifying numbers."""
+    if value is None:
+        return "default"
+    if type(value) is not int or value < 0:
+        return "unknown"
+    if value == 0:
+        return "none"
+    if value <= 10:
+        return "small"
+    if value <= 100:
+        return "medium"
+    return "large"

--- a/libs/giskard-scan/src/giskard/scan/quality.py
+++ b/libs/giskard-scan/src/giskard/scan/quality.py
@@ -127,22 +127,29 @@ async def quality_scan[InputType, OutputType, TraceType: Trace](  # pyright: ign
     }
     telemetry_capture("scan_run_started", properties=telemetry_properties)
 
-    suite = await generate_suite(
-        description=description,
-        languages=languages,
-        generators=quality_suite_generator_registry.generators(),
-        max_scenarios=opts["max_scenarios"],
-        seed=opts["seed"],
-        target_mode=target_mode,
-        knowledge_base=knowledge_base,
-    )
+    try:
+        suite = await generate_suite(
+            description=description,
+            languages=languages,
+            generators=quality_suite_generator_registry.generators(),
+            max_scenarios=opts["max_scenarios"],
+            seed=opts["seed"],
+            target_mode=target_mode,
+            knowledge_base=knowledge_base,
+        )
 
-    result: SuiteResult = await suite.run(
-        target,
-        parallel=opts["parallel"],
-        max_concurrency=opts["max_concurrency"],
-        return_exception=opts["return_exception"],
-    )
+        result: SuiteResult = await suite.run(
+            target,
+            parallel=opts["parallel"],
+            max_concurrency=opts["max_concurrency"],
+            return_exception=opts["return_exception"],
+        )
+    except Exception:
+        telemetry_capture(
+            "scan_run_finished",
+            properties={**telemetry_properties, "outcome": "error"},
+        )
+        raise
     try:
         recommendation = await generate_quality_recommendation(result)
     except Exception:
@@ -153,6 +160,7 @@ async def quality_scan[InputType, OutputType, TraceType: Trace](  # pyright: ign
         "scan_run_finished",
         properties={
             **telemetry_properties,
+            "outcome": "completed",
             "duration_ms": quality_result.duration_ms,
             "scenario_count": len(quality_result.results),
             "passed_count": quality_result.passed_count,

--- a/libs/giskard-scan/src/giskard/scan/quality.py
+++ b/libs/giskard-scan/src/giskard/scan/quality.py
@@ -4,7 +4,9 @@ import logging
 import warnings
 
 from giskard.checks import SuiteResult, Target, Trace
+from giskard.core import scoped_telemetry, telemetry_capture, telemetry_tag
 
+from ._telemetry import safe_bool, safe_target_mode, scenario_budget
 from .catalog import generate_suite
 from .generators.base import DEFAULT_TARGET_MODE, TargetMode
 from .generators.knowledge_base import (
@@ -35,6 +37,7 @@ for generator_type in QUALITY_GENERATOR_TYPES:
     quality_suite_generator_registry.register(generator_type)
 
 
+@scoped_telemetry
 async def quality_scan[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
     target: Target[InputType, OutputType, TraceType],
     description: str,
@@ -111,6 +114,18 @@ async def quality_scan[InputType, OutputType, TraceType: Trace](  # pyright: ign
     knowledge_base = normalize_knowledge_base(
         _warn_if_missing_knowledge_base(knowledge_base)
     )
+    telemetry_tag("giskard_component", "scan")
+    telemetry_tag("giskard_operation", "quality_scan")
+    telemetry_properties: dict[str, object] = {
+        "integration": "giskard-scan",
+        "scan_type": "quality",
+        "target_mode": safe_target_mode(target_mode),
+        "language_count": len(languages),
+        "scenario_budget": scenario_budget(opts["max_scenarios"]),
+        "parallel": safe_bool(opts["parallel"]),
+        "has_knowledge_base": knowledge_base is not None,
+    }
+    telemetry_capture("scan_run_started", properties=telemetry_properties)
 
     suite = await generate_suite(
         description=description,
@@ -134,6 +149,18 @@ async def quality_scan[InputType, OutputType, TraceType: Trace](  # pyright: ign
         logger.exception("Quality recommendation generation failed")
         recommendation = ""
     quality_result = result.model_copy(update={"recommendation": recommendation})
+    telemetry_capture(
+        "scan_run_finished",
+        properties={
+            **telemetry_properties,
+            "duration_ms": quality_result.duration_ms,
+            "scenario_count": len(quality_result.results),
+            "passed_count": quality_result.passed_count,
+            "failed_count": quality_result.failed_count,
+            "errored_count": quality_result.errored_count,
+            "skipped_count": quality_result.skipped_count,
+        },
+    )
     quality_result.print_report(group_by=opts["group_by"])
     return quality_result
 

--- a/libs/giskard-scan/src/giskard/scan/vulnerability.py
+++ b/libs/giskard-scan/src/giskard/scan/vulnerability.py
@@ -1,5 +1,7 @@
 from giskard.checks import SuiteResult, Target, Trace
+from giskard.core import scoped_telemetry, telemetry_capture, telemetry_tag
 
+from ._telemetry import safe_bool, safe_target_mode, scenario_budget
 from .catalog import generate_suite
 from .generators.adversarial import AdversarialScenarioGenerator
 from .generators.base import DEFAULT_TARGET_MODE, TargetMode
@@ -32,6 +34,7 @@ for generator in VULNERABILITY_GENERATORS:
     vulnerability_suite_generator_registry.register(generator)
 
 
+@scoped_telemetry
 async def vulnerability_scan[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
     target: Target[InputType, OutputType, TraceType],
     description: str,
@@ -104,6 +107,18 @@ async def vulnerability_scan[InputType, OutputType, TraceType: Trace](  # pyrigh
         return_exception=return_exception,
         commercial_use=commercial_use,
     )
+    telemetry_tag("giskard_component", "scan")
+    telemetry_tag("giskard_operation", "vulnerability_scan")
+    telemetry_properties: dict[str, object] = {
+        "integration": "giskard-scan",
+        "scan_type": "vulnerability",
+        "target_mode": safe_target_mode(target_mode),
+        "language_count": len(languages),
+        "scenario_budget": scenario_budget(opts["max_scenarios"]),
+        "parallel": safe_bool(opts["parallel"]),
+        "commercial_use": safe_bool(opts["commercial_use"]),
+    }
+    telemetry_capture("scan_run_started", properties=telemetry_properties)
 
     suite = await generate_suite(
         description=description,
@@ -121,6 +136,18 @@ async def vulnerability_scan[InputType, OutputType, TraceType: Trace](  # pyrigh
         parallel=opts["parallel"],
         max_concurrency=opts["max_concurrency"],
         return_exception=opts["return_exception"],
+    )
+    telemetry_capture(
+        "scan_run_finished",
+        properties={
+            **telemetry_properties,
+            "duration_ms": result.duration_ms,
+            "scenario_count": len(result.results),
+            "passed_count": result.passed_count,
+            "failed_count": result.failed_count,
+            "errored_count": result.errored_count,
+            "skipped_count": result.skipped_count,
+        },
     )
     result.print_report(group_by=opts["group_by"])
     return result

--- a/libs/giskard-scan/src/giskard/scan/vulnerability.py
+++ b/libs/giskard-scan/src/giskard/scan/vulnerability.py
@@ -120,27 +120,35 @@ async def vulnerability_scan[InputType, OutputType, TraceType: Trace](  # pyrigh
     }
     telemetry_capture("scan_run_started", properties=telemetry_properties)
 
-    suite = await generate_suite(
-        description=description,
-        languages=languages,
-        generators=vulnerability_suite_generator_registry.generators(
-            commercial_use=opts["commercial_use"]
-        ),
-        max_scenarios=opts["max_scenarios"],
-        seed=opts["seed"],
-        target_mode=target_mode,
-    )
+    try:
+        suite = await generate_suite(
+            description=description,
+            languages=languages,
+            generators=vulnerability_suite_generator_registry.generators(
+                commercial_use=opts["commercial_use"]
+            ),
+            max_scenarios=opts["max_scenarios"],
+            seed=opts["seed"],
+            target_mode=target_mode,
+        )
 
-    result = await suite.run(
-        target,
-        parallel=opts["parallel"],
-        max_concurrency=opts["max_concurrency"],
-        return_exception=opts["return_exception"],
-    )
+        result = await suite.run(
+            target,
+            parallel=opts["parallel"],
+            max_concurrency=opts["max_concurrency"],
+            return_exception=opts["return_exception"],
+        )
+    except Exception:
+        telemetry_capture(
+            "scan_run_finished",
+            properties={**telemetry_properties, "outcome": "error"},
+        )
+        raise
     telemetry_capture(
         "scan_run_finished",
         properties={
             **telemetry_properties,
+            "outcome": "completed",
             "duration_ms": result.duration_ms,
             "scenario_count": len(result.results),
             "passed_count": result.passed_count,

--- a/libs/giskard-scan/tests/test_quality.py
+++ b/libs/giskard-scan/tests/test_quality.py
@@ -10,6 +10,7 @@ from giskard.checks import Equals, Scenario, Trace
 from giskard.checks.core.result import SuiteResult
 from giskard.checks.scenarios.suite import Suite
 from giskard.llm.types import AssistantMessage, ChatMessage, Choice, CompletionResponse
+from giskard.scan._telemetry import scenario_budget
 from giskard.scan.generators.base import ScenarioContext, ScenarioGenerator
 from giskard.scan.generators.knowledge_base import (
     HallucinationScenarioGenerator,
@@ -425,6 +426,7 @@ async def test_quality_scan_emits_privacy_safe_product_telemetry(
     }
     assert events[1][1] == {
         **events[0][1],
+        "outcome": "completed",
         "duration_ms": result.duration_ms,
         "scenario_count": 2,
         "passed_count": 1,
@@ -435,3 +437,77 @@ async def test_quality_scan_emits_privacy_safe_product_telemetry(
     assert "private agent description" not in repr(events)
     assert "private knowledge-base document" not in repr(events)
     assert "private recommendation" not in repr(events)
+
+
+async def test_quality_scan_allowlists_caller_controlled_telemetry_values(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    quality_suite_generator_registry.register(_DeterministicQualityGenerator())
+    events: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        quality_module,
+        "telemetry_capture",
+        lambda event, *, properties: events.append((event, properties)),
+    )
+    monkeypatch.setattr(quality_module, "telemetry_tag", lambda *_: None)
+    monkeypatch.setattr(SuiteResult, "print_report", lambda self, **_: None)
+
+    private_string: Any = "private-caller-controlled-value"
+    private_unhashable: Any = {"private-caller-controlled-value": True}
+    await quality_scan(
+        target=lambda inputs: inputs,
+        description="description",
+        languages=[],
+        knowledge_base=None,
+        max_scenarios=0,
+        target_mode=private_unhashable,
+        parallel=private_string,
+    )
+
+    assert events[0][1]["target_mode"] == "unknown"
+    assert events[0][1]["parallel"] is None
+    assert events[0][1]["scenario_budget"] == "none"
+    assert private_string not in repr(events)
+    assert scenario_budget(private_string) == "unknown"
+
+
+@pytest.mark.parametrize("failure_stage", ["generate_suite", "suite_run"])
+async def test_quality_scan_finishes_telemetry_when_scan_raises(
+    monkeypatch: pytest.MonkeyPatch,
+    failure_stage: str,
+):
+    events: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        quality_module,
+        "telemetry_capture",
+        lambda event, *, properties: events.append((event, properties)),
+    )
+    monkeypatch.setattr(quality_module, "telemetry_tag", lambda *_: None)
+
+    private_error = "private-scan-failure"
+
+    class _FailingSuite:
+        async def run(self, *_: object, **__: object) -> SuiteResult:
+            raise RuntimeError(private_error)
+
+    async def generate_suite_spy(**_: object) -> _FailingSuite:
+        if failure_stage == "generate_suite":
+            raise RuntimeError(private_error)
+        return _FailingSuite()
+
+    monkeypatch.setattr(quality_module, "generate_suite", generate_suite_spy)
+
+    with pytest.warns(RuntimeWarning, match="received no knowledge base"):
+        with pytest.raises(RuntimeError, match=private_error):
+            await quality_scan(
+                target=lambda inputs: inputs,
+                description="description",
+                languages=[],
+            )
+
+    assert [event for event, _ in events] == [
+        "scan_run_started",
+        "scan_run_finished",
+    ]
+    assert events[1][1] == {**events[0][1], "outcome": "error"}
+    assert private_error not in repr(events)

--- a/libs/giskard-scan/tests/test_quality.py
+++ b/libs/giskard-scan/tests/test_quality.py
@@ -382,3 +382,56 @@ async def test_quality_scan_hides_recommendation_when_generation_fails(
 
     assert result.failed_count == 1
     assert result.recommendation == ""
+
+
+async def test_quality_scan_emits_privacy_safe_product_telemetry(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    quality_suite_generator_registry.register(_DeterministicQualityGenerator())
+    monkeypatch.setattr(SuiteResult, "print_report", lambda self, **_: None)
+    monkeypatch.setattr(
+        settings,
+        "_default_generator",
+        _MockRecommendationGenerator(responses=["private recommendation"]),
+    )
+    events: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        quality_module,
+        "telemetry_capture",
+        lambda event, *, properties: events.append((event, properties)),
+    )
+    monkeypatch.setattr(quality_module, "telemetry_tag", lambda *_: None)
+
+    result = await quality_scan(
+        target=lambda inputs: inputs,
+        description="private agent description",
+        languages=["en"],
+        knowledge_base=["private knowledge-base document"],
+        max_scenarios=2,
+    )
+
+    assert [event for event, _ in events] == [
+        "scan_run_started",
+        "scan_run_finished",
+    ]
+    assert events[0][1] == {
+        "integration": "giskard-scan",
+        "scan_type": "quality",
+        "target_mode": "multiturn",
+        "language_count": 1,
+        "scenario_budget": "small",
+        "parallel": True,
+        "has_knowledge_base": True,
+    }
+    assert events[1][1] == {
+        **events[0][1],
+        "duration_ms": result.duration_ms,
+        "scenario_count": 2,
+        "passed_count": 1,
+        "failed_count": 1,
+        "errored_count": 0,
+        "skipped_count": 0,
+    }
+    assert "private agent description" not in repr(events)
+    assert "private knowledge-base document" not in repr(events)
+    assert "private recommendation" not in repr(events)

--- a/libs/giskard-scan/tests/test_vulnerability.py
+++ b/libs/giskard-scan/tests/test_vulnerability.py
@@ -198,6 +198,7 @@ async def test_vulnerability_scan_emits_privacy_safe_product_telemetry(
                 "scenario_budget": "small",
                 "parallel": True,
                 "commercial_use": True,
+                "outcome": "completed",
                 "duration_ms": result.duration_ms,
                 "scenario_count": 2,
                 "passed_count": 1,
@@ -243,3 +244,43 @@ async def test_vulnerability_scan_allowlists_caller_controlled_telemetry_values(
     assert events[0][1]["scenario_budget"] == "none"
     assert private_string not in repr(events)
     assert scenario_budget(private_string) == "unknown"
+
+
+@pytest.mark.parametrize("failure_stage", ["generate_suite", "suite_run"])
+async def test_vulnerability_scan_finishes_telemetry_when_scan_raises(
+    monkeypatch: pytest.MonkeyPatch,
+    failure_stage: str,
+):
+    events: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        "giskard.scan.vulnerability.telemetry_capture",
+        lambda event, *, properties: events.append((event, properties)),
+    )
+    monkeypatch.setattr("giskard.scan.vulnerability.telemetry_tag", lambda *_: None)
+
+    private_error = "private-scan-failure"
+
+    class _FailingSuite:
+        async def run(self, *_: object, **__: object) -> SuiteResult:
+            raise RuntimeError(private_error)
+
+    async def generate_suite_spy(**_: object) -> _FailingSuite:
+        if failure_stage == "generate_suite":
+            raise RuntimeError(private_error)
+        return _FailingSuite()
+
+    monkeypatch.setattr("giskard.scan.vulnerability.generate_suite", generate_suite_spy)
+
+    with pytest.raises(RuntimeError, match=private_error):
+        await vulnerability_scan(
+            target=lambda inputs: inputs,
+            description="description",
+            languages=[],
+        )
+
+    assert [event for event, _ in events] == [
+        "scan_run_started",
+        "scan_run_finished",
+    ]
+    assert events[1][1] == {**events[0][1], "outcome": "error"}
+    assert private_error not in repr(events)

--- a/libs/giskard-scan/tests/test_vulnerability.py
+++ b/libs/giskard-scan/tests/test_vulnerability.py
@@ -5,6 +5,7 @@ import pytest
 from giskard.checks import Equals, Scenario, Trace
 from giskard.checks.core.result import SuiteResult
 from giskard.checks.scenarios.suite import Suite
+from giskard.scan._telemetry import scenario_budget
 from giskard.scan.generators.base import ScenarioContext, ScenarioGenerator
 from giskard.scan.vulnerability import (
     vulnerability_scan,
@@ -141,3 +142,104 @@ async def test_vulnerability_scan_forwards_run_options(
     assert run_kwargs == [
         {"parallel": True, "max_concurrency": 3, "return_exception": True}
     ]
+
+
+async def test_vulnerability_scan_emits_privacy_safe_product_telemetry(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    vulnerability_suite_generator_registry.register(
+        _DeterministicVulnerabilityGenerator()
+    )
+    events: list[tuple[str, dict[str, object]]] = []
+    tags: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "giskard.scan.vulnerability.telemetry_capture",
+        lambda event, *, properties: events.append((event, properties)),
+    )
+    monkeypatch.setattr(
+        "giskard.scan.vulnerability.telemetry_tag",
+        lambda key, value: tags.append((key, value)),
+    )
+    monkeypatch.setattr(SuiteResult, "print_report", lambda self, **_: None)
+
+    result = await vulnerability_scan(
+        target=lambda inputs: inputs,
+        description="private support-agent description",
+        languages=["en", "fr"],
+        max_scenarios=2,
+        target_mode="singleturn",
+        commercial_use=True,
+    )
+
+    assert tags == [
+        ("giskard_component", "scan"),
+        ("giskard_operation", "vulnerability_scan"),
+    ]
+    assert events == [
+        (
+            "scan_run_started",
+            {
+                "integration": "giskard-scan",
+                "scan_type": "vulnerability",
+                "target_mode": "singleturn",
+                "language_count": 2,
+                "scenario_budget": "small",
+                "parallel": True,
+                "commercial_use": True,
+            },
+        ),
+        (
+            "scan_run_finished",
+            {
+                "integration": "giskard-scan",
+                "scan_type": "vulnerability",
+                "target_mode": "singleturn",
+                "language_count": 2,
+                "scenario_budget": "small",
+                "parallel": True,
+                "commercial_use": True,
+                "duration_ms": result.duration_ms,
+                "scenario_count": 2,
+                "passed_count": 1,
+                "failed_count": 1,
+                "errored_count": 0,
+                "skipped_count": 0,
+            },
+        ),
+    ]
+    assert "private support-agent description" not in repr(events)
+    assert all("languages" not in properties for _, properties in events)
+
+
+async def test_vulnerability_scan_allowlists_caller_controlled_telemetry_values(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    vulnerability_suite_generator_registry.register(
+        _DeterministicVulnerabilityGenerator()
+    )
+    events: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        "giskard.scan.vulnerability.telemetry_capture",
+        lambda event, *, properties: events.append((event, properties)),
+    )
+    monkeypatch.setattr("giskard.scan.vulnerability.telemetry_tag", lambda *_: None)
+    monkeypatch.setattr(SuiteResult, "print_report", lambda self, **_: None)
+
+    private_string: Any = "private-caller-controlled-value"
+    private_unhashable: Any = {"private-caller-controlled-value": True}
+    await vulnerability_scan(
+        target=lambda inputs: inputs,
+        description="description",
+        languages=[],
+        max_scenarios=0,
+        target_mode=private_unhashable,
+        parallel=private_string,
+        commercial_use=private_string,
+    )
+
+    assert events[0][1]["target_mode"] == "unknown"
+    assert events[0][1]["parallel"] is None
+    assert events[0][1]["commercial_use"] is None
+    assert events[0][1]["scenario_budget"] == "none"
+    assert private_string not in repr(events)
+    assert scenario_budget(private_string) == "unknown"


### PR DESCRIPTION
## Description

Giskard OSS can now measure whether developers start and complete quality or vulnerability scans, and whether Checks results are prepared for Hub. These signals support the OSS vision's activation and paid-intent measures without collecting prompts, outputs, scenario content, names, paths, or arbitrary caller strings.

Caller-controlled telemetry values are constrained at runtime: modes and booleans use allowlists, requested scenario counts use fixed buckets, and scan results contain aggregate counts and duration only. This PR deliberately does not claim Scan-to-Checks conversion because OSS has no explicit promotion action that can be measured reliably.

Validation:

- Giskard Scan unit suite: 180 passed, 44 skipped, 2 deselected.
- Giskard Checks unit suite: 951 passed, 4 skipped.
- Formatting, linting, Python compatibility, type checking, license checks, and extra-pin checks passed.
- `make check` reaches the security audit and fails on the pre-existing `nltk==3.10.0` advisory `PYSEC-2026-3726`; the published fix is `3.10.2`.
- Independent privacy and code review approved the final implementation.

## Related Issue

No linked issue.

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Coding agents

The autonomous-agent instructions in `AUTONOMOUS.md` were followed. The agent-local plan remains uncommitted.

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [x] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been modified)
