### PR TITLE
fix(checks): [ENG-1737] Carry check_spec in CheckResult details for Hub import

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
@@ -23,6 +23,7 @@ from ..core.result import CheckResult, ScenarioResult, TestCaseError, TestCaseRe
 from ..core.scenario import Scenario, Step
 from ..core.testcase import TestCase
 from ..core.types import Target
+from ..testing.runner import check_spec
 from ..utils.inference import _infer_trace_type
 
 
@@ -97,6 +98,7 @@ def _skipped_check_results_for_step[InputType, OutputType, TraceType: Trace[Any,
                 "check_kind": check.kind,
                 "check_name": check.name,
                 "check_description": check.description,
+                "check_spec": check_spec(check),
             },
         )
         for check in step.checks

--- a/libs/giskard-checks/src/giskard/checks/testing/runner.py
+++ b/libs/giskard-checks/src/giskard/checks/testing/runner.py
@@ -1,5 +1,6 @@
 import time
 import traceback
+from typing import Any
 
 from giskard.core import scoped_telemetry, telemetry_capture, telemetry_tag
 
@@ -11,6 +12,26 @@ from ..core import Trace
 from ..core.check import Check
 from ..core.result import CheckResult, TestCaseResult
 from ..core.testcase import TestCase
+
+
+def check_spec(check: Check[Any, Any, Any]) -> dict[str, Any]:
+    """Flat ``{"kind": ..., **params}`` view of a check's configuration.
+
+    Mirrors the Giskard Hub's own check-spec wire shape (``giskard_hub``'s
+    ``check_param_to_spec``). Emitted into ``CheckResult.details["check_spec"]``
+    so a Hub import of an OSS ``SuiteResult`` can populate ``CheckResult.spec``
+    and render the check's settings (thresholds, rules, target keys) instead of
+    only pass/fail.
+
+    ``name``/``description`` are check identity, not configuration, and the Hub
+    surfaces them separately -- they are dropped here. ``fallback=str`` keeps a
+    check carrying a non-JSON field (e.g. a callable) from breaking the export.
+    """
+    dump = check.model_dump(mode="json", exclude_none=True, fallback=str)
+    dump.pop("name", None)
+    dump.pop("description", None)
+    dump.pop("kind", None)
+    return {"kind": check.kind, **dump}
 
 
 async def _run_check[
@@ -47,6 +68,7 @@ async def _run_check[
                 "check_kind": check.kind,
                 "check_name": check.name,
                 "check_description": check.description,
+                "check_spec": check_spec(check),
             }
         }
     )

--- a/libs/giskard-checks/tests/core/test_scenario.py
+++ b/libs/giskard-checks/tests/core/test_scenario.py
@@ -416,6 +416,40 @@ class TestScenarioNormalCases:
         assert result.steps[1].results[0].details.get("check_name") == "step"
         assert result.errored
 
+    async def test_skipped_step_check_results_carry_check_spec(self):
+        """Skipped checks still report their config via details['check_spec'].
+
+        A Hub import maps details['check_spec'] onto CheckResult.spec (ENG-1737);
+        a check skipped after an earlier failure must carry it too so its
+        settings render in the evaluation UI.
+        """
+        interaction1 = Interaction(inputs="input1", outputs="output1")
+        interaction2 = Interaction(inputs="input2", outputs="output2")
+
+        result = await (
+            Scenario("skipped_step_keeps_spec")
+            .add_interaction(MockInteractionSpec(interactions=[interaction1]))
+            .check(MockCheck(result=CheckResult.failure(message="Check 1 failed")))
+            .add_interaction(MockInteractionSpec(interactions=[interaction2]))
+            .check(
+                Equals(
+                    expected_value="output2",
+                    target_key="trace.interactions[-1].outputs",
+                    name="second_step_check",
+                )
+            )
+            .run()
+        )
+
+        assert result.steps[1].skipped
+        skipped = result.steps[1].results[0]
+        assert skipped.skipped
+        spec = skipped.details["check_spec"]
+        assert spec["kind"] == "equals"
+        assert spec["expected_value"] == "output2"
+        assert spec["target_key"] == "trace.interactions[-1].outputs"
+        assert "name" not in spec
+
     async def test_trace_accumulation_across_components(self):
         """Test that trace accumulates interactions across components."""
         interaction1 = Interaction(inputs="1", outputs="2")

--- a/libs/giskard-checks/tests/export/test_hub.py
+++ b/libs/giskard-checks/tests/export/test_hub.py
@@ -1,8 +1,41 @@
 """Tests for Hub format export."""
 
+from giskard.checks import Equals, Scenario, Suite
 from giskard.checks.core.result import SuiteResult
 from giskard.checks.export import hub as hub_module
 from giskard.checks.export.hub import to_hub_format
+
+
+async def test_to_hub_format_check_details_expose_flat_check_spec() -> None:
+    """The wire payload carries each check's config under details['check_spec'].
+
+    The Hub importer maps details['check_spec'] onto CheckResult.spec (ENG-1737)
+    to render the check-settings panel; without it the Hub shows only pass/fail.
+    """
+    suite = Suite(name="s").append(
+        Scenario("sc")
+        .interact(
+            inputs="q",
+            outputs=lambda inputs, trace: {"response": {"content": "a"}},
+        )
+        .check(
+            Equals(
+                expected_value="a",
+                target_key="trace.last.outputs.response.content",
+                name="answer_is_a",
+            )
+        )
+    )
+
+    payload = to_hub_format(await suite.run())
+
+    details = payload["results"][0]["steps"][0]["results"][0]["details"]
+    assert details["check_spec"] == {
+        "kind": "equals",
+        "expected_value": "a",
+        "target_key": "trace.last.outputs.response.content",
+        "normalization_form": "NFKC",
+    }
 
 
 def test_to_hub_format_pass_rate_null_when_empty() -> None:

--- a/libs/giskard-checks/tests/scenarios/test_testcase.py
+++ b/libs/giskard-checks/tests/scenarios/test_testcase.py
@@ -187,6 +187,35 @@ class TestTestCaseNormalCases:
         assert result.passed
         assert len(result.results) == 1
 
+    async def test_check_result_details_carry_flat_check_spec(self):
+        """Each CheckResult exposes the check's config as details['check_spec'].
+
+        A Hub import of the resulting SuiteResult maps details['check_spec']
+        onto CheckResult.spec (see ENG-1737), which drives the check-settings
+        panel in the evaluation UI. The dict mirrors the Hub's own wire shape:
+        a flat ``{"kind": ..., **params}`` with check identity stripped.
+        """
+        trace = await Trace.from_interactions(
+            Interaction(inputs="input", outputs="output")
+        )
+        check = Equals(
+            expected_value="output",
+            target_key="trace.interactions[-1].outputs",
+            name="exact_output",
+            description="ignored identity field",
+        )
+        test_case = TestCase(trace=trace, checks=[check])
+
+        result = await test_case.run()
+
+        spec = result.results[0].details["check_spec"]
+        assert spec["kind"] == "equals"
+        assert spec["target_key"] == "trace.interactions[-1].outputs"
+        assert spec["expected_value"] == "output"
+        # Identity, not configuration -- surfaced by the Hub separately.
+        assert "name" not in spec
+        assert "description" not in spec
+
 
 class TestTestCaseResult:
     """Test TestCaseResult properties and methods."""


### PR DESCRIPTION
## Description

OSS result uploads dropped check configuration, so imported Hub evaluations showed only pass/fail. This attaches each check's config (details.check_spec) to its result, so the Hub renders thresholds, rules, and target keys. 

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Coding agents

Autonomous agents with no human in the loop must read **[AUTONOMOUS.md](https://github.com/Giskard-AI/giskard-oss/blob/main/AUTONOMOUS.md)** before opening a PR.

**PR title:** agent-opened PRs **must** end the title with **`🤖🤖🤖🤖`** (exactly four robot emojis). Do not omit — that suffix is how the expedited agent PR workflow picks up the PR.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [ ] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been
  modified)
