### PR TITLE
fix(agents): preserve api_base and forbid unknown GenerationParams 🤖🤖🤖🤖

### DIFF
--- a/libs/giskard-agents/src/giskard/agents/generators/_types.py
+++ b/libs/giskard-agents/src/giskard/agents/generators/_types.py
@@ -4,7 +4,9 @@ Kept in a separate module to break the circular dependency between
 ``base`` (BaseGenerator) and ``middleware`` (CompletionMiddleware).
 """
 
-from pydantic import BaseModel, Field
+from typing import ClassVar
+
+from pydantic import BaseModel, ConfigDict, Field
 
 from ..tools import Tool
 
@@ -12,19 +14,38 @@ from ..tools import Tool
 class GenerationParams(BaseModel):
     """Parameters for generating a completion.
 
+    Unknown fields are rejected (``extra="forbid"``). Without this, pydantic
+    silently drops unrecognized keys (for example ``api_base`` typo'd as
+    ``api_bass``), so a custom endpoint or other wire option never reaches
+    the underlying completion call.
+
     Attributes
     ----------
     tools : list[Tool], optional
         List of tools available to the model.
     timeout : float | int | None, optional
         Maximum time in seconds to wait for the completion request.
+    api_base : str | None, optional
+        Base URL for an OpenAI-compatible completion endpoint (for example a
+        local LM Studio or Ollama server). Forwarded as ``api_base`` to
+        backends that accept it, such as LiteLLM.
     """
+
+    # Same rationale as ``BaseGenerator``: typos must fail loudly.
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
     temperature: float = Field(default=1.0)
     max_tokens: int | None = Field(default=None)
     response_format: type[BaseModel] | None = Field(default=None)
     tools: list[Tool] = Field(default_factory=list)
     timeout: float | int | None = Field(default=None)
+    api_base: str | None = Field(
+        default=None,
+        description=(
+            "Base URL for an OpenAI-compatible completion endpoint "
+            "(e.g. http://127.0.0.1:1234/v1)."
+        ),
+    )
 
     def merge(self, overrides: "GenerationParams | None") -> "GenerationParams":
         """Return a copy with *overrides*' explicitly-set fields applied on top.

--- a/libs/giskard-agents/src/giskard/agents/generators/base.py
+++ b/libs/giskard-agents/src/giskard/agents/generators/base.py
@@ -254,13 +254,29 @@ class BaseGenerator(Discriminated, ABC):
         Parameters
         ----------
         **kwargs
-            The parameters to set. All fields are optional.
+            The parameters to set. All fields are optional. Unknown field
+            names are rejected by ``GenerationParams`` (``extra="forbid"``).
 
         Returns
         -------
         Self
             A new generator with the given parameters.
+
+        Raises
+        ------
+        ValidationError
+            If *kwargs* contains a field that ``GenerationParams`` does not
+            declare (for example a typo).
         """
         generator = self.model_copy()
+        unknown = set(kwargs) - set(GenerationParams.model_fields)
+        if unknown:
+            # Reject unknown keys with the same ValidationError pydantic would
+            # raise under extra="forbid". Known keys still use model_copy so
+            # existing value semantics (including previously accepted types
+            # that construction would reject) stay unchanged.
+            GenerationParams.model_validate(
+                {key: kwargs[key] for key in sorted(unknown)}
+            )
         generator.params = generator.params.model_copy(update=kwargs)
         return generator

--- a/libs/giskard-agents/tests/test_litellm_generator.py
+++ b/libs/giskard-agents/tests/test_litellm_generator.py
@@ -71,6 +71,16 @@ async def test_litellm_generator_forwards_params(mock_acompletion: Any) -> None:
     assert kwargs["max_tokens"] == 50
 
 
+async def test_litellm_generator_forwards_api_base(mock_acompletion: Any) -> None:
+    """Custom OpenAI-compatible endpoints survive params serialization."""
+    generator = LiteLLMGenerator(model="openai/test-model").with_params(
+        api_base="http://127.0.0.1:1234/v1"
+    )
+    await generator.complete(messages=_USER_MESSAGE)
+
+    assert mock_acompletion.call_args.kwargs["api_base"] == "http://127.0.0.1:1234/v1"
+
+
 async def test_litellm_generator_sanitizes_response_format_schema_name(
     mock_acompletion: Any,
 ) -> None:

--- a/libs/giskard-agents/tests/test_serialization.py
+++ b/libs/giskard-agents/tests/test_serialization.py
@@ -220,6 +220,36 @@ async def test_chat_workflow_serialization_custom_generator():
 # -- Unknown-key rejection (``extra="forbid"``) ------------------------------
 
 
+def test_generation_params_rejects_unknown_key():
+    """Unsupported GenerationParams fields must fail loudly, not silently drop."""
+    with pytest.raises(ValidationError, match="api_bass"):
+        GenerationParams(api_bass="http://127.0.0.1:1234/v1")
+
+
+def test_generation_params_preserves_api_base():
+    """api_base must survive construction and dump so backends can receive it."""
+    params = GenerationParams(api_base="http://127.0.0.1:1234/v1")
+    dumped = params.model_dump(exclude={"tools"}, exclude_unset=True)
+    assert dumped == {"api_base": "http://127.0.0.1:1234/v1"}
+
+
+def test_generator_with_params_rejects_unknown_key():
+    """``.with_params`` must reject typos instead of silently discarding them."""
+    generator = GiskardLLMGenerator(model="gpt-4")
+
+    with pytest.raises(ValidationError, match="api_bass"):
+        generator.with_params(api_bass="http://127.0.0.1:1234/v1")
+
+
+def test_generator_with_params_preserves_api_base():
+    """``.with_params(api_base=...)`` must keep the endpoint on the new params."""
+    generator = GiskardLLMGenerator(model="gpt-4").with_params(
+        api_base="http://127.0.0.1:1234/v1"
+    )
+    dumped = generator.params.model_dump(exclude={"tools"}, exclude_unset=True)
+    assert dumped == {"api_base": "http://127.0.0.1:1234/v1"}
+
+
 def test_generator_rejects_unknown_key():
     """A typo'd key on a generator must fail loudly, not silently default."""
     payload = {


### PR DESCRIPTION
## Description

`GenerationParams` previously used pydantic's default `extra="ignore"`, so fields like `api_base` passed through `.with_params(...)` or construction were silently discarded before they could reach `litellm.acompletion` / `giskard.llm.acompletion`. That made custom OpenAI-compatible endpoints (LM Studio, Ollama, etc.) fail without a clear signal.

This change:

- Adds optional `api_base` so supported backends receive the custom endpoint via `model_dump(..., exclude_unset=True)`.
- Sets `extra="forbid"` on `GenerationParams`, matching `BaseGenerator` / middleware, so typos and unsupported kwargs raise `ValidationError`.
- Updates `BaseGenerator.with_params` to reject unknown kwargs before applying updates.

## Related Issue

Closes #2802

## Type of Change

- [x] 🔧 Bug fix (non-breaking change which fixes an issue)

## Coding agents

Read [AUTONOMOUS.md](https://github.com/Giskard-AI/giskard-oss/blob/main/AUTONOMOUS.md). Title includes the required agent marker.

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [x] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been modified) — N/A, no dependency changes.

## Verification

- `uv run --directory libs/giskard-agents python -m pytest tests src -m "not functional" -q` → **151 passed, 2 skipped, 16 deselected**
- `uv tool run ruff==0.16.1 format` / `check` on touched files → clean
- `uv tool run basedpyright --level error` on touched source files → 0 errors
- Manual repro: `.with_params(api_base=...)` now dumps `api_base`; `.with_params(typo_param=1)` raises `ValidationError`