### PR TITLE
fix(checks): reject non-finite JSON values 🤖🤖🤖🤖

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/builtin/json_valid.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/json_valid.py
@@ -22,10 +22,10 @@ class JsonValid[InputType, OutputType, TraceType: Trace](  # pyright: ignore[rep
     """Check that validates whether a trace value is valid JSON.
 
     With ``parse=True`` (default), the extracted value must be a serialized
-    JSON string, which is parsed with ``json.loads`` before validation. With
-    ``parse=False``, the value is treated as an already-parsed JSON value
-    (dict, list, str, number, bool, or None) and only checked for JSON
-    serializability and schema conformance.
+    JSON string, which is parsed before validation. With ``parse=False``, the
+    value is treated as an already-parsed JSON value (dict, list, str, finite
+    number, bool, or None) and only checked for JSON serializability and schema
+    conformance.
     """
 
     model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)
@@ -91,8 +91,10 @@ class JsonValid[InputType, OutputType, TraceType: Trace](  # pyright: ignore[rep
                     details=details,
                 )
             try:
-                value = json.loads(value)
-            except json.JSONDecodeError as err:
+                value = json.loads(
+                    value, parse_constant=self._reject_non_finite_constant
+                )
+            except ValueError as err:
                 details["error"] = str(err)
                 return CheckResult.failure(
                     message=f"Value at key '{self.target_key}' is not valid JSON: {err}",
@@ -100,7 +102,7 @@ class JsonValid[InputType, OutputType, TraceType: Trace](  # pyright: ignore[rep
                 )
         else:
             try:
-                json.dumps(value)
+                json.dumps(value, allow_nan=False)
             except (TypeError, ValueError) as err:
                 details["error"] = str(err)
                 return CheckResult.failure(
@@ -137,6 +139,22 @@ class JsonValid[InputType, OutputType, TraceType: Trace](  # pyright: ignore[rep
     @staticmethod
     def _validate_schema_definition(schema: dict[str, Any]) -> None:
         validator_for(schema).check_schema(schema)
+
+    @staticmethod
+    def _reject_non_finite_constant(value: str) -> None:
+        """Reject a non-finite numeric constant.
+
+        Parameters
+        ----------
+        value : str
+            Constant returned by the JSON parser.
+
+        Raises
+        ------
+        ValueError
+            Always, because JSON does not support non-finite numbers.
+        """
+        raise ValueError(f"Non-finite number {value!r} is not valid JSON.")
 
     @staticmethod
     def _validate_schema(parsed_value: Any, schema: dict[str, Any]) -> None:

--- a/libs/giskard-checks/tests/builtin/test_json_valid.py
+++ b/libs/giskard-checks/tests/builtin/test_json_valid.py
@@ -73,6 +73,29 @@ async def test_invalid_json_string_fails(outputs: str) -> None:
     assert "error" in result.details
 
 
+@pytest.mark.parametrize(
+    "outputs",
+    [
+        "NaN",
+        "Infinity",
+        "-Infinity",
+        '{"value": NaN}',
+    ],
+)
+async def test_non_finite_json_constants_fail(outputs: str) -> None:
+    check = JsonValid()
+    trace = await Trace.from_interactions(
+        Interaction(inputs="Return JSON", outputs=outputs)
+    )
+
+    result = await check.run(trace)
+
+    assert result.status == CheckStatus.FAIL
+    assert result.message is not None
+    assert "not valid JSON" in result.message
+    assert "error" in result.details
+
+
 async def test_nested_jsonpath_extraction() -> None:
     check = JsonValid(target_key="trace.last.outputs.response")
     trace = await Trace.from_interactions(
@@ -200,6 +223,29 @@ async def test_non_serializable_value_fails() -> None:
     assert result.failed
     assert result.message is not None
     assert "trace.last.outputs" in result.message
+    assert "not JSON serializable" in result.message
+    assert "error" in result.details
+
+
+@pytest.mark.parametrize(
+    "outputs",
+    [
+        float("nan"),
+        float("inf"),
+        -float("inf"),
+        {"value": float("nan")},
+    ],
+)
+async def test_non_finite_parsed_values_fail(outputs: Any) -> None:
+    check = JsonValid(parse=False)
+    trace = await Trace.from_interactions(
+        Interaction(inputs="Return JSON", outputs=outputs)
+    )
+
+    result = await check.run(trace)
+
+    assert result.status == CheckStatus.FAIL
+    assert result.message is not None
     assert "not JSON serializable" in result.message
     assert "error" in result.details
 


### PR DESCRIPTION
## Description

`JsonValid` currently accepts Python's non-standard `NaN`, `Infinity`, and
`-Infinity` values as valid JSON because the standard-library JSON parser and
serializer allow them by default.

This change:

- rejects non-finite constants when parsing serialized JSON;
- rejects non-finite floats in already-parsed values, including nested values;
- adds regression coverage for both `parse=True` and `parse=False`.

## Related Issue

N/A — this is a small, self-contained bug found on the current `main` branch.

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Coding agents

Opened with Codex assistance. `AUTONOMOUS.md` was reviewed, and the required
four-robot title suffix is present.

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [ ] I've updated the `uv.lock` running `uv lock` (not applicable: `pyproject.toml` was not modified)

## Verification

- `make format`
- `make check`
- `make test-unit PACKAGE=giskard-checks` (`962 passed, 4 skipped`)
- `uv run pytest libs/giskard-checks/tests/builtin/test_json_valid.py` (`36 passed`)
