### PR TITLE
fix(checks): reject empty and blank keywords and regex patterns

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
@@ -109,6 +109,16 @@ class TextBasedCheck[InputType, OutputType, TraceType: Trace](  # pyright: ignor
                 ),
             )
 
+        if not matcher.strip():
+            return (
+                None,
+                None,
+                CheckResult.error(
+                    message=f"Value for {matcher_name} is empty or blank, expected a non-empty {matcher_name}.",
+                    details=details,
+                ),
+            )
+
         # Validate text
         if isinstance(text, NoMatch):
             return (

--- a/libs/giskard-checks/tests/builtin/test_regex_matching.py
+++ b/libs/giskard-checks/tests/builtin/test_regex_matching.py
@@ -278,14 +278,48 @@ async def test_literal_special_chars_not_escaped() -> None:
 
 
 async def test_empty_pattern_regex_mode() -> None:
-    """Test behavior with empty pattern in regex mode."""
+    """Test behavior with an empty pattern in regex mode.
+
+    An empty pattern would trivially match any text, which is almost never
+    the intent, so it must be rejected as an error rather than silently
+    passing.
+    """
     check = RegexMatching(
         text="Hello",
         pattern="",
     )
     result = await check.run(Trace())
-    # Empty regex matches any string
-    assert result.status == CheckStatus.PASS
+    assert result.status == CheckStatus.ERROR
+    assert result.message is not None
+    assert "empty or blank" in result.message.lower()
+
+
+async def test_whitespace_only_pattern_regex_mode() -> None:
+    """Test that a whitespace-only pattern is rejected as an error."""
+    check = RegexMatching(
+        text="Hello",
+        pattern="   ",
+    )
+    result = await check.run(Trace())
+    assert result.status == CheckStatus.ERROR
+    assert result.message is not None
+    assert "empty or blank" in result.message.lower()
+
+
+async def test_blank_pattern_from_trace() -> None:
+    """Test that a blank pattern resolved via pattern_key is also rejected."""
+    check = RegexMatching(
+        text="Hello World",
+        pattern_key="trace.last.inputs.expected",
+    )
+    interaction = Interaction(
+        inputs={"expected": "   "},
+        outputs={"response": "Hello World"},
+    )
+    result = await check.run(Trace(interactions=[interaction]))
+    assert result.status == CheckStatus.ERROR
+    assert result.message is not None
+    assert "empty or blank" in result.message.lower()
 
 
 async def test_missing_pattern_validation() -> None:

--- a/libs/giskard-checks/tests/builtin/test_string_matching.py
+++ b/libs/giskard-checks/tests/builtin/test_string_matching.py
@@ -329,11 +329,42 @@ async def test_empty_text() -> None:
 
 
 async def test_empty_keyword() -> None:
-    """Test behavior with empty keyword."""
+    """Test behavior with an empty keyword.
+
+    An empty keyword would trivially match any text, which is almost never
+    the intent, so it must be rejected as an error rather than silently
+    passing.
+    """
     check = StringMatching(text="Hello", keyword="")
     result = await check.run(Trace())
-    # Empty string should be found in any text
-    assert result.status == CheckStatus.PASS
+    assert result.status == CheckStatus.ERROR
+    assert result.message is not None
+    assert "empty or blank" in result.message.lower()
+
+
+async def test_whitespace_only_keyword() -> None:
+    """Test that a whitespace-only keyword is rejected as an error."""
+    check = StringMatching(text="Hello", keyword="   ")
+    result = await check.run(Trace())
+    assert result.status == CheckStatus.ERROR
+    assert result.message is not None
+    assert "empty or blank" in result.message.lower()
+
+
+async def test_blank_keyword_from_trace() -> None:
+    """Test that a blank keyword resolved via keyword_key is also rejected."""
+    check = StringMatching(
+        text="Hello World",
+        keyword_key="trace.last.inputs.expected",
+    )
+    interaction = Interaction(
+        inputs={"expected": "   "},
+        outputs={"response": "Hello World"},
+    )
+    result = await check.run(Trace(interactions=[interaction]))
+    assert result.status == CheckStatus.ERROR
+    assert result.message is not None
+    assert "empty or blank" in result.message.lower()
 
 
 async def test_unicode_e_acute_nfc_nfd_matching() -> None:


### PR DESCRIPTION
## Description

`StringMatching(keyword="")`, `StringMatching(keyword="   ")` and `RegexMatching(pattern="")` all return PASS on any text: an empty string is a substring of everything, an empty regex matches everywhere, and `normalize_string` collapses a whitespace-only keyword to `""` before the containment test.

The shared `TextBasedCheck._extract_and_validate` now returns an ERROR result when the resolved matcher is empty or whitespace-only. It sits after `provided_or_resolve`, so a blank value coming from the trace through `keyword_key` / `pattern_key` is rejected the same way as a blank literal, and both checks get it from the one place. The message follows the neighbouring validation errors in the same method.

This is the follow-up to #2786, which was closed after review because `keyword="   "` still passed. `strip()` covers that case here and there is a test for it.

Two existing tests (`test_empty_keyword`, `test_empty_pattern_regex_mode`) asserted the old PASS behaviour and now assert ERROR. Four new tests cover whitespace-only keyword and pattern, and blank values resolved from the trace.

Verification:

```
uv run --frozen --directory libs/giskard-checks pytest tests/builtin/test_string_matching.py tests/builtin/test_regex_matching.py -m "not functional" -q   # 65 passed; 6 fail without the fix
make test-unit PACKAGE=giskard-checks   # 958 passed, 4 skipped (pre-existing integration skips)
make format && make lint                # no changes outside these files; all checks passed
basedpyright on text_matching.py        # 0 errors
```



## Related Issue

Fixes #2785

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [ ] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been
  modified)

Drafted by Claude from the Hive Fidelity Usage-Surplus OSS Program. All code reviewed by a human prior to submission. To request us back for more, email [kirsten@reinainblood.dev](mailto:kirsten@reinainblood.dev) or [hive@hivefidelity.ai](mailto:hive@hivefidelity.ai). [Usage-Surplus OSS Program](https://hivefidelity.ai/usage-surplus-oss/)